### PR TITLE
Fix mobile settings layout and show checkboxes

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -9,7 +9,7 @@
   gap: 24px;
 }
 
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 600px) {
   #chord-settings {
     grid-template-columns: 1fr 1fr;
   }
@@ -89,16 +89,6 @@
 }
 .chord-setting input[type='checkbox'] {
   margin: 0;
-  display: none;
-}
-
-.chord-setting.checked::after {
-  content: "✔";
-  position: absolute;
-  top: 2px;
-  right: 6px;
-  font-size: 1.1em;
-  color: green;
 }
 
 /* ヘッダー行 */


### PR DESCRIPTION
## Summary
- show checkboxes in the settings screen instead of hiding them
- change the mobile breakpoint for the chord settings grid to 600px so it uses two columns on phones

## Testing
- `git status --short`