### PR TITLE
Add mistake analysis and display

### DIFF
--- a/style.css
+++ b/style.css
@@ -101,3 +101,14 @@ body {
   z-index: 1000;
 }
 
+.mistake-details {
+  margin: 0.5em 0;
+  padding-left: 1.2em;
+  font-size: 0.85em;
+}
+
+.mistake-details li {
+  list-style-type: disc;
+  margin-left: 0.5em;
+}
+

--- a/utils/mistakeUtils.js
+++ b/utils/mistakeUtils.js
@@ -1,0 +1,48 @@
+export function convertMistakesJsonToStructuredForm(mistakesRaw = {}, answers = []) {
+  const structured = {
+    initial_mistake: false,
+    inversion_confusions: [],
+    top_bottom_confusions: [],
+    frequent_pairs: []
+  };
+
+  if (
+    Array.isArray(answers) &&
+    answers.length > 1 &&
+    !answers[0].correct &&
+    answers.slice(1).every(a => a.correct)
+  ) {
+    structured.initial_mistake = true;
+  }
+
+  const normalize = str => str.split("-").sort().join("-");
+  const getTop = chord => chord.split("-").slice(-1)[0];
+  const getBottom = chord => chord.split("-")[0];
+
+  const pairCounter = {};
+
+  Object.entries(mistakesRaw).forEach(([question, mistakes]) => {
+    Object.entries(mistakes).forEach(([answer, count]) => {
+      if (answer === "わからない") return;
+
+      if (normalize(question) === normalize(answer) && question !== answer) {
+        structured.inversion_confusions.push({ question, answer, count });
+      }
+
+      if (getTop(question) === getTop(answer) || getBottom(question) === getBottom(answer)) {
+        structured.top_bottom_confusions.push({ question, answer, count });
+      }
+
+      const key = [question, answer].sort().join(" ⇄ ");
+      pairCounter[key] = (pairCounter[key] || 0) + count;
+    });
+  });
+
+  Object.entries(pairCounter).forEach(([key, count]) => {
+    if (count >= 2) {
+      structured.frequent_pairs.push({ pair: key.split(" ⇄ "), count });
+    }
+  });
+
+  return structured;
+}

--- a/utils/trainingStore_supabase.js
+++ b/utils/trainingStore_supabase.js
@@ -2,6 +2,7 @@
 
 import { supabase } from "./supabaseClient.js";
 import { sessionMeetsStats, markQualifiedDayIfNeeded } from "./qualifiedStore_supabase.js";
+import { convertMistakesJsonToStructuredForm } from "./mistakeUtils.js";
 
 /**
  * トレーニングセッション結果をSupabaseに保存する関数
@@ -24,6 +25,7 @@ export async function saveTrainingSession({ userId, results, stats, mistakes, co
     totalCount,
     date
   });
+  const structuredMistakes = convertMistakesJsonToStructuredForm(mistakes, results);
   const isQualified = sessionMeetsStats(stats, totalCount);
   const { data, error } = await supabase.from("training_sessions").insert([
     {
@@ -33,7 +35,7 @@ export async function saveTrainingSession({ userId, results, stats, mistakes, co
       total_count: totalCount,
       results_json: results,
       stats_json: stats,
-      mistakes_json: mistakes,
+      mistakes_json: structuredMistakes,
       is_qualified: isQualified
     }
   ]);


### PR DESCRIPTION
## Summary
- analyze raw mistake pairs into categories
- save structured mistakes when creating training sessions
- show mistake details in the summary tab per session
- style mistake detail list

## Testing
- `node -e "const {convertMistakesJsonToStructuredForm}=require('./utils/mistakeUtils.js'); console.log(convertMistakesJsonToStructuredForm({'C-E-G':{'E-G-C':2}},[{chordName:'C-E-G',answerName:'E-G-C',correct:false},{chordName:'C-E-G',answerName:'C-E-G',correct:true}]));"`