### PR TITLE
Display debug note and fix replay bug

### DIFF
--- a/components/training_easy_note.js
+++ b/components/training_easy_note.js
@@ -57,6 +57,14 @@ export function renderTrainingScreen(user) {
     <button id="finish-btn">やめる</button>
   `;
 
+  const debugAnswer = document.createElement("div");
+  debugAnswer.style.position = "absolute";
+  debugAnswer.style.top = "10px";
+  debugAnswer.style.right = "10px";
+  debugAnswer.style.fontSize = "0.9em";
+  debugAnswer.style.color = "gray";
+  app.appendChild(debugAnswer);
+
   const whiteOrder = ["C", "D", "E", "F", "G", "A", "B"];
   const blackOrder = [
     { note: "C#", pos: "pos1" },
@@ -125,15 +133,7 @@ export function renderTrainingScreen(user) {
       }, FEEDBACK_DELAY);
     };
 
-    if (correct) {
-      isSoundPlaying = true;
-      playNote(currentNote).then(() => {
-        isSoundPlaying = false;
-        proceed();
-      });
-    } else {
-      proceed();
-    }
+    proceed();
   });
 
   finishBtn.onclick = () => {
@@ -145,6 +145,7 @@ export function renderTrainingScreen(user) {
       noteSequence = getRandomNoteSequence(maxQuestions);
     }
     currentNote = noteSequence.pop();
+    debugAnswer.textContent = `【デバッグ】正解: ${kanaToHiragana(noteLabels[currentNote.replace(/[0-9]/g, "")])}（${currentNote}）`;
     isSoundPlaying = true;
     setInteraction(false);
     playNote(currentNote).then(() => {

--- a/components/training_full.js
+++ b/components/training_full.js
@@ -55,6 +55,14 @@ export function renderTrainingScreen(user) {
     <button id="finish-btn">やめる</button>
   `;
 
+  const debugAnswer = document.createElement("div");
+  debugAnswer.style.position = "absolute";
+  debugAnswer.style.top = "10px";
+  debugAnswer.style.right = "10px";
+  debugAnswer.style.fontSize = "0.9em";
+  debugAnswer.style.color = "gray";
+  app.appendChild(debugAnswer);
+
   const whiteOrder = ["C", "D", "E", "F", "G", "A", "B"];
   const blackOrder = [
     { note: "C#", pos: "pos1" },
@@ -123,15 +131,7 @@ export function renderTrainingScreen(user) {
       }, FEEDBACK_DELAY);
     };
 
-    if (correct) {
-      isSoundPlaying = true;
-      playNote(currentNote).then(() => {
-        isSoundPlaying = false;
-        proceed();
-      });
-    } else {
-      proceed();
-    }
+    proceed();
   });
 
   finishBtn.onclick = () => {
@@ -140,6 +140,7 @@ export function renderTrainingScreen(user) {
 
   function nextQuestion() {
     currentNote = getRandomNote();
+    debugAnswer.textContent = `【デバッグ】正解: ${kanaToHiragana(noteLabels[currentNote.replace(/[0-9-]/g, "")])}（${currentNote}）`;
     isSoundPlaying = true;
     setInteraction(false);
     playNote(currentNote).then(() => {


### PR DESCRIPTION
## Summary
- show the current correct note in easy and full single-note training screens for debugging
- remove extra playback when selecting the correct note

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683a87b93ff48323b622a3267f5ffee0