### PR TITLE
Remove password visibility UI

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -15,10 +15,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       <h2 class="login-title">ログイン</h2>
       <form class="login-form">
         <input type="email" id="email" placeholder="メールアドレス" required />
-        <div class="password-input-wrap">
-          <input type="password" id="password" placeholder="パスワード" required />
-          <button type="button" class="toggle-password material-icons">visibility</button>
-        </div>
+        <input type="password" id="password" placeholder="パスワード" required />
         <button type="submit">ログイン</button>
       </form>
 
@@ -33,13 +30,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
     </div>
   `;
 
-  const passInput = container.querySelector('#password');
-  const toggleBtn = container.querySelector('.toggle-password');
-  toggleBtn.addEventListener('click', () => {
-    const hidden = passInput.type === 'password';
-    passInput.type = hidden ? 'text' : 'password';
-    toggleBtn.textContent = hidden ? 'visibility_off' : 'visibility';
-  });
+
 
   // 🔽 和音進捗の初期登録（必要なら）
   async function ensureUserAndProgress(user) {

--- a/components/mypage.js
+++ b/components/mypage.js
@@ -136,9 +136,6 @@ export function renderMyPageScreen(user) {
       labelEl.appendChild(badge);
       field.appendChild(labelEl);
 
-      const wrap = document.createElement("div");
-      wrap.className = "password-input-wrap";
-
       const input = document.createElement("input");
       input.type = "password";
       input.required = true;
@@ -147,19 +144,7 @@ export function renderMyPageScreen(user) {
         input.value = sessionStorage.getItem("currentPassword") || "";
       }
 
-      const toggle = document.createElement("button");
-      toggle.type = "button";
-      toggle.className = "toggle-password";
-      toggle.textContent = "\u{1F441}"; // eye icon
-      toggle.onclick = () => {
-        const hidden = input.type === "password";
-        input.type = hidden ? "text" : "password";
-        toggle.textContent = hidden ? "\u{1F648}" : "\u{1F441}"; // 🙈 / 👁
-      };
-
-      wrap.appendChild(input);
-      wrap.appendChild(toggle);
-      field.appendChild(wrap);
+      field.appendChild(input);
 
       return { field, input };
     }
@@ -175,7 +160,7 @@ export function renderMyPageScreen(user) {
     errorMsg.className = "password-error";
     errorMsg.textContent = "確認用パスワードが一致しません";
     errorMsg.style.display = "none";
-    confirm.field.insertBefore(errorMsg, confirm.field.querySelector(".password-input-wrap"));
+    confirm.field.insertBefore(errorMsg, confirm.field.querySelector("input"));
     form.appendChild(confirm.field);
 
     const btn = document.createElement("button");

--- a/components/signup.js
+++ b/components/signup.js
@@ -18,10 +18,7 @@ export function renderSignUpScreen() {
       <input type="email" id="signup-email" required />
 
       <label for="signup-password">パスワード（6文字以上）</label>
-      <div class="password-input-wrap">
-        <input type="password" id="signup-password" required />
-        <button type="button" class="toggle-password material-icons">visibility</button>
-      </div>
+      <input type="password" id="signup-password" required />
 
       <button type="submit" class="signup-button">アカウントを作成</button>
     </form>
@@ -36,13 +33,7 @@ export function renderSignUpScreen() {
 
   app.appendChild(container);
 
-  const passInput = container.querySelector('#signup-password');
-  const toggleBtn = container.querySelector('.toggle-password');
-  toggleBtn.addEventListener('click', () => {
-    const hidden = passInput.type === 'password';
-    passInput.type = hidden ? 'text' : 'password';
-    toggleBtn.textContent = hidden ? 'visibility_off' : 'visibility';
-  });
+
 
   // 通常のメールアドレス＋パスワード登録
   const form = container.querySelector(".signup-form");

--- a/css/common.css
+++ b/css/common.css
@@ -94,28 +94,4 @@ button:hover {
   }
 }
 
-/* Password input with eye toggle */
-.password-input-wrap {
-  position: relative;
-  width: 100%;
-}
 
-.password-input-wrap input {
-  width: 100%;
-  padding-right: 40px; /* アイコン分の余白 */
-  height: 40px;
-  border-radius: 6px;
-}
-
-.toggle-password {
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  background: transparent;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  height: 24px;
-  width: 24px;
-}


### PR DESCRIPTION
## Summary
- strip show/hide password button from login and signup components
- remove visibility button logic in my page
- drop unused CSS for the eye icon

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683c58eee3dc83239b45e5caf0b35a2f