### PR TITLE
Add growth status bar

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -12,6 +12,7 @@ import { loadGrowthFlags } from "../utils/growthStore_supabase.js";
 import { chords } from "../data/chords.js";
 import { renderHeader } from "../components/header.js";
 import { unlockChord, resetChordProgressToRed } from "../utils/progressUtils.js";
+import { updateGrowthStatusBar } from "../utils/progressStatus.js";
 
 export async function renderGrowthScreen(user) {
   const app = document.getElementById("app");
@@ -39,6 +40,20 @@ export async function renderGrowthScreen(user) {
     今日の状態: ${qualifiedToday ? "✅ 合格済み" : "❌ 未合格"}
   `;
   container.appendChild(info);
+
+  const statusBar = document.createElement("div");
+  statusBar.style.margin = "1em 0";
+  const msgSpan = document.createElement("span");
+  msgSpan.id = "growth-message";
+  const unlockBtn = document.createElement("button");
+  unlockBtn.id = "unlock-button";
+  unlockBtn.textContent = "次の和音を解放する";
+  unlockBtn.style.marginLeft = "1em";
+  statusBar.appendChild(msgSpan);
+  statusBar.appendChild(unlockBtn);
+  container.appendChild(statusBar);
+
+  await updateGrowthStatusBar(user, target);
 
   const progressBar = document.createElement("div");
   progressBar.style.height = "30px";

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -1,0 +1,70 @@
+import { supabase } from "./supabaseClient.js";
+import { unlockChord } from "./progressUtils.js";
+
+const PASS_DAYS = 14;
+const MIN_SETS = 2;
+const MIN_COUNT = 40;
+const PASS_RATE = 0.98;
+
+export async function countQualifiedDays(userId) {
+  const { data, error } = await supabase
+    .from("training_sessions")
+    .select("session_date, total_count, correct_count, results_json, stats_json")
+    .eq("user_id", userId);
+
+  if (error) {
+    console.error("❌ セッション取得失敗:", error);
+    return 0;
+  }
+
+  const daily = {};
+  data.forEach(row => {
+    const mode = row.results_json?.mode || row.stats_json?.mode || row.results_json?.[0]?.mode;
+    if (mode !== "recommended") return;
+    const dateStr = row.session_date.split("T")[0];
+    if (!daily[dateStr]) daily[dateStr] = { sets: 0, total: 0, correct: 0 };
+    daily[dateStr].sets += 1;
+    daily[dateStr].total += row.total_count;
+    daily[dateStr].correct += row.correct_count;
+  });
+
+  let passed = 0;
+  for (const date in daily) {
+    const d = daily[date];
+    if (d.sets >= MIN_SETS && d.total >= MIN_COUNT && d.correct / d.total >= PASS_RATE) {
+      passed++;
+    }
+  }
+
+  return passed;
+}
+
+export async function updateGrowthStatusBar(user, target) {
+  const msg = document.getElementById("growth-message");
+  const btn = document.getElementById("unlock-button");
+  if (!msg || !btn) return;
+
+  const passed = await countQualifiedDays(user.id);
+  if (passed >= PASS_DAYS) {
+    msg.textContent = "🎉 和音の進捗条件を満たしました。次の和音を解放してください。";
+    btn.disabled = false;
+    btn.style.display = "inline-block";
+    btn.onclick = async () => {
+      if (!target) return;
+      const ok = confirm(`「${target.label}」を解放しますか？`);
+      if (!ok) return;
+      const success = await unlockChord(user.id, target.key);
+      if (success) {
+        btn.disabled = true;
+        btn.style.display = "none";
+        await updateGrowthStatusBar(user, target);
+      }
+    };
+  } else {
+    const label = target ? target.label : "";
+    const remain = PASS_DAYS - passed;
+    msg.textContent = `いま ${label} の解放に挑戦中　解放まであと${remain}日`;
+    btn.disabled = true;
+    btn.style.display = "none";
+  }
+}


### PR DESCRIPTION
## Summary
- add a utility to compute qualified days from `training_sessions`
- show a status bar in growth screen with progress message
- allow unlocking the next chord when conditions are met

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `npm run lint` *(fails: ENOENT no package.json)*