### PR TITLE
Use number input spinner for chord settings

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -212,50 +212,18 @@ buttonGroup.appendChild(resetBtn);
     countInput.style.padding = "4px";
     countInput.style.fontSize = "1em";
 
-    const minusBtn = document.createElement("button");
-    minusBtn.textContent = "-";
-    minusBtn.className = "count-btn";
-    minusBtn.disabled = countInput.disabled;
-
-    const plusBtn = document.createElement("button");
-    plusBtn.textContent = "+";
-    plusBtn.className = "count-btn";
-    plusBtn.disabled = countInput.disabled;
-
     const countWrapper = document.createElement("div");
     countWrapper.className = "count-control";
-    countWrapper.appendChild(minusBtn);
     countWrapper.appendChild(countInput);
-    countWrapper.appendChild(plusBtn);
 
     checkbox.addEventListener("change", () => {
       const disabled = !checkbox.checked;
       countInput.disabled = disabled;
-      minusBtn.disabled = disabled;
-      plusBtn.disabled = disabled;
       if (checkbox.checked && countInput.value === "0") {
         countInput.value = "4";
       }
       div.classList.toggle("checked", checkbox.checked);
       updateSelection();
-    });
-
-    minusBtn.addEventListener("click", () => {
-      if (countInput.disabled) return;
-      let val = parseInt(countInput.value) || 0;
-      if (val > 0) {
-        countInput.value = val - 1;
-        updateSelection();
-      }
-    });
-
-    plusBtn.addEventListener("click", () => {
-      if (countInput.disabled) return;
-      let val = parseInt(countInput.value) || 0;
-      if (val < 20) {
-        countInput.value = val + 1;
-        updateSelection();
-      }
     });
 
     countInput.addEventListener("input", () => {

--- a/css/settings.css
+++ b/css/settings.css
@@ -58,13 +58,6 @@
   border-radius: 6px;
   box-sizing: border-box;    /* ← パディングとボーダーを含む */
   text-align: right;
-  appearance: none;          /* ← iOS や一部ブラウザでの独自スタイル無効化 */
-  -moz-appearance: textfield;        /* Firefox */
-}
-.chord-setting input[type='number']::-webkit-outer-spin-button,
-.chord-setting input[type='number']::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
 }
 
 .count-control {
@@ -73,20 +66,6 @@
   gap: 2px;
 }
 
-.count-control .count-btn {
-  width: 1.8em;
-  height: 1.8em;
-  font-size: 1em;
-  padding: 0;
-  border: 1px solid #ccc;
-  background-color: #fff;
-  border-radius: 4px;
-  cursor: pointer;
-}
-.count-control .count-btn:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
 .chord-setting input[type='checkbox'] {
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- swap plus/minus controls in settings screen for the browser's native number spinner
- stop hiding the spinner UI in settings.css

## Testing
- `npm test` *(fails: Could not find package.json)*