### PR TITLE
Add visible toggles for chord selection

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -242,6 +242,14 @@ buttonGroup.appendChild(resetBtn);
         updateSelection();
       });
 
+      // ブロック全体をクリックして ON/OFF できるようにする
+      block.addEventListener('click', (e) => {
+        if (e.target.tagName === 'INPUT' || e.target.tagName === 'BUTTON') return;
+        if (checkbox.disabled) return;
+        checkbox.checked = !checkbox.checked;
+        checkbox.dispatchEvent(new Event('change'));
+      });
+
       if (!isUnlocked) {
         setEnabled(false);
       }

--- a/css/settings.css
+++ b/css/settings.css
@@ -33,16 +33,15 @@
 }
 
 .chord-toggle {
-  display: none;
-}
-
-.chord-block.selected::after {
-  content: "✔";
   position: absolute;
   top: 2px;
-  right: 4px;
-  font-size: 1.1em;
-  color: green;
+  left: 2px;
+}
+
+/* 以前は選択中のブロックに擬似要素でチェックマークを表示していたが、
+   実際のチェックボックスを表示するため不要となった */
+.chord-block.selected::after {
+  display: none;
 }
 
 .chord-block.locked {


### PR DESCRIPTION
## Summary
- show the checkbox on each chord block and remove the overlay check mark
- allow clicking a chord block to toggle the checkbox

## Testing
- `npm test` *(fails: no package.json)*