### PR TITLE
Add debug reset button for growth progress

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -11,7 +11,7 @@ import {
 import { loadGrowthFlags } from "../utils/growthStore_supabase.js";
 import { chords } from "../data/chords.js";
 import { renderHeader } from "../components/header.js";
-import { unlockChord } from "../utils/progressUtils.js";
+import { unlockChord, resetChordProgressToRed } from "../utils/progressUtils.js";
 
 export async function renderGrowthScreen(user) {
   const app = document.getElementById("app");
@@ -54,6 +54,23 @@ export async function renderGrowthScreen(user) {
   progress.style.transition = "width 0.3s ease";
   progressBar.appendChild(progress);
   container.appendChild(progressBar);
+
+  // 🛠 デバッグ: 進捗を赤のみの状態に戻す
+  const resetBtn = document.createElement("button");
+  resetBtn.textContent = "🛠 進捗をリセット (赤のみ)";
+  resetBtn.style.marginBottom = "1em";
+  resetBtn.onclick = async () => {
+    const ok = confirm("本当に進捗を赤だけに戻しますか？");
+    if (!ok) return;
+    const success = await resetChordProgressToRed(user.id);
+    if (success) {
+      alert("進捗をリセットしました");
+      await renderGrowthScreen(user);
+    } else {
+      alert("リセットに失敗しました");
+    }
+  };
+  container.appendChild(resetBtn);
 
   // 和音進捗表示
   const chordStatus = document.createElement("div");

--- a/utils/progressUtils.js
+++ b/utils/progressUtils.js
@@ -77,3 +77,30 @@ export async function lockChord(userId, chordKey) {
     .eq("chord_key", chordKey);
   return !error;
 }
+
+// ✅ 進捗をリセットして赤のみ in_progress に戻す（デバッグ用）
+export async function resetChordProgressToRed(userId) {
+  const { error: lockError } = await supabase
+    .from("user_chord_progress")
+    .update({ status: "locked" })
+    .eq("user_id", userId);
+
+  if (lockError) {
+    console.error("❌ 進捗リセット失敗:", lockError);
+    return false;
+  }
+
+  const firstKey = chordOrder[0];
+  const { error: redError } = await supabase
+    .from("user_chord_progress")
+    .update({ status: "in_progress" })
+    .eq("user_id", userId)
+    .eq("chord_key", firstKey);
+
+  if (redError) {
+    console.error("❌ 赤の設定失敗:", redError);
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- add ability to reset chord progress so only the first (red) chord is unlocked
- expose this helper via `resetChordProgressToRed` in `progressUtils.js`
- include debug button on the growth screen for resetting progress

## Testing
- `npm test` *(fails: could not find package.json)*