### PR TITLE
Update training flow and summary

### DIFF
--- a/components/result_full.js
+++ b/components/result_full.js
@@ -1,6 +1,8 @@
 // components/result_full.js
 // Uses global VexFlow loaded in index.html
 
+import { switchScreen } from "../main.js";
+
 export function renderTrainingFullResultScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = `
@@ -132,6 +134,13 @@ export function renderTrainingFullResultScreen(user) {
 
 
   const summaryDiv = document.getElementById("summary");
+  const totalQuestions = entries.length;
+  const correctCount = entries.filter(e => e.correct).length;
+  const overallAccuracy = totalQuestions ? Math.round((correctCount / totalQuestions) * 100) : 0;
+
+  const summaryText = document.createElement("p");
+  summaryText.textContent = `正解率 ${overallAccuracy}％（${correctCount}/${totalQuestions}）`;
+  summaryDiv.appendChild(summaryText);
   const table = document.createElement("table");
   table.innerHTML = `<tr><th>音</th><th>正解数</th><th>出題数</th><th>正答率</th></tr>`;
 
@@ -217,6 +226,6 @@ export function renderTrainingFullResultScreen(user) {
   }
 
   document.getElementById("back-btn").onclick = () => {
-    location.reload();
+    switchScreen("settings", user);
   };
 }

--- a/components/training_full.js
+++ b/components/training_full.js
@@ -34,7 +34,7 @@ export function renderTrainingScreen(user) {
     <div class="piano-container">
       <div class="white-keys"></div>
     </div>
-    <button id="finish-btn">結果を見る</button>
+    <button id="finish-btn">やめる</button>
   `;
 
   const whiteOrder = ["C", "D", "E", "F", "G", "A", "B"];
@@ -96,8 +96,7 @@ export function renderTrainingScreen(user) {
   });
 
   document.getElementById("finish-btn").onclick = () => {
-    sessionStorage.setItem("noteHistory", JSON.stringify(noteHistory));
-    switchScreen("result_full", user);
+    switchScreen("settings", user);
   };
 
   function nextQuestion() {


### PR DESCRIPTION
## Summary
- rename finish button to quit the monophonic test
- stop the test and return to settings when quitting
- display total accuracy summary on the monophonic result screen
- allow going back to settings from result screen

## Testing
- `node -v`