### PR TITLE
Add common password toggle styles

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -93,3 +93,29 @@ button:hover {
     overflow-y: auto;
   }
 }
+
+/* Password input with eye toggle */
+.password-input-wrap {
+  position: relative;
+  width: 100%;
+}
+
+.password-input-wrap input {
+  width: 100%;
+  padding-right: 40px; /* アイコン分の余白 */
+  height: 40px;
+  border-radius: 6px;
+}
+
+.toggle-password {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  height: 24px;
+  width: 24px;
+}

--- a/css/login.css
+++ b/css/login.css
@@ -106,20 +106,4 @@
   font-size: 0.9rem;
 }
 
-.password-input-wrap {
-  position: relative;
-}
 
-.password-input-wrap input {
-  padding-right: 2.5em;
-}
-
-.toggle-password {
-  position: absolute;
-  right: 0.5em;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
-}

--- a/css/mypage.css
+++ b/css/mypage.css
@@ -101,23 +101,7 @@
   padding: 0.4em 0.8em;
 }
 
-.password-input-wrap {
-  position: relative;
-}
 
-.password-input-wrap input {
-  padding-right: 2.5em;
-}
-
-.toggle-password {
-  position: absolute;
-  right: 0.5em;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
 
 .password-error {
   color: red;

--- a/css/signup.css
+++ b/css/signup.css
@@ -89,20 +89,4 @@
   background-color: #3367d6;
 }
 
-.password-input-wrap {
-  position: relative;
-}
 
-.password-input-wrap input {
-  padding-right: 2.5em;
-}
-
-.toggle-password {
-  position: absolute;
-  right: 0.5em;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
-}


### PR DESCRIPTION
## Summary
- centralize password input styles in `css/common.css`
- remove redundant rules from login, signup, and my page styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683c570f15388323b701a35789353fcc