### PR TITLE
Enable weekly report text output

### DIFF
--- a/components/summary.js
+++ b/components/summary.js
@@ -4,7 +4,7 @@ import { chords } from "../data/chords.js";
 import { renderHeader } from "./header.js";
 import { loadTrainingRecords } from "../utils/recordStore_supabase.js";
 import { loadTrainingSessionsForDate } from "../utils/trainingStore_supabase.js";
-import { generateWeeklyReport } from "../utils/weeklyReport.js";
+import { generateWeeklyReport, shareReport } from "../utils/weeklyReport.js";
 import { createResultTable } from "./result.js";
 
 function createMistakeDetailHtml(mistakes) {
@@ -113,12 +113,44 @@ export async function renderSummarySection(container, date, user) {
   weeklyBtn.style.margin = '0 auto 1em';
   container.appendChild(weeklyBtn);
 
-  weeklyBtn.onclick = () => {
+  const reportWrap = document.createElement('div');
+  reportWrap.style.display = 'none';
+  reportWrap.style.margin = '1em 0';
+  reportWrap.style.maxWidth = '600px';
+  reportWrap.style.marginLeft = 'auto';
+  reportWrap.style.marginRight = 'auto';
+
+  const reportArea = document.createElement('textarea');
+  reportArea.id = 'weekly-report-text';
+  reportArea.readOnly = true;
+  reportArea.rows = 10;
+  reportArea.style.width = '100%';
+  reportArea.style.boxSizing = 'border-box';
+  reportWrap.appendChild(reportArea);
+
+  const shareBtn = document.createElement('button');
+  shareBtn.textContent = '共有';
+  shareBtn.style.display = 'block';
+  shareBtn.style.margin = '1em auto 0';
+  reportWrap.appendChild(shareBtn);
+  container.appendChild(reportWrap);
+
+  weeklyBtn.onclick = async () => {
     const end = date;
     const startDateObj = new Date(date);
     startDateObj.setDate(startDateObj.getDate() - 6);
     const startStr = startDateObj.toISOString().split('T')[0];
-    generateWeeklyReport(user.id, startStr, end);
+    const text = await generateWeeklyReport(user.id, startStr, end);
+    if (text) {
+      reportArea.value = text;
+      reportWrap.style.display = 'block';
+    }
+  };
+
+  shareBtn.onclick = () => {
+    if (reportArea.value) {
+      shareReport(reportArea.value);
+    }
   };
 
   const allDates = Object.keys(records).sort();

--- a/utils/weeklyReport.js
+++ b/utils/weeklyReport.js
@@ -49,16 +49,20 @@ export async function generateWeeklyReport(userId, startDate, endDate) {
 
   const reportText = `\n【🎼 絶対音感トレーニング週次レポート】\n${userId}（${startDate}〜${endDate}）\n\n🗓 トレーニング実施日数：${totalSessions}日間\n✅ 合格日数：${passedSessions}日間（1日あたり40問以上・98%以上）\n📊 合計出題数：${totalQuestions}問\n🎯 正答率：${accuracy}%\n\n🔓 解放済み和音（色）：\n${chordNames}\n\n🔍 ミス傾向：\n${inversionMistakes.concat(topBottomMistakes).join('\n')}\n${initialMistakeCount > 0 ? `・初回だけミス：${initialMistakeCount}回あり` : ''}\n\n📣 コメント：\n今週もよくがんばりました。来週はさらに安定した結果を目指しましょう！`.trim();
 
+  return reportText;
+}
+
+export async function shareReport(text) {
   if (navigator.share) {
     try {
       await navigator.share({
         title: '絶対音感レポート',
-        text: reportText
+        text
       });
     } catch (err) {
       console.error('❌ 共有に失敗:', err);
     }
   } else {
-    alert('このブラウザは共有機能に対応していません。\n\n' + reportText);
+    alert('このブラウザは共有機能に対応していません。\n\n' + text);
   }
 }


### PR DESCRIPTION
## Summary
- show weekly report text on the summary screen
- provide a `共有` button to share the text
- refactor weekly report generation to return the report and add share helper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683a78f380948323a497fda2af72244c