### PR TITLE
Add single note differentiation mode

### DIFF
--- a/css/training.css
+++ b/css/training.css
@@ -130,3 +130,9 @@
 .hai       { background-color: gray;      color: white; }
 .mizuiro   { background-color: skyblue;   color: white; }
 .white     { background-color: white;     color: black; border: 1px solid #ccc; }
+
+/* --- Single note question --- */
+.single-note-options button {
+  font-size: 1.5rem;
+  padding: 0.5em 1em;
+}


### PR DESCRIPTION
## Summary
- extend chord training with a toggle to enable single note drill after each chord
- implement logic to select a random chord tone and present three-note choices
- support wrong/correct playback and feedback for single note questions
- style single note buttons

## Testing
- `npm test` *(fails: Could not read package.json)*