### PR TITLE
Add admin panel for Stripe management

### DIFF
--- a/api/cancel-subscription.js
+++ b/api/cancel-subscription.js
@@ -1,0 +1,48 @@
+import Stripe from 'stripe';
+import { createClient } from '@supabase/supabase-js';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end('Method Not Allowed');
+
+  const { email } = req.body;
+
+  // Supabaseからcustomer_idを取得
+  const { data: user, error } = await supabase
+    .from('users')
+    .select('stripe_customer_id')
+    .eq('email', email)
+    .single();
+
+  if (error || !user?.stripe_customer_id) {
+    return res.status(400).json({ error: 'User or customer ID not found' });
+  }
+
+  // Stripeからサブスクリプション取得 → キャンセル
+  const subscriptions = await stripe.subscriptions.list({
+    customer: user.stripe_customer_id,
+    status: 'active',
+    limit: 1,
+  });
+
+  if (subscriptions.data.length === 0) {
+    return res.status(400).json({ error: 'No active subscription found' });
+  }
+
+  const subscription = subscriptions.data[0];
+
+  await stripe.subscriptions.del(subscription.id);
+
+  // Supabase更新：is_premiumをfalseに
+  await supabase
+    .from('users')
+    .update({ is_premium: false })
+    .eq('email', email);
+
+  return res.status(200).json({ message: 'Subscription canceled' });
+}

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -35,10 +35,15 @@ export default async function handler(req, res) {
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object;
     const email = session.customer_email;
+    const customerId = session.customer;
 
+    // is_premium と stripe_customer_id を同時に更新
     const { error } = await supabase
       .from('users')
-      .update({ is_premium: true })
+      .update({
+        is_premium: true,
+        stripe_customer_id: customerId,
+      })
       .eq('email', email);
 
     if (error) {
@@ -46,7 +51,9 @@ export default async function handler(req, res) {
       return res.status(500).send('Supabase update failed');
     }
 
-    console.log(`✅ ${email} is now a premium user.`);
+    console.log(
+      `✅ ${email} is now a premium user with customer ID ${customerId}`
+    );
   }
 
   res.status(200).json({ received: true });

--- a/components/admin.js
+++ b/components/admin.js
@@ -1,0 +1,81 @@
+import { renderHeader } from './header.js';
+import { supabase } from '../utils/supabaseClient.js';
+
+async function fetchUsers() {
+  const { data, error } = await supabase
+    .from('users')
+    .select('email,is_premium,stripe_customer_id');
+  if (error) {
+    console.error('Failed to fetch users:', error);
+    return [];
+  }
+  return data || [];
+}
+
+async function cancelSubscription(email) {
+  const res = await fetch('/api/cancel-subscription', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+  });
+
+  const result = await res.json();
+  alert(result.message || result.error);
+}
+
+export async function renderAdminScreen() {
+  const app = document.getElementById('app');
+  app.innerHTML = '';
+
+  renderHeader(app, renderAdminScreen);
+
+  const container = document.createElement('div');
+  container.className = 'screen active admin-screen';
+  app.appendChild(container);
+
+  const title = document.createElement('h2');
+  title.textContent = 'ユーザー一覧';
+  container.appendChild(title);
+
+  const table = document.createElement('table');
+  table.className = 'admin-table';
+  table.innerHTML = `
+    <thead>
+      <tr>
+        <th>Email</th>
+        <th>is_premium</th>
+        <th>customer_id</th>
+        <th>Action</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  `;
+  container.appendChild(table);
+
+  async function load() {
+    const tbody = table.querySelector('tbody');
+    tbody.innerHTML = '';
+    const users = await fetchUsers();
+    users.forEach((u) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${u.email || ''}</td>
+        <td>${u.is_premium ? 'true' : 'false'}</td>
+        <td>${u.stripe_customer_id || ''}</td>
+        <td></td>
+      `;
+      if (u.is_premium) {
+        const btn = document.createElement('button');
+        btn.textContent = 'キャンセル';
+        btn.onclick = async () => {
+          await cancelSubscription(u.email);
+          await load();
+        };
+        tr.lastElementChild.appendChild(btn);
+      }
+      tbody.appendChild(tr);
+    });
+  }
+
+  load();
+}

--- a/components/header.js
+++ b/components/header.js
@@ -20,6 +20,7 @@ export function renderHeader(container) {
         <button id="settings-btn">⚙️ 設定</button>
         <button id="summary-btn">📊 分析画面</button>
         <button id="mypage-btn">👤 マイページ</button>
+        <button id="admin-btn">🛠 管理画面</button>
         <button id="growth-btn">🌱 育成モード</button>
         <button id="logout-btn">🚪 ログアウト</button>
       </div>
@@ -53,6 +54,7 @@ export function renderHeader(container) {
   header.querySelector("#growth-btn").onclick = () => switchScreen("growth");
 
   header.querySelector("#mypage-btn").onclick = () => switchScreen("mypage");
+  header.querySelector("#admin-btn").onclick = () => switchScreen("admin");
   // ▼ ログアウト処理
   header.querySelector("#logout-btn").addEventListener("click", async () => {
     try {

--- a/main.js
+++ b/main.js
@@ -17,6 +17,7 @@ import { renderInitialSetupScreen } from "./components/initialSetup.js";
 import { supabase } from "./utils/supabaseClient.js";
 import { createInitialChordProgress } from "./utils/progressUtils.js";
 import { renderMyPageScreen } from "./components/mypage.js";
+import { renderAdminScreen } from "./components/admin.js";
 import { clearTimeOfDayStyling } from "./utils/timeOfDay.js";
 
 
@@ -78,6 +79,7 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   else if (screen === "signup") renderSignUpScreen(user);
   else if (screen === "setup") renderInitialSetupScreen(user, (u) => switchScreen("home", u));
   else if (screen === "mypage") renderMyPageScreen(user);
+  else if (screen === "admin") renderAdminScreen(user);
   else if (screen === "result") renderResultScreen(user);
   else if (screen === "result_easy") renderTrainingEasyResultScreen(user);
   else if (screen === "result_full") renderTrainingFullResultScreen(user);


### PR DESCRIPTION
## Summary
- store Stripe customer ID in webhook handler
- create API to cancel subscriptions via Stripe
- implement admin screen to manage premium users
- expose admin screen through header menu and router

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683ba986101483238c592e4e6a624d56