### PR TITLE
Align unlock button with quit confirmation

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -14,6 +14,7 @@ import { chords } from "../data/chords.js";
 import { renderHeader } from "../components/header.js";
 import { unlockChord, resetChordProgressToRed } from "../utils/progressUtils.js";
 import { updateGrowthStatusBar } from "../utils/progressStatus.js";
+import { showCustomConfirm } from "../components/home.js";
 
 export async function renderGrowthScreen(user) {
   const app = document.getElementById("app");
@@ -134,16 +135,15 @@ export async function renderGrowthScreen(user) {
       const button = document.createElement("button");
       button.style.marginTop = "4px";
       button.textContent = "🔓 次の和音を解放する";
-      button.onclick = async () => {
-        const confirmed = confirm(`「${chord.label}」を解放しますか？`);
-        if (!confirmed) return;
-
-        const success = await unlockChord(user.id, chord.key);
-        if (success) {
-          alert(`🎉 ${chord.label} を解放しました！`);
-          await applyRecommendedSelection(user.id);
-          await renderGrowthScreen(user);
-        }
+      button.onclick = () => {
+        showCustomConfirm(async () => {
+          const success = await unlockChord(user.id, chord.key);
+          if (success) {
+            alert(`🎉 ${chord.label} を解放しました！`);
+            await applyRecommendedSelection(user.id);
+            await renderGrowthScreen(user);
+          }
+        });
       };
       item.appendChild(button);
     }

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -1,6 +1,7 @@
 import { supabase } from "./supabaseClient.js";
 import { unlockChord } from "./progressUtils.js";
 import { applyRecommendedSelection } from "./growthUtils.js";
+import { showCustomConfirm } from "../components/home.js";
 
 const PASS_DAYS = 14;
 const MIN_SETS = 2;
@@ -50,22 +51,22 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
     msg.textContent = "🎉 和音の進捗条件を満たしました。次の和音を解放してください。";
     btn.disabled = false;
     btn.style.display = "inline-block";
-    btn.onclick = async () => {
+    btn.onclick = () => {
       if (!target) return;
-      const ok = confirm(`「${target.label}」を解放しますか？`);
-      if (!ok) return;
-      const success = await unlockChord(user.id, target.key);
-      if (success) {
-        alert(`🎉 ${target.label} を解放しました！`);
-        await applyRecommendedSelection(user.id);
-        btn.disabled = true;
-        btn.style.display = "none";
-        if (onUnlocked) {
-          await onUnlocked();
-        } else {
-          await updateGrowthStatusBar(user, target);
+      showCustomConfirm(async () => {
+        const success = await unlockChord(user.id, target.key);
+        if (success) {
+          alert(`🎉 ${target.label} を解放しました！`);
+          await applyRecommendedSelection(user.id);
+          btn.disabled = true;
+          btn.style.display = "none";
+          if (onUnlocked) {
+            await onUnlocked();
+          } else {
+            await updateGrowthStatusBar(user, target);
+          }
         }
-      }
+      });
     };
   } else {
     const label = target ? target.label : "";


### PR DESCRIPTION
## Summary
- use the same custom confirmation modal as the quit button when unlocking chords

## Testing
- `npm test` *(fails: could not find package.json)*