### PR TITLE
Add readonly email display on profile page for Google login

### DIFF
--- a/components/mypage.js
+++ b/components/mypage.js
@@ -24,6 +24,9 @@ export function renderMyPageScreen(user) {
   const hasPassword = firebaseUser?.providerData.some(
     (p) => p.providerId === "password"
   );
+  const googleOnly =
+    firebaseUser?.providerData.some((p) => p.providerId === "google.com") &&
+    !hasPassword;
 
   const tabs = [
     { id: "profile", label: "プロフィール変更" },
@@ -89,13 +92,20 @@ export function renderMyPageScreen(user) {
     });
     form.appendChild(yearField);
 
-    const emailField = createField("メールアドレス", true, () => {
-      const input = document.createElement("input");
-      input.type = "email";
-      input.required = true;
-      input.value = user?.email || "";
-      return input;
-    });
+    const emailField = googleOnly
+      ? createField("ログインメールアドレス（変更不可）", null, () => {
+          const span = document.createElement("div");
+          span.className = "email-readonly";
+          span.textContent = firebaseUser.email || user?.email || "";
+          return span;
+        })
+      : createField("メールアドレス", true, () => {
+          const input = document.createElement("input");
+          input.type = "email";
+          input.required = true;
+          input.value = user?.email || "";
+          return input;
+        });
     form.appendChild(emailField);
 
     const saveBtn = document.createElement("button");
@@ -271,10 +281,12 @@ export function renderMyPageScreen(user) {
 
     const label = document.createElement("label");
     label.textContent = labelText;
-    const badge = document.createElement("span");
-    badge.className = required ? "required" : "optional";
-    badge.textContent = required ? "必須" : "任意";
-    label.appendChild(badge);
+    if (required !== null) {
+      const badge = document.createElement("span");
+      badge.className = required ? "required" : "optional";
+      badge.textContent = required ? "必須" : "任意";
+      label.appendChild(badge);
+    }
     wrapper.appendChild(label);
     wrapper.appendChild(inputFactory());
     return wrapper;

--- a/css/mypage.css
+++ b/css/mypage.css
@@ -124,3 +124,8 @@
   font-size: 0.8rem;
   margin-bottom: 0.2em;
 }
+
+.email-readonly {
+  padding: 0.6em 0;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- detect Google-only logins in profile screen
- display login email as read-only with new label
- allow fields without badge when needed
- style read-only email text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683c545b125c83239c0fc0e60cc6b2ac