### PR TITLE
Fix missing email field when creating users

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -44,10 +44,17 @@ export function renderLoginScreen(container, onLoginSuccess) {
     let userId;
   
     if (!existingUser) {
-      const { data: inserted, error: insertError } = await supabase.from("users").insert([{
-        firebase_uid: user.uid,
-        name: user.displayName || "名前未設定"
-      }]).select().single();
+      const { data: inserted, error: insertError } = await supabase
+        .from("users")
+        .insert([
+          {
+            firebase_uid: user.uid,
+            name: user.displayName || "名前未設定",
+            email: user.email,
+          },
+        ])
+        .select()
+        .single();
   
       if (insertError || !inserted) {
         console.error("❌ Supabaseユーザー登録失敗:", insertError);

--- a/components/signup.js
+++ b/components/signup.js
@@ -67,14 +67,18 @@ export function renderSignUpScreen() {
 
       let userId = existingUser?.id;
 
-      if (!existingUser) {
-        const { data: inserted, error: insertError } = await supabase
-          .from("users")
-          .insert([
-            { firebase_uid: user.uid, name: user.displayName || "名前未設定" }
-          ])
-          .select()
-          .maybeSingle();
+        if (!existingUser) {
+          const { data: inserted, error: insertError } = await supabase
+            .from("users")
+            .insert([
+              {
+                firebase_uid: user.uid,
+                name: user.displayName || "名前未設定",
+                email: user.email,
+              },
+            ])
+            .select()
+            .maybeSingle();
 
         if (insertError || !inserted) {
           console.error("❌ Supabaseユーザー登録失敗:", insertError);

--- a/main.js
+++ b/main.js
@@ -117,7 +117,13 @@ onAuthStateChanged(auth, async (firebaseUser) => {
   if (!user) {
     const { data: inserted, error: insertError } = await supabase
       .from("users")
-      .insert([{ firebase_uid: firebaseUser.uid, name: firebaseUser.displayName || "名前未設定" }])
+      .insert([
+        {
+          firebase_uid: firebaseUser.uid,
+          name: firebaseUser.displayName || "名前未設定",
+          email: firebaseUser.email,
+        },
+      ])
       .select()
       .maybeSingle();
 


### PR DESCRIPTION
## Summary
- include `email` when inserting users on login or signup
- persist email in `main.js` when auto-registering Firebase users

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683bb6933be0832390fb704e1dc18e2b