### PR TITLE
Fix chord name wrapping

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -39,6 +39,7 @@
   font-weight: bold;
   margin-bottom: 2px;
   border-radius: 4px;
+  white-space: nowrap; /* Prevent chord names from wrapping */
 }
 
 .count-control {


### PR DESCRIPTION
## Summary
- prevent line wrapping for long chord names

## Testing
- `npm -v`