### PR TITLE
Move single note mode switch to settings

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -138,6 +138,25 @@ buttonGroup.appendChild(resetBtn);
   headerBar.appendChild(buttonGroup);
   container.appendChild(headerBar);
 
+  const singleWrap = document.createElement('label');
+  singleWrap.style.display = 'flex';
+  singleWrap.style.alignItems = 'center';
+  singleWrap.style.gap = '4px';
+  singleWrap.style.margin = '0.5em 1em';
+  const singleToggle = document.createElement('input');
+  singleToggle.type = 'checkbox';
+  singleToggle.checked = localStorage.getItem('singleNoteMode') === 'on';
+  singleToggle.onchange = () => {
+    if (singleToggle.checked) {
+      localStorage.setItem('singleNoteMode', 'on');
+    } else {
+      localStorage.removeItem('singleNoteMode');
+    }
+  };
+  singleWrap.appendChild(singleToggle);
+  singleWrap.appendChild(document.createTextNode('単音分化モード'));
+  container.appendChild(singleWrap);
+
   const chordSettings = document.createElement("div");
   chordSettings.id = "chord-settings";
 


### PR DESCRIPTION
## Summary
- move '単音分化モード' toggle to settings screen
- read the toggle from localStorage when starting training
- keep progress header while showing single note quiz
- map flat/sharp names to existing wrong note audio files

## Testing
- `node -e "require('./components/training.js')"` *(fails: ERR_NETWORK_IMPORT_DISALLOWED)*