### PR TITLE
Add chord grid layout to settings screen

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -1,73 +1,60 @@
 /* ===== settings.css ===== */
 
-/* 全体のグリッドエリア */
+/* 出題数設定エリア */
 #chord-settings {
-  max-width: 960px;
+  max-width: 600px;
   margin: 1em auto;
+}
+
+.chord-group {
+  margin-bottom: 1.5em;
+}
+
+.chord-group h2 {
+  text-align: center;
+  font-size: 1.1em;
+  margin: 0.5em 0;
+}
+
+.chord-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 24px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
 }
 
-@media screen and (max-width: 600px) {
-  #chord-settings {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
-.chord-columns-row {
-  display: contents;
-}
-
-.chord-column-inv {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-/* 各列内のスタイル */
-.chord-column {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.chord-setting {
-  display: flex;
-  align-items: center;
-  gap: 0.5em;
-  padding: 6px 10px;
+.chord-block {
   border: 1px solid #ccc;
   border-radius: 6px;
   background: #fff;
-  box-sizing: border-box;
-  width: 100%;
-  color: black;
-  position: relative;
-}
-
-.chord-setting label {
-  flex: 1;
-}
-
-.chord-setting input[type='number'] {
-  width: 3.5em;              /* ← px より em 単位のほうが縮小時に強い */
-  font-size: 1em;
   padding: 4px;
-  border: 1px solid #ccc;    /* ← 明示的に border を再定義 */
-  border-radius: 6px;
-  box-sizing: border-box;    /* ← パディングとボーダーを含む */
-  text-align: right;
+  text-align: center;
+  font-size: 0.9em;
+}
+
+.chord-block.locked {
+  opacity: 0.5;
+}
+
+.chord-name {
+  font-weight: bold;
+  margin-bottom: 2px;
+  border-radius: 4px;
 }
 
 .count-control {
   display: flex;
+  justify-content: center;
   align-items: center;
-  gap: 2px;
+  gap: 4px;
 }
 
-.chord-setting input[type='checkbox'] {
-  margin: 0;
+.count-control button {
+  padding: 2px 6px;
+}
+
+.count-number {
+  min-width: 1.2em;
+  text-align: center;
 }
 
 /* ヘッダー行 */


### PR DESCRIPTION
## Summary
- simplify settings layout
- show 24 chords in a 3-column grid with +/- controls
- adjust bulk/debug buttons and selection logic

## Testing
- `git status --short`