### PR TITLE
Add static success page

### DIFF
--- a/success/index.html
+++ b/success/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>決済完了</title>
+</head>
+<body style="margin:0;">
+  <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;background-color:#fff;text-align:center;">
+    <img src="../images/payment-success.webp" alt="決済完了" style="max-width:90%;height:auto" />
+    <p style="margin-top:1rem;color:#666">3秒後にホーム画面に戻ります</p>
+  </div>
+  <script>
+    setTimeout(() => {
+      window.location.href = '/';
+    }, 3000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show success page at `/success` using static HTML

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683c58ae660883239d7d4e42aab262f7