### PR TITLE
Improve audio playback speed with caching

### DIFF
--- a/components/soundPlayer.js
+++ b/components/soundPlayer.js
@@ -1,3 +1,4 @@
+import { getAudio } from "../utils/audioCache.js";
 const audioBasePath = "./sounds";
 
 function normalizeNoteName(name) {
@@ -17,7 +18,7 @@ function normalizeNoteName(name) {
 export function playNote(noteName) {
   return new Promise((resolve) => {
     const encoded = encodeURIComponent(normalizeNoteName(noteName));
-    const audio = new Audio(`sounds/${encoded}.mp3`);
+    const audio = getAudio(`sounds/${encoded}.mp3`);
     audio.addEventListener("ended", resolve);
     audio.addEventListener("error", () => {
       console.warn(`音声再生エラー: ${noteName}`);

--- a/components/training.js
+++ b/components/training.js
@@ -10,6 +10,7 @@ import { autoUnlockNextChord } from "../utils/progressUtils.js";
 import { saveTrainingSession } from "../utils/trainingStore_supabase.js";
 import { generateRecommendedQueue } from "../utils/growthUtils.js";
 import { loadGrowthFlags } from "../utils/growthStore_supabase.js";
+import { getAudio } from "../utils/audioCache.js";
 
 let questionCount = 0;
 let currentAnswer = null;
@@ -55,7 +56,7 @@ function playSoundThen(name, callback) {
     currentAudio.currentTime = 0;
   }
   const encoded = encodeURIComponent(name);
-  currentAudio = new Audio(`audio/${encoded}.mp3`);
+  currentAudio = getAudio(`audio/${encoded}.mp3`);
   currentAudio.onended = () => setTimeout(callback, 100);
   currentAudio.onerror = () => {
     console.error("⚠️ 音声ファイルが読み込めませんでした:", name);
@@ -408,7 +409,7 @@ function playChordFile(filename) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
   }
-  currentAudio = new Audio(`audio/${filename}`);
+  currentAudio = getAudio(`audio/${filename}`);
   currentAudio.onerror = () => console.error("音声ファイルが見つかりません:", filename);
   currentAudio.play();
 }
@@ -433,7 +434,7 @@ function playNoteFile(note, callback) {
     currentAudio.currentTime = 0;
   }
   const encoded = encodeURIComponent(normalizeNoteName(note));
-  currentAudio = new Audio(`sounds/${encoded}.mp3`);
+  currentAudio = getAudio(`sounds/${encoded}.mp3`);
   currentAudio.onerror = () => console.error("音声ファイルが見つかりません:", note);
   if (callback) {
     currentAudio.onended = () => setTimeout(callback, 100);

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -7,6 +7,7 @@ import { resetResultFlag } from "./result.js";
 import { saveSessionToHistory } from "./summary.js";
 import { incrementSetCount, updateTrainingRecord } from "../utils/recordStore_supabase.js";
 import { autoUnlockNextChord } from "../utils/progressUtils.js";
+import { getAudio } from "../utils/audioCache.js";
 
 let questionCount = 0;
 let currentAnswer = null;
@@ -28,7 +29,7 @@ function playSoundThen(name, callback) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
   }
-  currentAudio = new Audio(`audio/${name}.mp3`);
+  currentAudio = getAudio(`audio/${name}.mp3`);
   currentAudio.onended = () => setTimeout(callback, 100);
   currentAudio.onerror = () => {
     console.error("⚠️ 音声ファイルが読み込めませんでした:", name);
@@ -303,7 +304,7 @@ function playChordFile(filename) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
   }
-  currentAudio = new Audio(`audio/${filename}`);
+  currentAudio = getAudio(`audio/${filename}`);
   currentAudio.onerror = () => console.error("音声ファイルが見つかりません:", filename);
   currentAudio.play();
 }

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -18,6 +18,7 @@ import {
 import { chords } from "../data/chords.js";
 import { renderHeader } from "../components/header.js";
 import { unlockChord, resetChordProgressToRed } from "../utils/progressUtils.js";
+import { getAudio } from "../utils/audioCache.js";
 import {
   updateGrowthStatusBar,
   getUnlockCriteriaStatus
@@ -194,7 +195,7 @@ export async function renderGrowthScreen(user) {
 
     circle.onclick = () => {
       if (chord.file) {
-        const audio = new Audio(`audio/${chord.file}`);
+        const audio = getAudio(`audio/${chord.file}`);
         audio.play();
       }
     };

--- a/utils/audioCache.js
+++ b/utils/audioCache.js
@@ -1,0 +1,17 @@
+const cache = new Map();
+
+/**
+ * Get an Audio instance for the given source path, reusing
+ * previously created objects for faster playback.
+ * @param {string} src - audio file path
+ * @returns {HTMLAudioElement} reusable audio element
+ */
+export function getAudio(src) {
+  let audio = cache.get(src);
+  if (!audio) {
+    audio = new Audio(src);
+    cache.set(src, audio);
+  }
+  audio.currentTime = 0;
+  return audio;
+}


### PR DESCRIPTION
## Summary
- create `utils/audioCache.js` for reusable audio objects
- use cached audio in training screens and sound player
- apply caching to growth screen audio previews

## Testing
- `node --version`
- `node -e "import('./utils/audioCache.js').then(m=>console.log('cache function',typeof m.getAudio))"`
