### PR TITLE
Fix missing italian property error

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -264,7 +264,7 @@ function drawQuizScreen() {
 
     const inner = document.createElement("div");
     inner.className = `square-btn-content ${chord.colorClass}`;
-    if (chordProgressCount >= 10) {
+    if (chordProgressCount >= 10 && chord.italian) {
       inner.innerHTML = chord.italian.join("<br>");
     } else {
       inner.innerHTML = chord.labelHtml;


### PR DESCRIPTION
## Summary
- handle chords without `italian` text when rendering training screen

## Testing
- `git status --short`