### PR TITLE
Add Stripe webhook handler

### DIFF
--- a/pages/api/stripe-webhook.js
+++ b/pages/api/stripe-webhook.js
@@ -1,0 +1,65 @@
+import Stripe from 'stripe';
+import { createClient } from '@supabase/supabase-js';
+import { buffer } from 'micro';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const endpointSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).send('Method Not Allowed');
+  }
+
+  const sig = req.headers['stripe-signature'];
+
+  let event;
+  try {
+    const buf = await buffer(req);
+    event = stripe.webhooks.constructEvent(buf, sig, endpointSecret);
+  } catch (err) {
+    console.error('Webhook signature verification failed.', err.message);
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  const { type, data } = event;
+  const customerId = data?.object?.customer;
+
+  let isPremium;
+  if (type === 'invoice.payment_succeeded') {
+    isPremium = true;
+  } else if (
+    type === 'customer.subscription.deleted' ||
+    type === 'invoice.payment_failed'
+  ) {
+    isPremium = false;
+  }
+
+  if (typeof isPremium === 'boolean' && customerId) {
+    const { error } = await supabase
+      .from('users')
+      .update({ is_premium: isPremium })
+      .eq('stripe_customer_id', customerId);
+
+    if (error) {
+      console.error('Supabase update error:', error);
+      return res.status(500).send('Supabase update failed');
+    }
+
+    console.log(
+      `Updated user with customer ID ${customerId}: is_premium -> ${isPremium}`
+    );
+  }
+
+  res.status(200).json({ received: true });
+}


### PR DESCRIPTION
## Summary
- handle subscription-related events via `pages/api/stripe-webhook.js`
- respond to Stripe webhooks and update `is_premium` in Supabase

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_b_683c5e7809d08323ae59f9be4bd8a486