### PR TITLE
Integrate summary view into result screen

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -49,7 +49,7 @@ export function renderHeader(container) {
 
   // ▼ その他画面遷移
   header.querySelector("#settings-btn").onclick = () => switchScreen("settings");
-  header.querySelector("#summary-btn").onclick = () => switchScreen("summary");
+  header.querySelector("#summary-btn").onclick = () => switchScreen("result");
   header.querySelector("#growth-btn").onclick = () => switchScreen("growth");
 
   header.querySelector("#mypage-btn").onclick = () => switchScreen("mypage");

--- a/components/result.js
+++ b/components/result.js
@@ -1,8 +1,10 @@
 // components/result.js
 import { switchScreen } from "../main.js";
-import { lastResults, stats, correctCount } from "./training.js";
+import { lastResults } from "./training.js";
 import { chords } from "../data/chords.js";
 import { drawStaffFromNotes } from "./resultStaff.js";  // 楽譜描画（必要なら）
+import { renderHeader } from "./header.js";
+import { renderSummarySection } from "./summary.js";
 
 let resultShownInThisSession = false;
 
@@ -34,25 +36,17 @@ function labelNote(n) {
 
 // ✅ 本番用：こども向けごほうび画面
 export function renderResultScreen() {
-  if (resultShownInThisSession) {
-    switchScreen("home");
-    return;
-  }
-
-  resultShownInThisSession = true;
-
   const results = lastResults;
   const singleNoteMode = localStorage.getItem('singleNoteMode') === 'on';
 
-  const totalQuestions = Object.values(stats).reduce((sum, s) => sum + (s.total || 0), 0);
-  const rate = totalQuestions > 0 ? ((correctCount / totalQuestions) * 100).toFixed(1) : '0.0';
-
-  const summaryRows = Object.entries(stats).map(([name, st]) => {
-    return `<tr><td>${getLabelHiragana(name)}</td><td>${st.correct}</td><td>${st.wrong}</td><td>${st.unknown || 0}</td></tr>`;
-  }).join('');
 
   const app = document.getElementById("app");
-  app.innerHTML = `
+  app.innerHTML = "";
+  renderHeader(app);
+
+  const container = document.createElement("div");
+  container.className = "screen active";
+  container.innerHTML = `
     <div class="tab-menu">
       <button class="tab active" data-tab="result">👶 こたえ</button>
       <button class="tab" data-tab="summary">👨‍👩‍👧 くわしく</button>
@@ -105,23 +99,22 @@ export function renderResultScreen() {
             </tbody>
           </table>
 
-          <div class="result-footer">
-            <p>この画面は1回だけのごほうびだよ♪</p>
-          </div>
+          <div class="result-footer"></div>
         </div>
       </div>
       <div id="summary" class="tab-content">
-        <div class="summary-container">
-          <p class="summary-note">これはおうちのひと・せんせい向けです</p>
-          <p class="summary-total">正解数：${correctCount} / ${totalQuestions}（${rate}%）</p>
-          <table class="summary-table">
-            <thead><tr><th>わおん</th><th>◯</th><th>✕</th><th>？</th></tr></thead>
-            <tbody>${summaryRows}</tbody>
-          </table>
-        </div>
+        <div class="summary-container"></div>
       </div>
     </div>
   `;
+
+  app.appendChild(container);
+
+  const history = JSON.parse(localStorage.getItem("training-history") || "{}");
+  const dates = Object.keys(history).sort();
+  const latestDate = dates[dates.length - 1] || new Date().toISOString().slice(0,10);
+  const summaryContainer = container.querySelector("#summary .summary-container");
+  renderSummarySection(summaryContainer, latestDate);
 
   app.querySelectorAll('.tab').forEach(btn => {
     btn.addEventListener('click', () => {

--- a/components/summary.js
+++ b/components/summary.js
@@ -51,18 +51,11 @@ export function renderSummaryScreen() {
   renderSummaryScreenForDate(today);
 }
 
-window.saveSessionToHistory = saveSessionToHistory;
-window.renderSummaryScreen = renderSummaryScreen;
-
-export function renderSummaryScreenForDate(date) {
+export function renderSummarySection(container, date) {
   const history = JSON.parse(localStorage.getItem("training-history") || "{}");
   const sessions = history[date] || [];
 
-  const app = document.getElementById("app");
-  app.innerHTML = "";
-  renderHeader(app, renderSummaryScreen);
-
-  const container = document.createElement("div");
+  container.innerHTML = "";
   container.className = "screen active";
 
   const calendarInput = document.createElement("input");
@@ -77,8 +70,6 @@ export function renderSummaryScreenForDate(date) {
 
   if (window.flatpickrInstance) window.flatpickrInstance.destroy();
 
-  app.appendChild(container);
-
   const todayObj = new Date();
   const twoYearsAgo = new Date();
   twoYearsAgo.setFullYear(todayObj.getFullYear() - 2);
@@ -91,13 +82,11 @@ export function renderSummaryScreenForDate(date) {
     defaultDate: date,
     disableMobile: true,
     onChange: function (_, dateStr) {
-      renderSummaryScreenForDate(dateStr);
+      renderSummarySection(container, dateStr);
     }
   });
 
-  // 🎹 最新セッションの結果（←ここを最新のみに修正）
   const latestSession = sessions[sessions.length - 1] || {};
-  const latestStats = latestSession.stats || {};
   const latestCorrect = latestSession.correctCount || 0;
   const latestTotal = latestSession.totalQuestions || 0;
   const latestRate = latestTotal > 0 ? ((latestCorrect / latestTotal) * 100).toFixed(1) : "0.0";
@@ -114,7 +103,6 @@ export function renderSummaryScreenForDate(date) {
   dayTotal.style.fontWeight = "bold";
   container.appendChild(dayTotal);
 
-  // 各セッションの表示
   sessions.forEach((session, sessionIndex) => {
     const sessionCorrect = session.correctCount ?? Object.values(session.stats).reduce((sum, stat) => sum + stat.correct, 0);
     const sessionTotal = session.totalQuestions ?? Object.values(session.stats).reduce((sum, stat) => sum + stat.correct + stat.wrong + (stat.unknown || 0), 0);
@@ -146,7 +134,6 @@ export function renderSummaryScreenForDate(date) {
     container.appendChild(sessionSummary);
   });
 
-  // 🧮 今回のセッションの詳細（すでに正しく最新を参照）
   const summaryHeading = document.createElement("h3");
   summaryHeading.textContent = "今回のトレーニング結果";
   summaryHeading.style.textAlign = "center";
@@ -154,25 +141,22 @@ export function renderSummaryScreenForDate(date) {
   container.appendChild(summaryHeading);
 
   const summary = document.createElement("p");
-  summary.innerHTML = `
-    トレーニング回数：${sessions.length} 回<br>
-    正解数：${latestCorrect} / ${latestTotal}（${latestRate}%）
-  `;
+  summary.innerHTML = `\n    トレーニング回数：${sessions.length} 回<br>\n    正解数：${latestCorrect} / ${latestTotal}（${latestRate}%）\n  `;
   summary.style.textAlign = "center";
   summary.style.margin = "0.5em 0 1.5em";
   container.appendChild(summary);
+}
 
-  // 🐛 デバッグ：最新セッションの stats 表示
-  //const debug = document.createElement("pre");
-  //debug.style.fontSize = "0.8em";
-  //debug.style.background = "#f9f9f9";
-  //debug.style.border = "1px solid #ccc";
-  //debug.style.padding = "1em";
-  //debug.style.margin = "2em auto";
-  //debug.style.width = "90%";
-  //debug.style.whiteSpace = "pre-wrap";
-  //debug.textContent = `🛠 DEBUG: 最新セッションの stats\n` + JSON.stringify(latestStats, null, 2);
-  //container.appendChild(debug);
+window.saveSessionToHistory = saveSessionToHistory;
+window.renderSummaryScreen = renderSummaryScreen;
 
+export function renderSummaryScreenForDate(date) {
+  const app = document.getElementById("app");
+  app.innerHTML = "";
+  renderHeader(app, renderSummaryScreen);
+
+  const container = document.createElement("div");
   app.appendChild(container);
+
+  renderSummarySection(container, date);
 }


### PR DESCRIPTION
## Summary
- integrate summary data rendering into result page and add header
- provide reusable `renderSummarySection`
- remove one-time message and allow viewing latest results
- point "診断結果" menu to the new result view

## Testing
- `npm test` *(fails: could not find `package.json`)*