### PR TITLE
Improve growth progress UI

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -62,6 +62,20 @@
   transition: width 0s;
 }
 /* ⭐ 育成進捗バー */
+.progress-bar {
+  display: flex;
+  align-items: center;
+}
+
+.face-icon {
+  margin-right: 8px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 2px solid #5b4636;
+}
+
 .growth-progress {
   display: flex;
   align-items: center;
@@ -69,18 +83,11 @@
   padding: 0.25em 0.5em;
   border: 2px solid #5b4636;
   border-radius: 12px;
-  background-color: #fffacd;
+  background-color: #ffe066;
   background-image: radial-gradient(white 1.5px, transparent 1.5px);
   background-size: 10px 10px;
   max-width: 100%;
   box-sizing: border-box;
-}
-
-.growth-progress img {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  border: 2px solid #5b4636;
 }
 
 .growth-progress .stars {
@@ -90,7 +97,7 @@
 }
 
 .growth-progress .star {
-  font-size: 16px;
+  font-size: 32px;
   color: #ccc;
 }
 

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -72,13 +72,17 @@ export async function renderGrowthScreen(user) {
   container.appendChild(statusBar);
 
   // ⭐ 進捗を星で表示
-  const progressBar = document.createElement("div");
-  progressBar.className = "growth-progress";
+  const progressWrapper = document.createElement("div");
+  progressWrapper.className = "progress-bar";
 
   const face = document.createElement("img");
   face.src = "images/otolon_face.webp";
   face.alt = "オトロン";
-  progressBar.appendChild(face);
+  face.className = "face-icon";
+  progressWrapper.appendChild(face);
+
+  const progressBar = document.createElement("div");
+  progressBar.className = "growth-progress";
 
   const starsWrapper = document.createElement("div");
   starsWrapper.className = "stars";
@@ -93,7 +97,8 @@ export async function renderGrowthScreen(user) {
   }
 
   progressBar.appendChild(starsWrapper);
-  container.appendChild(progressBar);
+  progressWrapper.appendChild(progressBar);
+  container.appendChild(progressWrapper);
 
   // 🛠 デバッグ: 進捗を赤のみの状態に戻す
   const resetBtn = document.createElement("button");


### PR DESCRIPTION
## Summary
- move Otolon face icon outside of progress bar
- brighten progress bar background color
- enlarge star icons for better visibility

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683c4a8ab9548323b116c70900553759