### PR TITLE
Add password management UI

### DIFF
--- a/css/mypage.css
+++ b/css/mypage.css
@@ -87,3 +87,16 @@
   border-radius: 6px;
   font-size: 1rem;
 }
+
+.password-guide {
+  padding: 1em;
+  margin: 1em;
+  background: #fff4e0;
+  border: 1px solid #ffd599;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+.password-guide button {
+  margin-left: 0.5em;
+  padding: 0.4em 0.8em;
+}


### PR DESCRIPTION
## Summary
- show password change tab only for email/password users
- add link option when password isn't set
- implement password update logic with reauthentication
- style password guide

## Testing
- `No tests`

------
https://chatgpt.com/codex/tasks/task_b_683ada93e0648323b703d314abbac15e