### PR TITLE
Add logging for Stripe checkout

### DIFF
--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -3,11 +3,14 @@ import Stripe from 'stripe';
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
 export default async function handler(req, res) {
+  console.log('Stripe Checkout API called');
+
   if (req.method !== 'POST') {
     return res.status(405).send('Method Not Allowed');
   }
 
   const { email } = req.body;
+  console.log('Received email:', email);
 
   try {
     const session = await stripe.checkout.sessions.create({
@@ -17,14 +20,15 @@ export default async function handler(req, res) {
         price: 'price_1RUo5t4aOXt1PnHZ6WGANKa8',
         quantity: 1,
       }],
-      success_url: 'https://your-site.com/success',
-      cancel_url: 'https://your-site.com/cancel',
+      success_url: 'https://otoron-app.vercel.app/success',
+      cancel_url: 'https://otoron-app.vercel.app/cancel',
       customer_email: email,
     });
 
+    console.log('Created session:', session.id);
     res.status(200).json({ id: session.id });
   } catch (error) {
-    console.error('Stripe checkout error:', error);
+    console.error('❌ Error creating Stripe session:', error);
     res.status(500).json({ error: error.message });
   }
 }

--- a/utils/stripeCheckout.js
+++ b/utils/stripeCheckout.js
@@ -1,8 +1,9 @@
 import { firebaseAuth } from '../firebase/firebase-init.js';
 
 export async function startCheckout() {
-  const email = firebaseAuth.currentUser?.email;
-  if (!email) {
+  const email = firebaseAuth.currentUser?.email || '未取得';
+  console.log('✨ checkout email:', email);
+  if (!firebaseAuth.currentUser?.email) {
     alert('ログイン情報がありません');
     return;
   }
@@ -14,9 +15,13 @@ export async function startCheckout() {
       body: JSON.stringify({ email })
     });
 
-    const session = await response.json();
-    const stripe = Stripe('pk_test_51RUmpu4aOXt1PnHZ4QI4ED8IqIZstCQTAMzMm6isjY34QP5ESFYKClhQSwRI8d52n80G4c2FgPQTvFXLjOQG9Yl400wFCPpXca');
-    await stripe.redirectToCheckout({ sessionId: session.id });
+    const data = await response.json();
+    if (data.id) {
+      const stripe = Stripe('pk_test_51RUmpu4aOXt1PnHZ4QI4ED8IqIZstCQTAMzMm6isjY34QP5ESFYKClhQSwRI8d52n80G4c2FgPQTvFXLjOQG9Yl400wFCPpXca');
+      await stripe.redirectToCheckout({ sessionId: data.id });
+    } else {
+      console.error('No session ID returned:', data);
+    }
   } catch (err) {
     console.error('Stripe checkout error', err);
     alert('決済処理でエラーが発生しました');


### PR DESCRIPTION
## Summary
- log email and session info in `create-checkout-session.js`
- log checkout email and handle missing session id on the client

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683bb83fa9488323b8bb41884aa8253d