### PR TITLE
Fix past training results display

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -37,7 +37,21 @@ function labelNote(n) {
 
 export function createResultTable(results) {
   const singleNoteMode = localStorage.getItem('singleNoteMode') === 'on';
-  if (!results.length) {
+
+  // results may come as a JSON string or object. Normalize to an array.
+  if (typeof results === 'string') {
+    try {
+      const parsed = JSON.parse(results);
+      if (Array.isArray(parsed)) results = parsed;
+      else if (Array.isArray(parsed.results)) results = parsed.results;
+    } catch (_) {
+      results = [];
+    }
+  } else if (results && !Array.isArray(results) && Array.isArray(results.results)) {
+    results = results.results;
+  }
+
+  if (!Array.isArray(results) || results.length === 0) {
     return `<p class="no-training">きょうは まだ トレーニングしてないよ</p>`;
   }
 

--- a/components/summary.js
+++ b/components/summary.js
@@ -139,6 +139,9 @@ export async function renderSummarySection(container, date, user) {
     const toggleBtn = document.createElement('button');
     toggleBtn.textContent = '＋';
     toggleBtn.style.marginLeft = '1em';
+    toggleBtn.style.fontSize = '0.8em';
+    toggleBtn.style.lineHeight = '1';
+    toggleBtn.style.padding = '0.1em 0.4em';
 
     const toggleLabel = document.createElement('span');
     toggleLabel.textContent = '結果一覧';


### PR DESCRIPTION
## Summary
- handle string/object results data when rendering results table
- reduce toggle button size on summary screen

## Testing
- `npm test` *(fails: package.json missing)*