### PR TITLE
Add debug tools for chord unlock feature

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -9,7 +9,11 @@ import {
   getSortedRecordArray,
   applyRecommendedSelection
 } from "../utils/growthUtils.js";
-import { loadGrowthFlags } from "../utils/growthStore_supabase.js";
+import {
+  loadGrowthFlags,
+  markChordAsUnlocked,
+  generateMockGrowthData
+} from "../utils/growthStore_supabase.js";
 import { chords } from "../data/chords.js";
 import { renderHeader } from "../components/header.js";
 import { unlockChord, resetChordProgressToRed } from "../utils/progressUtils.js";
@@ -86,6 +90,53 @@ export async function renderGrowthScreen(user) {
     }
   };
   container.appendChild(resetBtn);
+
+  // 🛠 デバッグ: 任意和音解放やモックデータ生成
+  const debugPanel = document.createElement("div");
+  debugPanel.style.marginBottom = "1em";
+
+  const select = document.createElement("select");
+  chords.forEach(c => {
+    const opt = document.createElement("option");
+    opt.value = c.key;
+    opt.textContent = c.label;
+    select.appendChild(opt);
+  });
+
+  const manualBtn = document.createElement("button");
+  manualBtn.textContent = "🛠 選択和音を解放";
+  manualBtn.style.marginLeft = "0.5em";
+  manualBtn.onclick = async () => {
+    await markChordAsUnlocked(user.id, select.value);
+    alert(`${select.value} を手動で解放しました`);
+    await renderGrowthScreen(user);
+  };
+
+  const mockBtn = document.createElement("button");
+  mockBtn.textContent = "🛠 モック記録生成";
+  mockBtn.style.marginLeft = "0.5em";
+  mockBtn.onclick = async () => {
+    await generateMockGrowthData(user.id);
+    alert("モックデータを生成しました");
+    await renderGrowthScreen(user);
+  };
+
+  const logLabel = document.createElement("label");
+  logLabel.style.marginLeft = "0.5em";
+  const logChk = document.createElement("input");
+  logChk.type = "checkbox";
+  logChk.checked = window.unlockDebugLogs === true;
+  logChk.onchange = () => {
+    window.unlockDebugLogs = logChk.checked;
+  };
+  logLabel.appendChild(logChk);
+  logLabel.appendChild(document.createTextNode("詳細ログ"));
+
+  debugPanel.appendChild(select);
+  debugPanel.appendChild(manualBtn);
+  debugPanel.appendChild(mockBtn);
+  debugPanel.appendChild(logLabel);
+  container.appendChild(debugPanel);
 
   // 和音進捗表示
   const chordStatus = document.createElement("div");

--- a/utils/growthStore_supabase.js
+++ b/utils/growthStore_supabase.js
@@ -50,3 +50,41 @@ export async function markChordAsUnlocked(userId, chordKey) {
     console.log(`✅ 和音 ${chordKey} を手動で解放しました`);
   }
 }
+
+/**
+ * 直近7日分のモック記録を生成（デバッグ用）
+ * @param {string} userId
+ */
+export async function generateMockGrowthData(userId) {
+  const now = new Date();
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(now);
+    d.setDate(now.getDate() - i);
+    const dateStr = d.toISOString().split("T")[0];
+
+    const rec = {
+      user_id: userId,
+      date: dateStr,
+      count: 60,
+      correct: 58,
+      sets: 3
+    };
+    const { error: recErr } = await supabase
+      .from("training_records")
+      .upsert(rec, { onConflict: "user_id,date" });
+    if (recErr) console.error("❌ モック記録挿入失敗:", recErr);
+
+    const ses = {
+      user_id: userId,
+      session_date: `${dateStr}T12:00:00`,
+      correct_count: 58,
+      total_count: 60,
+      results_json: { mode: "recommended" },
+      stats_json: { dummy: { total: 20 } }
+    };
+    const { error: sesErr } = await supabase
+      .from("training_sessions")
+      .insert(ses);
+    if (sesErr) console.error("❌ モックセッション挿入失敗:", sesErr);
+  }
+}


### PR DESCRIPTION
## Summary
- add developer controls for manual chord unlocks and mock data generation
- provide a checkbox to enable verbose unlock logs
- implement `generateMockGrowthData` helper
- show detailed logs from `checkRecentUnlockCriteria`

## Testing
- `git status --short`
