### PR TITLE
Fix screen margins and show custom confirm

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -105,11 +105,14 @@ export function renderHomeScreen(user) {
 }
 
 // ✅ 他の画面から再利用できるカスタム confirm 関数
-export function showCustomConfirm(message, onConfirm) {
+export function showCustomConfirm(message, onConfirm, options = {}) {
   if (typeof message === "function") {
     onConfirm = message;
     message = "本当に和音を解放しますか？";
+    options = {};
   }
+  const { okText = "OK", cancelText = "キャンセル", showCancel = true } =
+    options;
   let modal = document.getElementById("custom-confirm");
   if (!modal) {
     modal = document.createElement("div");
@@ -141,7 +144,7 @@ export function showCustomConfirm(message, onConfirm) {
     buttons.style.marginTop = "1em";
 
     const okBtn = document.createElement("button");
-    okBtn.textContent = "OK";
+    okBtn.className = "ok-btn";
     okBtn.style.margin = "0 0.5em";
     okBtn.onclick = () => {
       modal.style.display = "none";
@@ -151,7 +154,7 @@ export function showCustomConfirm(message, onConfirm) {
     };
 
     const cancelBtn = document.createElement("button");
-    cancelBtn.textContent = "キャンセル";
+    cancelBtn.className = "cancel-btn";
     cancelBtn.style.margin = "0 0.5em";
     cancelBtn.onclick = () => {
       modal.style.display = "none";
@@ -167,6 +170,16 @@ export function showCustomConfirm(message, onConfirm) {
   const msgEl = modal.querySelector("#custom-confirm-message");
   if (msgEl) {
     msgEl.textContent = message;
+  }
+
+  const okBtnEl = modal.querySelector(".ok-btn");
+  if (okBtnEl) {
+    okBtnEl.textContent = okText;
+  }
+  const cancelBtnEl = modal.querySelector(".cancel-btn");
+  if (cancelBtnEl) {
+    cancelBtnEl.textContent = cancelText;
+    cancelBtnEl.style.display = showCancel ? "inline-block" : "none";
   }
 
   modal.callback = onConfirm;

--- a/components/settings.js
+++ b/components/settings.js
@@ -5,6 +5,7 @@ import { switchScreen } from "../main.js";
 import { supabase } from "../utils/supabaseClient.js";
 import { chords, chordOrder } from "../data/chords.js";
 import { generateRecommendedQueue } from "../utils/growthUtils.js"; // use queue util
+import { showCustomConfirm } from "./home.js";
 
 export let selectedChords = [];
 
@@ -127,11 +128,13 @@ buttonGroup.appendChild(resetBtn);
   singleToggle.checked = localStorage.getItem('singleNoteMode') === 'on';
   singleToggle.onchange = () => {
     if (singleToggle.checked) {
-      if (confirm('白鍵全ての絶対音感が身に着いたあとで使ってください')) {
-        localStorage.setItem('singleNoteMode', 'on');
-      } else {
-        singleToggle.checked = false;
-      }
+      showCustomConfirm(
+        '白鍵全ての絶対音感が身に着いたあとで使ってください',
+        () => {
+          localStorage.setItem('singleNoteMode', 'on');
+        },
+        { okText: 'はい', showCancel: false }
+      );
     } else {
       localStorage.removeItem('singleNoteMode');
     }

--- a/css/common.css
+++ b/css/common.css
@@ -42,7 +42,7 @@
 /* .screen の基本レイアウト */
 .screen {
   max-width: 900px;
-  margin: 0 auto 2em; /* 上部余白は #app.with-header に委任 */
+  margin: 0 auto; /* 上部余白は #app.with-header に委任 */
   padding: 1em;
   box-sizing: border-box;
 }

--- a/css/mypage.css
+++ b/css/mypage.css
@@ -1,6 +1,6 @@
 .mypage-screen {
   max-width: 480px;
-  margin: 0 auto 2em; /* 上部余白は #app.with-header に委任 */
+  margin: 0 auto; /* 上部余白は #app.with-header に委任 */
 }
 
 .mypage-tabs {


### PR DESCRIPTION
## Summary
- remove bottom margin for all `.screen` elements and update mypage screen
- extend `showCustomConfirm` with customizable buttons
- use the new confirm UI for the single-note mode toggle

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683ac51ee1288323bb6f8c2069116e4a