### PR TITLE
Add star-based progress to growth screen

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -61,3 +61,37 @@
   background: rgba(255, 255, 255, 0.3);
   transition: width 0s;
 }
+/* ⭐ 育成進捗バー */
+.growth-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.5em 1em;
+  border: 4px solid #5b4636;
+  border-radius: 12px;
+  background: repeating-radial-gradient(circle at 0 0, #fff 0 3px, #ffe680 3px 12px);
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.growth-progress img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 3px solid #5b4636;
+}
+
+.growth-progress .stars {
+  display: flex;
+  flex: 1;
+  justify-content: space-between;
+}
+
+.growth-progress .star {
+  font-size: 32px;
+  color: #ccc;
+}
+
+.growth-progress .star.filled {
+  color: #FFD700;
+}

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -71,19 +71,28 @@ export async function renderGrowthScreen(user) {
   statusBar.appendChild(unlockBtn);
   container.appendChild(statusBar);
 
+  // ⭐ 進捗を星で表示
   const progressBar = document.createElement("div");
-  progressBar.style.height = "30px";
-  progressBar.style.background = "#eee";
-  progressBar.style.borderRadius = "10px";
-  progressBar.style.margin = "1em 0";
-  progressBar.style.overflow = "hidden";
+  progressBar.className = "growth-progress";
 
-  const progress = document.createElement("div");
-  progress.style.height = "100%";
-  progress.style.width = `${Math.min((passed / 7) * 100, 100)}%`;
-  progress.style.background = passed >= 7 ? "#4caf50" : "#66bbff";
-  progress.style.transition = "width 0.3s ease";
-  progressBar.appendChild(progress);
+  const face = document.createElement("img");
+  face.src = "images/otolon_face.webp";
+  face.alt = "オトロン";
+  progressBar.appendChild(face);
+
+  const starsWrapper = document.createElement("div");
+  starsWrapper.className = "stars";
+
+  const filled = Math.max(0, Math.min(passed, 7));
+  for (let i = 0; i < 7; i++) {
+    const star = document.createElement("span");
+    star.className = "star";
+    star.textContent = "★";
+    if (i < filled) star.classList.add("filled");
+    starsWrapper.appendChild(star);
+  }
+
+  progressBar.appendChild(starsWrapper);
   container.appendChild(progressBar);
 
   // 🛠 デバッグ: 進捗を赤のみの状態に戻す


### PR DESCRIPTION
## Summary
- show progress in growth mode using a cute star bar with character icon
- style progress bar with polka dot background and star icons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683be9204bc88323bc97ff84c5adcdcd