### PR TITLE
Play applause sound on chord unlock

### DIFF
--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -88,7 +88,9 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
         const success = await unlockChord(user.id, target.key);
         if (success) {
           const audio = getAudio("audio/unlock_chord.mp3");
+          const applause = getAudio("audio/applause.mp3");
           audio.play();
+          applause.play();
           await applyRecommendedSelection(user.id);
           forceUnlock();
           btn.style.display = "none";


### PR DESCRIPTION
## Summary
- play an additional applause audio clip when a chord is successfully unlocked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683a536f9ae0832380da9369a2290194