### PR TITLE
Fix UI layout and audio encoding

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -72,13 +72,13 @@ export function renderResultScreen() {
                 </div>
               </td>
               <td>
-                <span class="ans-mark ${r.correct ? 'correct' : 'wrong'}">${r.correct ? '◯' : '×'}</span>
                 <div class="chord-box ${getColorClass(r.answerName)}">
+                  <span class="ans-mark ${r.correct ? 'correct' : 'wrong'}">${r.correct ? '◯' : '×'}</span>
                   ${getLabelHiragana(r.answerName)}
                 </div>
               </td>
               ${singleNoteMode ? `<td>${noteRes ? labelNote(noteRes.noteQuestion || '') : ''}</td>` : ''}
-              ${singleNoteMode ? `<td>${noteRes ? '<span class="ans-mark ' + (noteRes.correct ? 'correct' : 'wrong') + '">' + (noteRes.correct ? '◯' : '×') + '</span>' + labelNote(noteRes.noteAnswer || '') : ''}</td>` : ''}
+              ${singleNoteMode ? `<td>${noteRes ? '<span class="note-answer">' + '<span class="ans-mark ' + (noteRes.correct ? 'correct' : 'wrong') + '">' + (noteRes.correct ? '◯' : '×') + '</span>' + labelNote(noteRes.noteAnswer || '') + '</span>' : ''}</td>` : ''}
             </tr>`;
             }
             return rows;

--- a/components/training.js
+++ b/components/training.js
@@ -48,7 +48,8 @@ function playSoundThen(name, callback) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
   }
-  currentAudio = new Audio(`audio/${name}.mp3`);
+  const encoded = encodeURIComponent(name);
+  currentAudio = new Audio(`audio/${encoded}.mp3`);
   currentAudio.onended = () => setTimeout(callback, 100);
   currentAudio.onerror = () => {
     console.error("⚠️ 音声ファイルが読み込めませんでした:", name);
@@ -247,14 +248,33 @@ function drawQuizScreen() {
     "E-A-C#", "A-D-F#", "B-E-G#", "F-B♭-D", "B♭-E♭-G"
   ];
 
-  order.forEach(name => {
-    if (name === null) {
-      const placeholder = document.createElement("div");
-      placeholder.className = "square-btn";
-      placeholder.style.visibility = "hidden";
-      layout.appendChild(placeholder);
-      return;
+  const visibleNames = selectedChords.map(c => c.name);
+  if (btnCount === 1 && visibleNames.length === 1) {
+    const only = chords.find(c => c.name === visibleNames[0]);
+    if (only) {
+      const wrapper = document.createElement("div");
+      wrapper.className = "square-btn";
+
+      const inner = document.createElement("div");
+      inner.className = `square-btn-content ${only.colorClass}`;
+      inner.innerHTML = chordProgressCount >= 10 && only.italian ? only.italian.join("<br>") : only.labelHtml;
+      inner.setAttribute("data-name", only.name);
+      inner.style.pointerEvents = "auto";
+      inner.style.opacity = "1";
+      inner.addEventListener("click", () => checkAnswer(only.name));
+
+      wrapper.appendChild(inner);
+      layout.appendChild(wrapper);
     }
+  } else {
+    order.forEach(name => {
+      if (name === null) {
+        const placeholder = document.createElement("div");
+        placeholder.className = "square-btn";
+        placeholder.style.visibility = "hidden";
+        layout.appendChild(placeholder);
+        return;
+      }
 
     const chord = chords.find(c => c.name === name);
     if (!chord) return;
@@ -279,9 +299,10 @@ function drawQuizScreen() {
       inner.style.visibility = "hidden";
     }
 
-    wrapper.appendChild(inner);
-    layout.appendChild(wrapper);
-  });
+      wrapper.appendChild(inner);
+      layout.appendChild(wrapper);
+    });
+  }
 
   const quitBtn = document.createElement("button");
   quitBtn.id = "quitBtn";

--- a/css/result.css
+++ b/css/result.css
@@ -68,14 +68,25 @@
 }
 
 .ans-mark {
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translateX(-50%);
   font-weight: bold;
-  margin-right: 4px;
+  font-size: 1rem;
 }
 .ans-mark.correct { color: green; }
 .ans-mark.wrong { color: red; }
 
+/* 単音回答ラッパー */
+.note-answer {
+  position: relative;
+  display: inline-block;
+}
+
 /* 和音色ボックス（文字折り返し無し＋小サイズ） */
 .chord-box {
+  position: relative;
   width: 50px;
   height: 50px;
   line-height: 50px;

--- a/css/training_full.css
+++ b/css/training_full.css
@@ -15,7 +15,8 @@
 
 .key-white,
 .key-black {
-  font-size: 0.9rem;
+  font-size: 0.8rem;
+  line-height: 1;
   display: flex;
   align-items: flex-end;
   justify-content: center;
@@ -38,6 +39,8 @@
   border: 1px solid #333;
   top: 0;
   z-index: 2;
+  font-size: 0.75rem;
+  padding-bottom: 2px;
 }
 
 .key-black.pos1 { left: calc(100% / 7 * 0.75); }


### PR DESCRIPTION
## Summary
- position answer marks on top of chord boxes so the table layout doesn't shift
- encode filenames when playing audio to load sounds like wrong_A# correctly
- center a single training chord instead of using placeholder grid
- shrink piano key text so "フィス" fits

## Testing
- `npm test` *(fails: package.json missing)*