### PR TITLE
Fix screen padding

### DIFF
--- a/components/summary.js
+++ b/components/summary.js
@@ -92,7 +92,8 @@ export async function renderSummarySection(container, date, user) {
   const sessions = await loadTrainingSessionsForDate(user.id, date);
 
   container.innerHTML = "";
-  container.className = "screen active";
+  // Add a specific class so CSS rules don't affect other screens
+  container.className = "screen active summary-screen";
 
   const calendarLabel = document.createElement("div");
   calendarLabel.textContent = "日付を絞って選択";

--- a/css/summary.css
+++ b/css/summary.css
@@ -1,7 +1,7 @@
 /* summary.css */
 
-.screen.active {
-  padding: 2em;
+.summary-screen {
+  padding: 1em;
   max-width: 960px;
   margin: 0 auto;
   font-family: inherit;


### PR DESCRIPTION
## Summary
- add `summary-screen` class to summary container
- scope padding rule to `.summary-screen` and reduce to 1em

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_683ac33700848323985fb59d719cfb3c