### PR TITLE
Implement password visibility toggle

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -15,7 +15,10 @@ export function renderLoginScreen(container, onLoginSuccess) {
       <h2 class="login-title">ログイン</h2>
       <form class="login-form">
         <input type="email" id="email" placeholder="メールアドレス" required />
-        <input type="password" id="password" placeholder="パスワード" required />
+        <div class="password-input-wrap">
+          <input type="password" id="password" placeholder="パスワード" required />
+          <button type="button" class="toggle-password material-icons">visibility</button>
+        </div>
         <button type="submit">ログイン</button>
       </form>
 
@@ -29,6 +32,14 @@ export function renderLoginScreen(container, onLoginSuccess) {
       </div>
     </div>
   `;
+
+  const passInput = container.querySelector('#password');
+  const toggleBtn = container.querySelector('.toggle-password');
+  toggleBtn.addEventListener('click', () => {
+    const hidden = passInput.type === 'password';
+    passInput.type = hidden ? 'text' : 'password';
+    toggleBtn.textContent = hidden ? 'visibility_off' : 'visibility';
+  });
 
   // 🔽 和音進捗の初期登録（必要なら）
   async function ensureUserAndProgress(user) {

--- a/components/signup.js
+++ b/components/signup.js
@@ -18,7 +18,10 @@ export function renderSignUpScreen() {
       <input type="email" id="signup-email" required />
 
       <label for="signup-password">パスワード（6文字以上）</label>
-      <input type="password" id="signup-password" required />
+      <div class="password-input-wrap">
+        <input type="password" id="signup-password" required />
+        <button type="button" class="toggle-password material-icons">visibility</button>
+      </div>
 
       <button type="submit" class="signup-button">アカウントを作成</button>
     </form>
@@ -32,6 +35,14 @@ export function renderSignUpScreen() {
   `;
 
   app.appendChild(container);
+
+  const passInput = container.querySelector('#signup-password');
+  const toggleBtn = container.querySelector('.toggle-password');
+  toggleBtn.addEventListener('click', () => {
+    const hidden = passInput.type === 'password';
+    passInput.type = hidden ? 'text' : 'password';
+    toggleBtn.textContent = hidden ? 'visibility_off' : 'visibility';
+  });
 
   // 通常のメールアドレス＋パスワード登録
   const form = container.querySelector(".signup-form");

--- a/css/login.css
+++ b/css/login.css
@@ -105,3 +105,21 @@
   color: #999;
   font-size: 0.9rem;
 }
+
+.password-input-wrap {
+  position: relative;
+}
+
+.password-input-wrap input {
+  padding-right: 2.5em;
+}
+
+.toggle-password {
+  position: absolute;
+  right: 0.5em;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+}

--- a/css/signup.css
+++ b/css/signup.css
@@ -88,3 +88,21 @@
 .google-button:hover {
   background-color: #3367d6;
 }
+
+.password-input-wrap {
+  position: relative;
+}
+
+.password-input-wrap input {
+  padding-right: 2.5em;
+}
+
+.toggle-password {
+  position: absolute;
+  right: 0.5em;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
   <!-- CSS -->
   <link rel="stylesheet" href="css/common.css" />


### PR DESCRIPTION
## Summary
- add Material Icons for toggling password input
- add password visibility toggle on login and sign up forms
- style new password toggle

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683c5499c1c8832391ded2ae71bbc6e3