### PR TITLE
Japanese hiragana labels and fixed controls

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -7,19 +7,25 @@ import { drawStaffFromNotes } from "./resultStaff.js";  // 楽譜描画（必要
 let resultShownInThisSession = false;
 
 const noteLabels = {
-  "C": "ド",
-  "D": "レ",
-  "E": "ミ",
-  "F": "ファ",
-  "G": "ソ",
-  "A": "ラ",
-  "B": "シ",
-  "C#": "チス", "Db": "チス",
-  "D#": "エス", "Eb": "エス",
-  "F#": "フィス", "Gb": "フィス",
-  "G#": "ジス", "Ab": "ジス",
-  "A#": "ベー", "Bb": "ベー"
+  "C": "ど",
+  "D": "れ",
+  "E": "み",
+  "F": "ふぁ",
+  "G": "そ",
+  "A": "ら",
+  "B": "し",
+  "C#": "ちす", "Db": "ちす",
+  "D#": "えす", "Eb": "えす",
+  "F#": "ふぃす", "Gb": "ふぃす",
+  "G#": "じす", "Ab": "じす",
+  "A#": "べー", "Bb": "べー"
 };
+
+function kanaToHiragana(str) {
+  return str.replace(/[ァ-ン]/g, ch =>
+    String.fromCharCode(ch.charCodeAt(0) - 0x60)
+  );
+}
 
 function labelNote(n) {
   const pitch = n ? n.replace(/\d/g, '') : '';

--- a/components/training.js
+++ b/components/training.js
@@ -23,19 +23,25 @@ let singleNoteMode = false;
 let chordProgressCount = 0;
 
 const noteLabels = {
-  "C": "ド",
-  "D": "レ",
-  "E": "ミ",
-  "F": "ファ",
-  "G": "ソ",
-  "A": "ラ",
-  "B": "シ",
-  "C#": "チス", "Db": "チス",
-  "D#": "エス", "Eb": "エス",
-  "F#": "フィス", "Gb": "フィス",
-  "G#": "ジス", "Ab": "ジス",
-  "A#": "ベー", "Bb": "ベー"
+  "C": "ど",
+  "D": "れ",
+  "E": "み",
+  "F": "ふぁ",
+  "G": "そ",
+  "A": "ら",
+  "B": "し",
+  "C#": "ちす", "Db": "ちす",
+  "D#": "えす", "Eb": "えす",
+  "F#": "ふぃす", "Gb": "ふぃす",
+  "G#": "じす", "Ab": "じす",
+  "A#": "べー", "Bb": "べー"
 };
+
+function kanaToHiragana(str) {
+  return str.replace(/[ァ-ン]/g, ch =>
+    String.fromCharCode(ch.charCodeAt(0) - 0x60)
+  );
+}
 
 export const stats = {};
 export const mistakes = {};
@@ -183,7 +189,9 @@ function drawQuizScreen() {
 
   const container = document.createElement("div");
   container.className = "screen active";
-  container.style.padding = "0";
+  container.style.minHeight = "100vh";
+  container.style.boxSizing = "border-box";
+  container.style.padding = "1em 0 6em";
   container.style.width = "100vw";
 
   const feedback = document.createElement("div");
@@ -262,7 +270,9 @@ function drawQuizScreen() {
 
       const inner = document.createElement("div");
       inner.className = `square-btn-content ${only.colorClass}`;
-      inner.innerHTML = chordProgressCount >= 10 && only.italian ? only.italian.join("<br>") : only.labelHtml;
+      inner.innerHTML = chordProgressCount >= 10 && only.italian
+        ? only.italian.map(kanaToHiragana).join("<br>")
+        : only.labelHtml;
       inner.setAttribute("data-name", only.name);
       inner.style.pointerEvents = "auto";
       inner.style.opacity = "1";
@@ -290,7 +300,7 @@ function drawQuizScreen() {
     const inner = document.createElement("div");
     inner.className = `square-btn-content ${chord.colorClass}`;
     if (chordProgressCount >= 10 && chord.italian) {
-      inner.innerHTML = chord.italian.join("<br>");
+      inner.innerHTML = chord.italian.map(kanaToHiragana).join("<br>");
     } else {
       inner.innerHTML = chord.labelHtml;
     }
@@ -330,7 +340,6 @@ function drawQuizScreen() {
   const unknownBtn = document.createElement("button");
   unknownBtn.id = "unknownBtn";
   unknownBtn.textContent = "わからない";
-  unknownBtn.style.marginTop = "1em";
   unknownBtn.onclick = () => {
     if (alreadyTried || isForcedAnswer) return;
 
@@ -370,12 +379,16 @@ if (correctBtn) {
     });
   };
 
+  const bottomWrap = document.createElement("div");
+  bottomWrap.id = "bottom-buttons";
+  bottomWrap.appendChild(unknownBtn);
+  bottomWrap.appendChild(quitBtn);
+
   container.appendChild(debugAnswer);
   container.appendChild(header);
   container.appendChild(layout);
-  container.appendChild(unknownBtn);
-  container.appendChild(quitBtn);
   app.appendChild(container);
+  app.appendChild(bottomWrap);
 }
 
 

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -110,7 +110,9 @@ function drawQuizScreen() {
 
   const container = document.createElement("div");
   container.className = "screen active";
-  container.style.padding = "0";
+  container.style.minHeight = "100vh";
+  container.style.boxSizing = "border-box";
+  container.style.padding = "1em 0 6em";
   container.style.width = "100vw";
 
   const feedback = document.createElement("div");
@@ -231,7 +233,6 @@ function drawQuizScreen() {
   const unknownBtn = document.createElement("button");
   unknownBtn.id = "unknownBtn";
   unknownBtn.textContent = "わからない";
-  unknownBtn.style.marginTop = "1em";
   unknownBtn.onclick = () => {
     if (alreadyTried || isForcedAnswer) return;
 
@@ -271,12 +272,16 @@ if (correctBtn) {
     });
   };
 
+  const bottomWrap = document.createElement("div");
+  bottomWrap.id = "bottom-buttons";
+  bottomWrap.appendChild(unknownBtn);
+  bottomWrap.appendChild(quitBtn);
+
   container.appendChild(debugAnswer);
   container.appendChild(header);
   container.appendChild(layout);
-  container.appendChild(unknownBtn);
-  container.appendChild(quitBtn);
   app.appendChild(container);
+  app.appendChild(bottomWrap);
 }
 
 

--- a/components/training_easy_note.js
+++ b/components/training_easy_note.js
@@ -14,24 +14,30 @@ const FEEDBACK_DELAY = 1000;
 const maxQuestions = 24;
 
 const noteLabels = {
-  "C": "ド",
-  "D": "レ",
-  "E": "ミ",
-  "F": "ファ",
-  "G": "ソ",
-  "A": "ラ",
-  "B": "シ",
-  "C#": "チス",
-  "D#": "エス",
-  "F#": "フィス",
-  "G#": "ジス",
-  "A#": "ベー",
-  "Db": "チス",
-  "Eb": "エス",
-  "Gb": "フィス",
-  "Ab": "ジス",
-  "Bb": "ベー",
+  "C": "ど",
+  "D": "れ",
+  "E": "み",
+  "F": "ふぁ",
+  "G": "そ",
+  "A": "ら",
+  "B": "し",
+  "C#": "ちす",
+  "D#": "えす",
+  "F#": "ふぃす",
+  "G#": "じす",
+  "A#": "べー",
+  "Db": "ちす",
+  "Eb": "えす",
+  "Gb": "ふぃす",
+  "Ab": "じす",
+  "Bb": "べー",
 };
+
+function kanaToHiragana(str) {
+  return str.replace(/[ァ-ン]/g, ch =>
+    String.fromCharCode(ch.charCodeAt(0) - 0x60)
+  );
+}
 
 export function renderTrainingScreen(user) {
   const app = document.getElementById("app");

--- a/components/training_full.js
+++ b/components/training_full.js
@@ -13,24 +13,30 @@ const FEEDBACK_DELAY = 1000;
 const maxQuestions = 5; // ← テスト用（本番時は30に）
 
 const noteLabels = {
-  "C": "ド",
-  "D": "レ",
-  "E": "ミ",
-  "F": "ファ",
-  "G": "ソ",
-  "A": "ラ",
-  "B": "シ",
-  "C#": "チス",
-  "D#": "エス",
-  "F#": "フィス",
-  "G#": "ジス",
-  "A#": "ベー",
-  "Db": "チス",
-  "Eb": "エス",
-  "Gb": "フィス",
-  "Ab": "ジス",
-  "Bb": "ベー",
+  "C": "ど",
+  "D": "れ",
+  "E": "み",
+  "F": "ふぁ",
+  "G": "そ",
+  "A": "ら",
+  "B": "し",
+  "C#": "ちす",
+  "D#": "えす",
+  "F#": "ふぃす",
+  "G#": "じす",
+  "A#": "べー",
+  "Db": "ちす",
+  "Eb": "えす",
+  "Gb": "ふぃす",
+  "Ab": "じす",
+  "Bb": "べー",
 };
+
+function kanaToHiragana(str) {
+  return str.replace(/[ァ-ン]/g, ch =>
+    String.fromCharCode(ch.charCodeAt(0) - 0x60)
+  );
+}
 
 export function renderTrainingScreen(user) {
   const app = document.getElementById("app");

--- a/style.css
+++ b/style.css
@@ -90,3 +90,14 @@ body {
 #feedback.good { color: #4CAF50; }
 #feedback.bad { color: #f44336; }
 
+#bottom-buttons {
+  position: fixed;
+  bottom: 1em;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 1em;
+  z-index: 1000;
+}
+


### PR DESCRIPTION
## Summary
- show note names in hiragana across training and result screens
- keep “わからない” and “やめる” buttons fixed to the bottom of the viewport

## Testing
- `npm test` *(fails: package.json missing)*