### PR TITLE
Fix horizontal scroll on mobile

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -74,8 +74,9 @@ export function showCustomConfirm(onConfirm) {
     modal.style.position = "fixed";
     modal.style.top = "0";
     modal.style.left = "0";
-    modal.style.width = "100vw";
-    modal.style.height = "100vh";
+    // Prevent potential overflow caused by viewport units
+    modal.style.width = "100%";
+    modal.style.height = "100%";
     modal.style.background = "rgba(0,0,0,0.6)";
     modal.style.display = "flex";
     modal.style.justifyContent = "center";

--- a/components/training.js
+++ b/components/training.js
@@ -192,7 +192,8 @@ function drawQuizScreen() {
   container.style.minHeight = "100vh";
   container.style.boxSizing = "border-box";
   container.style.padding = "1em 0 6em";
-  container.style.width = "100vw";
+  // Avoid potential horizontal scroll on mobile
+  container.style.width = "100%";
 
   const feedback = document.createElement("div");
   feedback.id = "feedback";

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -113,7 +113,8 @@ function drawQuizScreen() {
   container.style.minHeight = "100vh";
   container.style.boxSizing = "border-box";
   container.style.padding = "1em 0 6em";
-  container.style.width = "100vw";
+  // Avoid potential horizontal scroll on mobile
+  container.style.width = "100%";
 
   const feedback = document.createElement("div");
   feedback.id = "feedback";

--- a/css/result.css
+++ b/css/result.css
@@ -139,8 +139,9 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
-  height: 100vh;
+  /* Avoid horizontal scrollbars caused by viewport units */
+  width: 100%;
+  height: 100%;
   background: rgba(0, 0, 0, 0.7);
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- avoid viewport width units that caused overflow on small screens
- update training screen container widths to `100%`
- adjust confirm modal and result modal sizing

## Testing
- `npm test` *(fails: package.json missing)*