### PR TITLE
Adjust result styling and note buttons

### DIFF
--- a/css/result.css
+++ b/css/result.css
@@ -69,11 +69,11 @@
 
 .ans-mark {
   position: absolute;
-  top: -10px;
+  top: -12px;
   left: 50%;
   transform: translateX(-50%);
-  font-weight: bold;
-  font-size: 1.4rem;
+  font-weight: 900;
+  font-size: 2rem;
   color: red;
 }
 .ans-mark.correct { color: red; }

--- a/css/training.css
+++ b/css/training.css
@@ -134,9 +134,9 @@
 /* --- Single note question --- */
 .single-note-options button {
   font-size: 1.5rem;
-  width: 3.4em;
-  height: 3.4em;
-  padding: 0.5em 1em;
+  width: 4em;
+  height: 4em;
+  padding: 0.5em;
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- increase `.ans-mark` size for clearer "かいとう" marks
- enlarge single note option buttons so labels like "フィス" fit inside

## Testing
- `git status --short`