### PR TITLE
Fix weekly report output

### DIFF
--- a/components/summary.js
+++ b/components/summary.js
@@ -140,7 +140,7 @@ export async function renderSummarySection(container, date, user) {
     const startDateObj = new Date(date);
     startDateObj.setDate(startDateObj.getDate() - 6);
     const startStr = startDateObj.toISOString().split('T')[0];
-    const text = await generateWeeklyReport(user.id, startStr, end);
+    const text = await generateWeeklyReport(user, startStr, end);
     if (text) {
       reportArea.value = text;
       reportWrap.style.display = 'block';

--- a/utils/weeklyReport.js
+++ b/utils/weeklyReport.js
@@ -1,6 +1,10 @@
 import { supabase } from './supabaseClient.js';
+import { chords } from '../data/chords.js';
 
-export async function generateWeeklyReport(userId, startDate, endDate) {
+export async function generateWeeklyReport(user, startDate, endDate) {
+  const userId = typeof user === 'string' ? user : user?.id;
+  const userName = typeof user === 'object' ? user?.name : null;
+
   const { data: trainingSessions, error: sesErr } = await supabase
     .from('training_sessions')
     .select('*')
@@ -15,9 +19,9 @@ export async function generateWeeklyReport(userId, startDate, endDate) {
 
   const { data: progress, error: progErr } = await supabase
     .from('user_chord_progress')
-    .select('chord_key')
+    .select('chord_key, status')
     .eq('user_id', userId)
-    .eq('status', 'unlocked');
+    .not('status', 'eq', 'locked');
 
   if (progErr) {
     console.error('❌ 進捗取得失敗:', progErr);
@@ -30,24 +34,37 @@ export async function generateWeeklyReport(userId, startDate, endDate) {
   const totalCorrect = trainingSessions.reduce((sum, s) => sum + (s.correct_count || 0), 0);
   const accuracy = totalQuestions > 0 ? ((totalCorrect / totalQuestions) * 100).toFixed(1) : '0.0';
 
-  const chordNames = progress.map(p => p.chord_key).join('、');
+  const chordLabelMap = Object.fromEntries(chords.map(c => [c.key, c.label]));
+  const chordNames = progress.map(p => chordLabelMap[p.chord_key] || p.chord_key).join('、');
 
-  const inversionMistakes = [];
-  const topBottomMistakes = [];
+  const inversionMap = new Map();
+  const topBottomMap = new Map();
   let initialMistakeCount = 0;
 
   trainingSessions.forEach(session => {
     const m = session.mistakes_json;
     if (m?.initial_mistake) initialMistakeCount++;
     m?.inversion_confusions?.forEach(i => {
-      inversionMistakes.push(`・「${i.question}」→「${i.answer}」（転回形ミス）×${i.count}`);
+      const key = `${i.question}|${i.answer}`;
+      inversionMap.set(key, (inversionMap.get(key) || 0) + (i.count || 1));
     });
     m?.top_bottom_confusions?.forEach(i => {
-      topBottomMistakes.push(`・「${i.question}」→「${i.answer}」（上下音一致）×${i.count}`);
+      const key = `${i.question}|${i.answer}`;
+      topBottomMap.set(key, (topBottomMap.get(key) || 0) + (i.count || 1));
     });
   });
 
-  const reportText = `\n【🎼 絶対音感トレーニング週次レポート】\n${userId}（${startDate}〜${endDate}）\n\n🗓 トレーニング実施日数：${totalSessions}日間\n✅ 合格日数：${passedSessions}日間（1日あたり40問以上・98%以上）\n📊 合計出題数：${totalQuestions}問\n🎯 正答率：${accuracy}%\n\n🔓 解放済み和音（色）：\n${chordNames}\n\n🔍 ミス傾向：\n${inversionMistakes.concat(topBottomMistakes).join('\n')}\n${initialMistakeCount > 0 ? `・初回だけミス：${initialMistakeCount}回あり` : ''}\n\n📣 コメント：\n今週もよくがんばりました。来週はさらに安定した結果を目指しましょう！`.trim();
+  const inversionMistakes = Array.from(inversionMap.entries()).map(([key, count]) => {
+    const [q, a] = key.split('|');
+    return `・「${q}」→「${a}」（転回形ミス）×${count}`;
+  });
+  const topBottomMistakes = Array.from(topBottomMap.entries()).map(([key, count]) => {
+    const [q, a] = key.split('|');
+    return `・「${q}」→「${a}」（上下音一致）×${count}`;
+  });
+
+  const userLabel = userName ? `${userName}ちゃん` : userId;
+  const reportText = `\n【🎼 絶対音感トレーニング週次レポート】\n${userLabel}（${startDate}〜${endDate}）\n\n🗓 トレーニング実施日数：${totalSessions}日間\n✅ 合格日数：${passedSessions}日間（1日あたり40問以上・98%以上）\n📊 合計出題数：${totalQuestions}問\n🎯 正答率：${accuracy}%\n\n🔓 解放済み和音（色）：\n${chordNames}\n\n🔍 ミス傾向：\n${inversionMistakes.concat(topBottomMistakes).join('\n')}\n${initialMistakeCount > 0 ? `・初回だけミス：${initialMistakeCount}回あり` : ''}\n\n📣 コメント：\n今週もよくがんばりました。来週はさらに安定した結果を目指しましょう！`.trim();
 
   return reportText;
 }


### PR DESCRIPTION
## Summary
- display user name in weekly report header
- fetch unlocked chord progress correctly
- aggregate weekly mistake counts
- map chord keys to color labels
- update summary screen to use new weekly report function

## Testing
- `node -e "import('./utils/weeklyReport.js').then(()=>console.log('ok')).catch(e=>console.error(e))"` *(fails: Only URLs with a scheme in: file and data are supported)*

------
https://chatgpt.com/codex/tasks/task_b_683a7c0dfa1c83238e183bcc13e8699d