### PR TITLE
Reset progress after unlocking

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -7,7 +7,8 @@ import {
   getPassedDays,
   getCurrentTargetChord,
   getSortedRecordArray,
-  applyRecommendedSelection
+  applyRecommendedSelection,
+  forceUnlock
 } from "../utils/growthUtils.js";
 import {
   loadGrowthFlags,
@@ -216,6 +217,7 @@ export async function renderGrowthScreen(user) {
           if (success) {
             alert(`🎉 ${chord.label} を解放しました！`);
             await applyRecommendedSelection(user.id);
+            forceUnlock();
             await renderGrowthScreen(user);
           }
         });

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -1,6 +1,6 @@
 import { supabase } from "./supabaseClient.js";
 import { unlockChord } from "./progressUtils.js";
-import { applyRecommendedSelection } from "./growthUtils.js";
+import { applyRecommendedSelection, forceUnlock } from "./growthUtils.js";
 import { showCustomConfirm } from "../components/home.js";
 import { getConsecutiveQualifiedDays } from "./qualifiedStore_supabase.js";
 
@@ -69,6 +69,7 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
         if (success) {
           alert(`🎉 ${target.label} を解放しました！`);
           await applyRecommendedSelection(user.id);
+          forceUnlock();
           btn.disabled = true;
           btn.style.display = "none";
           if (onUnlocked) {


### PR DESCRIPTION
## Summary
- ensure consecutive day count resets visually when a chord is unlocked
- call `forceUnlock()` whenever the unlock buttons succeed

## Testing
- `git status --short`