### PR TITLE
Fix training footer buttons

### DIFF
--- a/css/training.css
+++ b/css/training.css
@@ -142,3 +142,15 @@
   justify-content: center;
   box-sizing: border-box;
 }
+
+/* 下部の操作ボタンを常に画面下部に固定 */
+#bottom-buttons {
+  position: fixed;
+  bottom: 1em;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 1em;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- keep training screen action buttons fixed to the bottom of the viewport

## Testing
- `git status --short`
