### PR TITLE
Adjust settings layout and add collapsible groups

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -160,17 +160,30 @@ buttonGroup.appendChild(resetBtn);
 
   selectedChords = [];
 
+  const hasBlack = unlockedKeys.some(k => chords.find(c => c.key === k && c.type === "black-root"));
+  const hasInv = unlockedKeys.some(k => chords.find(c => c.key === k && c.type === "black-inv"));
+
   const groups = [
-    { title: "白鍵", type: "white" },
-    { title: "黒鍵", type: "black-root" },
-    { title: "転回形", type: "black-inv" }
+    { title: "白鍵", type: "white", open: true },
+    { title: "黒鍵", type: "black-root", open: hasBlack },
+    { title: "転回形", type: "black-inv", open: hasInv }
   ];
 
   groups.forEach(g => {
     const sec = document.createElement("section");
     sec.className = "chord-group";
+    if (!g.open) sec.classList.add("collapsed");
     const h2 = document.createElement("h2");
-    h2.textContent = g.title;
+    const toggleBtn = document.createElement("button");
+    toggleBtn.className = "group-toggle-btn";
+    toggleBtn.textContent = g.open ? "－" : "＋";
+    toggleBtn.onclick = () => {
+      const willOpen = sec.classList.contains("collapsed");
+      sec.classList.toggle("collapsed");
+      toggleBtn.textContent = willOpen ? "－" : "＋";
+    };
+    h2.appendChild(toggleBtn);
+    h2.appendChild(document.createTextNode(g.title));
     sec.appendChild(h2);
 
     const grid = document.createElement("div");
@@ -255,7 +268,11 @@ buttonGroup.appendChild(resetBtn);
       ctrl.appendChild(numSpan);
       ctrl.appendChild(plusBtn);
 
-      block.appendChild(checkbox);
+      const checkboxRow = document.createElement('div');
+      checkboxRow.className = 'checkbox-row';
+      checkboxRow.appendChild(checkbox);
+
+      block.appendChild(checkboxRow);
       block.appendChild(nameDiv);
       block.appendChild(ctrl);
       grid.appendChild(block);

--- a/css/settings.css
+++ b/css/settings.css
@@ -11,9 +11,19 @@
 }
 
 .chord-group h2 {
-  text-align: center;
+  display: flex;
+  align-items: center;
   font-size: 1.1em;
   margin: 0.5em 0;
+  justify-content: center;
+}
+
+.group-toggle-btn {
+  margin-right: 0.5em;
+}
+
+.chord-group.collapsed .chord-grid {
+  display: none;
 }
 
 .chord-grid {
@@ -33,9 +43,13 @@
 }
 
 .chord-toggle {
-  position: absolute;
-  top: 2px;
-  left: 2px;
+  position: relative;
+  margin: 0 auto;
+}
+
+.checkbox-row {
+  text-align: center;
+  margin-bottom: 2px;
 }
 
 /* 以前は選択中のブロックに擬似要素でチェックマークを表示していたが、
@@ -91,6 +105,12 @@
   font-size: 1.2em;
   font-weight: bold;
   white-space: nowrap;
+}
+
+.header-button-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
 }
 
 .header-title-line #total-count {


### PR DESCRIPTION
## Summary
- style header buttons side by side
- support collapsible chord groups with `+` buttons
- default open state reflects unlocked progress
- improve mobile layout for checkboxes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_683acdf8dab483238e8f1dd8e167c52e