### PR TITLE
Update success image size

### DIFF
--- a/pages/success.js
+++ b/pages/success.js
@@ -21,7 +21,7 @@ export default function Success() {
       backgroundColor: '#fff',
       textAlign: 'center'
     }}>
-      <img src="images/payment-success.webp" alt="決済完了" style={{ maxWidth: '90%', height: 'auto' }} />
+      <img src="images/payment-success.webp" alt="決済完了" style={{ maxWidth: '80%', maxHeight: '80vh', height: 'auto' }} />
       <p style={{ marginTop: '1rem', color: '#666' }}>3秒後にホーム画面に戻ります</p>
     </div>
   );

--- a/success/index.html
+++ b/success/index.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin:0;">
   <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;background-color:#fff;text-align:center;">
-    <img src="../images/payment-success.webp" alt="決済完了" style="max-width:90%;height:auto" />
+    <img src="../images/payment-success.webp" alt="決済完了" style="max-width:80%;max-height:80vh;height:auto" />
     <p style="margin-top:1rem;color:#666">3秒後にホーム画面に戻ります</p>
   </div>
   <script>


### PR DESCRIPTION
## Summary
- keep payment success image within viewport

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683c5d3ba0e8832386695622d4219a22