### PR TITLE
Restrict time‑of‑day theme to home screen

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -2,11 +2,18 @@ import { switchScreen } from "../main.js";
 import { loadGrowthData } from "../utils/growthStore.js";
 import { getToday } from "../utils/growthUtils.js";
 import { renderHeader } from "./header.js";
-import { getGreeting, getTimeOfDay } from "../utils/timeOfDay.js";
+import {
+  getGreeting,
+  getTimeOfDay,
+  clearTimeOfDayStyling,
+} from "../utils/timeOfDay.js";
 
 export function renderHomeScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
+
+  // Remove any previous time-of-day classes/intervals before applying new one
+  clearTimeOfDayStyling();
 
   // ✅ ヘッダー（固定表示、上部に表示）
   renderHeader(app);
@@ -16,13 +23,6 @@ export function renderHomeScreen(user) {
   let timeClass = getTimeOfDay();
   console.log('[home] time class:', timeClass);
   container.className = `home-screen active ${timeClass}`;
-  document.body.classList.remove(
-    "morning",
-    "day",
-    "noon",
-    "evening",
-    "night"
-  );
   document.body.classList.add(timeClass);
   app.appendChild(container);
 

--- a/main.js
+++ b/main.js
@@ -16,6 +16,7 @@ import { renderSignUpScreen } from "./components/signup.js";
 import { supabase } from "./utils/supabaseClient.js";
 import { createInitialChordProgress } from "../utils/progressUtils.js";
 import { renderMyPageScreen } from "./components/mypage.js";
+import { clearTimeOfDayStyling } from "./utils/timeOfDay.js";
 
 
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.11.0/firebase-app.js";
@@ -50,6 +51,10 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
 
   const app = document.getElementById("app");
   app.innerHTML = "";
+
+  if (screen !== "home") {
+    clearTimeOfDayStyling();
+  }
 
   currentUser = user;
 

--- a/utils/timeOfDay.js
+++ b/utils/timeOfDay.js
@@ -15,3 +15,19 @@ export function getGreeting() {
   if (time === 'evening') return 'こんばんは';
   return 'こんばんわ';
 }
+
+// Remove all time-of-day classes from the given element.
+// Defaults to `document.body` which has the `.app-root` class.
+export function clearTimeClasses(target = document.body) {
+  target.classList.remove('morning', 'noon', 'evening', 'night');
+}
+
+// Reset any time-of-day styling applied by the home screen. This will
+// also clear the interval used to update the background.
+export function clearTimeOfDayStyling() {
+  clearTimeClasses();
+  if (window.homeTimeInterval) {
+    clearInterval(window.homeTimeInterval);
+    window.homeTimeInterval = null;
+  }
+}


### PR DESCRIPTION
## Summary
- add utilities to clear time-of-day styling
- reset time classes when leaving the home screen
- ensure home screen resets existing classes before applying a new one

## Testing
- `git status --short`