### PR TITLE
Fix small scroll on home and training screens

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -189,7 +189,8 @@ function drawQuizScreen() {
 
   const container = document.createElement("div");
   container.className = "screen active";
-  container.style.minHeight = "100vh";
+  // Avoid scroll by accounting for header height and padding
+  container.style.minHeight = "calc(100dvh - 56px - 7em)";
   container.style.boxSizing = "border-box";
   container.style.padding = "1em 0 6em";
   // Avoid potential horizontal scroll on mobile

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -110,7 +110,8 @@ function drawQuizScreen() {
 
   const container = document.createElement("div");
   container.className = "screen active";
-  container.style.minHeight = "100vh";
+  // Avoid scroll by accounting for header height and padding
+  container.style.minHeight = "calc(100dvh - 56px - 7em)";
   container.style.boxSizing = "border-box";
   container.style.padding = "1em 0 6em";
   // Avoid potential horizontal scroll on mobile

--- a/css/common.css
+++ b/css/common.css
@@ -60,7 +60,7 @@ button:hover {
   }
 
   .screen {
-    height: calc(100vh - 56px); /* ヘッダーを除く高さ */
+    height: calc(100dvh - 56px); /* ヘッダーを除く高さ */
     overflow-y: auto;
   }
 }

--- a/css/home.css
+++ b/css/home.css
@@ -10,7 +10,7 @@ html, body {
 
 /* ===== ホーム画面専用スタイル ===== */
 .home-screen {
-  height: calc(100vh - 56px);
+  height: calc(100dvh - 56px);
   margin-top: 56px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- avoid minor vertical scroll by adjusting min-height in training screens
- use dynamic viewport units for the home screen and generic screen style

## Testing
- `npm test` *(fails: package.json missing)*