### PR TITLE
Modify result screen answer style

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -73,12 +73,12 @@ export function renderResultScreen() {
               </td>
               <td>
                 <div class="chord-box ${getColorClass(r.answerName)}">
-                  <span class="ans-mark ${r.correct ? 'correct' : 'wrong'}">${r.correct ? '◯' : '×'}</span>
+                  <span class="ans-mark ${r.correct ? 'correct' : 'wrong'}">${r.correct ? '◯' : ''}</span>
                   ${getLabelHiragana(r.answerName)}
                 </div>
               </td>
               ${singleNoteMode ? `<td>${noteRes ? labelNote(noteRes.noteQuestion || '') : ''}</td>` : ''}
-              ${singleNoteMode ? `<td>${noteRes ? '<span class="note-answer">' + '<span class="ans-mark ' + (noteRes.correct ? 'correct' : 'wrong') + '">' + (noteRes.correct ? '◯' : '×') + '</span>' + labelNote(noteRes.noteAnswer || '') + '</span>' : ''}</td>` : ''}
+              ${singleNoteMode ? `<td>${noteRes ? '<span class="note-answer">' + '<span class="ans-mark ' + (noteRes.correct ? 'correct' : 'wrong') + '">' + (noteRes.correct ? '◯' : '') + '</span>' + labelNote(noteRes.noteAnswer || '') + '</span>' : ''}</td>` : ''}
             </tr>`;
             }
             return rows;

--- a/components/result_full.js
+++ b/components/result_full.js
@@ -115,7 +115,7 @@ export function renderTrainingFullResultScreen(user) {
         }
         vNote.addModifier(
           0,
-          new VF.Annotation(entry.correct ? "◯" : "×").setVerticalJustification(VF.Annotation.VerticalJustify.ABOVE)
+          new VF.Annotation(entry.correct ? "◯" : "").setVerticalJustification(VF.Annotation.VerticalJustify.ABOVE)
         );
       }
 

--- a/css/result.css
+++ b/css/result.css
@@ -69,15 +69,16 @@
 
 .ans-mark {
   position: absolute;
-  top: -12px;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   font-weight: 900;
-  font-size: 2rem;
-  color: red;
+  font-size: 2.6rem; /* 30% larger */
+  color: #ff6666; /* lighter red */
+  -webkit-text-stroke: 1px #ff6666; /* slightly thicker */
 }
-.ans-mark.correct { color: red; }
-.ans-mark.wrong { color: red; }
+.ans-mark.correct { color: #ff6666; }
+.ans-mark.wrong { color: #ff6666; }
 
 /* 単音回答ラッパー */
 .note-answer {


### PR DESCRIPTION
## Summary
- restyle answer mark to be bigger, centered, and lighter red
- hide cross mark when the answer is wrong
- apply same behavior on staff result view

## Testing
- `node -v`