### PR TITLE
Add provider detection for Supabase OIDC login

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,28 @@ Supabase の認証に Firebase の ID トークンを使用するため、Supaba
 
 ## `main.js` での認証処理
 
-Firebase でログイン後、取得した ID トークンを用いて Supabase にサインインする処理は `main.js` に実装されています。設定が完了すると、以下のコードが正常に動作します。
+Firebase でログイン後、取得した ID トークンを用いて Supabase にサインインします。Supabase 側で登録したカスタム OIDC のスラッグが `firebase` とは限らないため、`main.js` では複数の候補を順番に試します。
 
 ```javascript
-const idToken = await firebaseUser.getIdToken();
-const { error: signInError } = await supabase.auth.signInWithIdToken({
-  provider: "firebase",
-  token: idToken,
-});
+const idToken = await firebaseUser.getIdToken(true);
+const saved = localStorage.getItem("supabaseProvider");
+const providersToTry = saved ? [saved] : ["firebase", "Firebase", "google"];
+let signInError = null;
+for (const provider of providersToTry) {
+  const { error } = await supabase.auth.signInWithIdToken({ provider, token: idToken });
+  if (error) {
+    console.warn(`❌ Sign-in with "${provider}" failed:`, error.message);
+    signInError = error;
+  } else {
+    console.log(`✅ Sign-in with "${provider}" succeeded`);
+    localStorage.setItem("supabaseProvider", provider);
+    signInError = null;
+    break;
+  }
+}
+if (signInError) {
+  console.error("❌ Supabase sign-in failed:", signInError.message);
+}
 ```
 
-`signInError` が返らなければ、Firebase ユーザーに対応する Supabase のセッションが生成され、アプリの各機能で Supabase の API を利用できるようになります。
+一度成功したプロバイダーは `localStorage` に保存され、次回以降はその値のみでサインインを試みます。

--- a/main.js
+++ b/main.js
@@ -95,11 +95,27 @@ onAuthStateChanged(auth, async (firebaseUser) => {
 
   // 🆕 FirebaseのIDトークンでSupabaseにもサインイン
   try {
-    const idToken = await firebaseUser.getIdToken();
-    const { error: signInError } = await supabase.auth.signInWithIdToken({
-      provider: "firebase",
-      token: idToken,
-    });
+    const idToken = await firebaseUser.getIdToken(true);
+    const saved = localStorage.getItem("supabaseProvider");
+    const providersToTry = saved ? [saved] : ["firebase", "Firebase", "google"];
+    let signInError = null;
+
+    for (const provider of providersToTry) {
+      const { error } = await supabase.auth.signInWithIdToken({
+        provider,
+        token: idToken,
+      });
+      if (error) {
+        console.warn(`❌ Sign-in with "${provider}" failed:`, error.message);
+        signInError = error;
+      } else {
+        console.log(`✅ Sign-in with "${provider}" succeeded`);
+        localStorage.setItem("supabaseProvider", provider);
+        signInError = null;
+        break;
+      }
+    }
+
     if (signInError) {
       console.error("❌ Supabase sign-in failed:", signInError.message);
     }


### PR DESCRIPTION
## Summary
- support multiple provider slugs when signing into Supabase with Firebase ID tokens
- document provider fallback logic in README

## Testing
- `npm test` *(fails: Could not read package.json)*