### PR TITLE
Update growth mock data and menu label

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -18,7 +18,7 @@ export function renderHeader(container) {
       <button id="parent-menu-btn" aria-label="設定">⚙️</button>
       <div id="parent-dropdown" class="parent-dropdown">
         <button id="settings-btn">⚙️ 設定</button>
-        <button id="summary-btn">📊 診断結果</button>
+        <button id="summary-btn">📊 分析画面</button>
         <button id="mypage-btn">👤 マイページ</button>
         <button id="growth-btn">🌱 育成モード</button>
         <button id="logout-btn">🚪 ログアウト</button>


### PR DESCRIPTION
## Summary
- rename 診断結果 to 分析画面 in header menu
- generate realistic recommended-mode mock data for growth mode

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_683a779eb8848323974233b44fddc7ba