### PR TITLE
Fix result mark style and overflow

### DIFF
--- a/css/result.css
+++ b/css/result.css
@@ -69,13 +69,14 @@
 
 .ans-mark {
   position: absolute;
-  top: -8px;
+  top: -10px;
   left: 50%;
   transform: translateX(-50%);
   font-weight: bold;
-  font-size: 1rem;
+  font-size: 1.4rem;
+  color: red;
 }
-.ans-mark.correct { color: green; }
+.ans-mark.correct { color: red; }
 .ans-mark.wrong { color: red; }
 
 /* 単音回答ラッパー */

--- a/css/training.css
+++ b/css/training.css
@@ -134,10 +134,11 @@
 /* --- Single note question --- */
 .single-note-options button {
   font-size: 1.5rem;
-  width: 3em;
-  height: 3em;
-  padding: 0;
+  width: 3.4em;
+  height: 3.4em;
+  padding: 0.5em 1em;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- enlarge and recolor answer mark
- adjust single note option buttons so text like `フィス` fits inside

## Testing
- `git status --short`
