### PR TITLE
Add first-time setup flow

### DIFF
--- a/components/initialSetup.js
+++ b/components/initialSetup.js
@@ -1,0 +1,63 @@
+import { chords } from "../data/chords.js";
+import { supabase } from "../utils/supabaseClient.js";
+import { applyStartChordIndex } from "../utils/progressUtils.js";
+
+export function renderInitialSetupScreen(user, onComplete) {
+  const app = document.getElementById("app");
+  app.innerHTML = "";
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "setup-wrapper";
+  app.appendChild(wrapper);
+
+  let nickname = "";
+
+  function step1() {
+    wrapper.innerHTML = `
+      <h2>おなまえをおしえてね</h2>
+      <input type="text" id="nickname" placeholder="にっくねーむ" />
+      <button id="next-btn">つぎへ</button>
+    `;
+    wrapper.querySelector("#next-btn").onclick = () => {
+      const value = wrapper.querySelector("#nickname").value.trim();
+      if (!value) {
+        alert("おなまえをいれてね");
+        return;
+      }
+      nickname = value;
+      step2();
+    };
+  }
+
+  function step2() {
+    wrapper.innerHTML = `
+      <h2>れんしゅう けいけんは ある？</h2>
+      <p class="setup-note">スタートしたい いろを えらんでね</p>
+      <select id="start-chord"></select>
+      <button id="start-btn">はじめる</button>
+    `;
+    const select = wrapper.querySelector("#start-chord");
+    chords.forEach((ch, idx) => {
+      const opt = document.createElement("option");
+      opt.value = idx;
+      opt.textContent = ch.label;
+      select.appendChild(opt);
+    });
+    wrapper.querySelector("#start-btn").onclick = async () => {
+      const idx = parseInt(select.value, 10);
+      await supabase
+        .from("users")
+        .update({ name: nickname })
+        .eq("id", user.id);
+      await applyStartChordIndex(user.id, idx);
+      const { data } = await supabase
+        .from("users")
+        .select("*")
+        .eq("id", user.id)
+        .maybeSingle();
+      onComplete(data || user);
+    };
+  }
+
+  step1();
+}

--- a/components/signup.js
+++ b/components/signup.js
@@ -47,7 +47,6 @@ export function renderSignUpScreen() {
     try {
       await createUserWithEmailAndPassword(firebaseAuth, email, password);
       alert("登録が完了しました！");
-      switchScreen("home");
     } catch (e) {
       alert("登録エラー：" + e.message);
     }
@@ -95,8 +94,6 @@ export function renderSignUpScreen() {
           await createInitialChordProgress(userId);
         }
       }
-
-      switchScreen("home");
     } catch (err) {
       alert("Google登録失敗：" + err.message);
     }

--- a/css/setup.css
+++ b/css/setup.css
@@ -1,0 +1,48 @@
+.setup-wrapper {
+  max-width: 400px;
+  margin: 100px auto;
+  padding: 2rem;
+  border: 1px solid #ccc;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.1);
+  font-family: sans-serif;
+  text-align: center;
+}
+
+.setup-wrapper h2 {
+  font-size: 1.6rem;
+  margin-bottom: 1rem;
+  color: #333;
+}
+
+.setup-wrapper input,
+.setup-wrapper select {
+  width: 100%;
+  padding: 0.7rem;
+  font-size: 1rem;
+  border: 1px solid #bbb;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+}
+
+.setup-wrapper button {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  background: #ffa500;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.setup-wrapper button:hover {
+  background: #e38c00;
+}
+
+.setup-note {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+  color: #555;
+}

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   <link rel="stylesheet" href="css/summary.css" />
   <link rel="stylesheet" href="css/growth.css" />
   <link rel="stylesheet" href="css/mypage.css" />
+  <link rel="stylesheet" href="css/setup.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
 </head>
 

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ import { renderGrowthScreen } from "./logic/growth.js";
 import { renderLoginScreen } from "./components/login.js";
 import { renderIntroScreen } from "./components/intro.js";
 import { renderSignUpScreen } from "./components/signup.js";
+import { renderInitialSetupScreen } from "./components/initialSetup.js";
 import { supabase } from "./utils/supabaseClient.js";
 import { createInitialChordProgress } from "./utils/progressUtils.js";
 import { renderMyPageScreen } from "./components/mypage.js";
@@ -66,7 +67,7 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   }
 
   if (screen === "intro") renderIntroScreen();
-  else if (screen === "login") renderLoginScreen(app, () => switchScreen("home", user));
+  else if (screen === "login") renderLoginScreen(app, () => {});
   else if (screen === "home") renderHomeScreen(user);
   else if (screen === "training") renderTrainingScreen(user);
   else if (screen === "training_easy") renderTrainingEasy(user);
@@ -75,6 +76,7 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   else if (screen === "summary") renderSummaryScreen(user);
   else if (screen === "growth") renderGrowthScreen(user);
   else if (screen === "signup") renderSignUpScreen(user);
+  else if (screen === "setup") renderInitialSetupScreen(user, (u) => switchScreen("home", u));
   else if (screen === "mypage") renderMyPageScreen(user);
   else if (screen === "result") renderResultScreen(user);
   else if (screen === "result_easy") renderTrainingEasyResultScreen(user);
@@ -131,7 +133,11 @@ onAuthStateChanged(auth, async (firebaseUser) => {
   }
 
   currentUser = user;
-  switchScreen("home", user);
+  if (!user.name || user.name === "名前未設定") {
+    switchScreen("setup", user);
+  } else {
+    switchScreen("home", user);
+  }
 });
 
 window.addEventListener("DOMContentLoaded", () => {

--- a/utils/progressUtils.js
+++ b/utils/progressUtils.js
@@ -25,6 +25,39 @@ export async function createInitialChordProgress(userId) {
   }
 }
 
+// ✅ 経験者向け：任意の和音からスタートできるよう進捗を設定
+export async function applyStartChordIndex(userId, startIndex) {
+  const chordKeys = chords.map((c) => c.key);
+  const completed = chordKeys.slice(0, startIndex);
+  const current = chordKeys[startIndex];
+  const locked = chordKeys.slice(startIndex + 1);
+  const today = new Date().toISOString().split("T")[0];
+
+  if (completed.length > 0) {
+    await supabase
+      .from("user_chord_progress")
+      .update({ status: "completed", unlocked_date: null })
+      .eq("user_id", userId)
+      .in("chord_key", completed);
+  }
+
+  if (current) {
+    await supabase
+      .from("user_chord_progress")
+      .update({ status: "in_progress", unlocked_date: today })
+      .eq("user_id", userId)
+      .eq("chord_key", current);
+  }
+
+  if (locked.length > 0) {
+    await supabase
+      .from("user_chord_progress")
+      .update({ status: "locked", unlocked_date: null })
+      .eq("user_id", userId)
+      .in("chord_key", locked);
+  }
+}
+
 // ✅ 連続合格日数が7日に達したら、次の和音に進める
 export async function autoUnlockNextChord(user) {
   const passed = await getPassedDays(user.id);


### PR DESCRIPTION
## Summary
- ask user for nickname and starting chord on first login
- update chord progress according to selected start
- add setup screen and styling
- load setup screen from main logic when user has no nickname

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683a41fa4a008323bb6a3523728b4f26