### PR TITLE
Update settings UI/UX

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -89,19 +89,6 @@ buttonGroup.appendChild(resetBtn);
 
   buttonGroup.className = "header-button-group";
 
-  const debugBtn = document.createElement("button");
-  debugBtn.textContent = "🛠 全部選択 (4回)";
-  debugBtn.onclick = () => {
-    document.querySelectorAll('.chord-block').forEach(block => {
-      if (block.classList.contains('locked')) return;
-      block.querySelector('.count-number').textContent = '4';
-      const cb = block.querySelector('.chord-toggle');
-      if (cb) cb.checked = true;
-      block.classList.add('selected');
-      block.querySelectorAll('button').forEach(b => b.disabled = false);
-    });
-    updateSelection();
-  };
 
   const bulkDropdown = document.createElement("select");
   bulkDropdown.innerHTML = `
@@ -126,28 +113,35 @@ buttonGroup.appendChild(resetBtn);
     updateSelection();
   };
 
-  buttonGroup.appendChild(debugBtn);
   buttonGroup.appendChild(bulkDropdown);
   headerBar.appendChild(titleLine);
   headerBar.appendChild(buttonGroup);
   container.appendChild(headerBar);
 
   const singleWrap = document.createElement('label');
-  singleWrap.style.display = 'flex';
-  singleWrap.style.alignItems = 'center';
-  singleWrap.style.gap = '4px';
-  singleWrap.style.margin = '0.5em 1em';
+  singleWrap.className = 'toggle-wrap';
+
   const singleToggle = document.createElement('input');
   singleToggle.type = 'checkbox';
+  singleToggle.className = 'toggle-input';
   singleToggle.checked = localStorage.getItem('singleNoteMode') === 'on';
   singleToggle.onchange = () => {
     if (singleToggle.checked) {
-      localStorage.setItem('singleNoteMode', 'on');
+      if (confirm('白鍵全ての絶対音感が身に着いたあとで使ってください')) {
+        localStorage.setItem('singleNoteMode', 'on');
+      } else {
+        singleToggle.checked = false;
+      }
     } else {
       localStorage.removeItem('singleNoteMode');
     }
   };
+
+  const slider = document.createElement('span');
+  slider.className = 'toggle-slider';
+
   singleWrap.appendChild(singleToggle);
+  singleWrap.appendChild(slider);
   singleWrap.appendChild(document.createTextNode('単音分化モード'));
   container.appendChild(singleWrap);
 
@@ -273,6 +267,7 @@ buttonGroup.appendChild(resetBtn);
 
   // ✅ その他のトレーニングセクション
   const section = document.createElement("div");
+  section.className = "other-training-section";
   section.innerHTML = `
     <h3>その他のトレーニング</h3>
     <ul>

--- a/css/settings.css
+++ b/css/settings.css
@@ -124,3 +124,54 @@
 .center-button-box select:hover {
   background-color: #f8f8f8;
 }
+
+/* 単音分化モードトグル */
+.toggle-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0.5em 1em;
+  position: relative;
+}
+
+.toggle-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 40px;
+  height: 20px;
+  background-color: #ccc;
+  border-radius: 20px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  left: 2px;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+  background-color: #fff;
+  border-radius: 50%;
+  transition: transform 0.3s;
+}
+
+.toggle-input:checked + .toggle-slider {
+  background-color: #4caf50;
+}
+
+.toggle-input:checked + .toggle-slider::before {
+  transform: translateX(20px);
+}
+
+/* その他のトレーニングの見出し */
+.other-training-section h3 {
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- remove bulk "select all" debug button
- convert single note mode to a toggle switch with confirmation
- add class for other training section
- center align "その他のトレーニング" heading
- style toggle switch in CSS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683ab991c304832398be7b522e9f0daf