### PR TITLE
Refine growth screen layout

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -68,6 +68,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
+  margin: 1.5em auto;
   padding: 0.5em;
   background: #fff8d6;
   border-radius: 12px;
@@ -129,17 +130,29 @@
   width: 100%;
 }
 
-#growth-message {
-  margin-bottom: 1em;
-  text-align: center;
+.unlock-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5em;
+  max-width: 320px;
 }
 
-#growth-message.can-unlock {
+.unlock-card.highlight {
   background: #ffe6f0;
   border: 2px solid #ff66cc;
   border-radius: 12px;
   padding: 0.75em;
+}
+
+#growth-message {
+  margin-bottom: 0.5em;
+  text-align: center;
+  font-size: 0.9em;
+  line-height: 1.2;
+}
+
+#growth-message.can-unlock {
   color: #d1007d;
   font-weight: bold;
-  max-width: 320px;
 }

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -49,6 +49,11 @@ export async function renderGrowthScreen(user) {
 
   const statusBar = document.createElement("div");
   statusBar.className = "status-bar";
+
+  const unlockCard = document.createElement("div");
+  unlockCard.className = "unlock-card";
+  unlockCard.id = "unlockCard";
+
   const msgSpan = document.createElement("div");
   msgSpan.id = "growth-message";
 
@@ -62,8 +67,9 @@ export async function renderGrowthScreen(user) {
   progressEl.className = "progress";
   unlockBtn.appendChild(progressEl);
 
-  statusBar.appendChild(msgSpan);
-  statusBar.appendChild(unlockBtn);
+  unlockCard.appendChild(msgSpan);
+  unlockCard.appendChild(unlockBtn);
+  statusBar.appendChild(unlockCard);
   container.appendChild(statusBar);
 
   // ⭐ 進捗を星で表示

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -60,8 +60,9 @@ export async function getUnlockCriteriaStatus(userId) {
 export async function updateGrowthStatusBar(user, target, onUnlocked) {
   const msg = document.getElementById("growth-message");
   const btn = document.getElementById("unlockBtn");
+  const card = document.getElementById("unlockCard");
   const progress = btn?.querySelector(".progress");
-  if (!msg || !btn || !progress) return;
+  if (!msg || !btn || !progress || !card) return;
 
   const canUnlock = await checkRecentUnlockCriteria(user.id);
   const holdTime = 1500;
@@ -76,6 +77,7 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
   if (canUnlock) {
     msg.textContent = "合格条件（7日間の合格）を満たしました。次の和音を解放できます。";
     msg.classList.add("can-unlock");
+    card.classList.add("highlight");
     btn.style.display = "block";
 
     btn.onpointerdown = () => {
@@ -110,6 +112,7 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
     const label = target ? target.label : "";
     msg.textContent = `いま ${label} の解放条件を満たしていません`;
     msg.classList.remove("can-unlock");
+    card.classList.remove("highlight");
     btn.style.display = "none";
     btn.onpointerdown = null;
     btn.onpointerup = null;


### PR DESCRIPTION
## Summary
- wrap growth status message and unlock button in a card container
- center progress bar with vertical margins
- tweak message font size and new card highlight style

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683d8f6981848323bddb1462a7377906