### PR TITLE
Adjust mock data generation and progress bar style

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -69,10 +69,6 @@
   justify-content: center;
   width: 100%;
   margin: 1.5em auto;
-  padding: 0.5em;
-  background: #fff8d6;
-  border-radius: 12px;
-  box-sizing: border-box;
 }
 
 .face-icon {

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -110,7 +110,7 @@ export async function renderGrowthScreen(user) {
     { value: "", label: "デバッグ機能（本番モードでは削除）" },
     { value: "reset", label: "進捗をリセット（赤のみ）" },
     { value: "unlock", label: "次の和音を解放" },
-    { value: "mock4", label: "モック記録生成（4/7合格）" },
+    { value: "mock4", label: "モック記録生成（4日分合格）" },
     { value: "mock7", label: "モック記録生成（7/7合格）" }
   ].forEach(opt => {
     const o = document.createElement("option");
@@ -142,7 +142,7 @@ export async function renderGrowthScreen(user) {
       }
     } else if (val === "mock4") {
       await generateMockGrowthData(user.id, 4);
-      alert("モックデータ(4/7)を生成しました");
+      alert("モックデータ(4日分)を生成しました");
     } else if (val === "mock7") {
       await generateMockGrowthData(user.id, 7);
       alert("モックデータ(7/7)を生成しました");

--- a/utils/growthStore_supabase.js
+++ b/utils/growthStore_supabase.js
@@ -56,15 +56,16 @@ export async function markChordAsUnlocked(userId, chordKey) {
 }
 
 /**
- * 直近7日分のモック記録を生成（デバッグ用）
+ * 指定日数分のモック記録を生成（デバッグ用）
  * @param {string} userId
+ * @param {number} [days=7] - 生成する合格記録の日数
  */
-export async function generateMockGrowthData(userId, qualifiedDays = 7) {
+export async function generateMockGrowthData(userId, days = 7) {
   const now = new Date();
 
-  // 現在進行中の和音の解放日を7日前に調整して解放条件を満たす
+  // 現在進行中の和音の解放日を days 日前に調整して解放条件を満たす
   const past = new Date(now);
-  past.setDate(now.getDate() - 7);
+  past.setDate(now.getDate() - days);
   const pastStr = past.toISOString().split("T")[0];
   await supabase
     .from("user_chord_progress")
@@ -84,16 +85,15 @@ export async function generateMockGrowthData(userId, qualifiedDays = 7) {
   let queue = generateRecommendedQueue(flags);
   if (queue.length === 0) queue = ["C-E-G"];
 
-  // 直近7日分の記録を挿入
-  // qualifiedDays 回分は合格となるよう調整
-  for (let i = 0; i < 7; i++) {
+  // 指定日数分の記録を挿入（すべて合格とする）
+  for (let i = 0; i < days; i++) {
     const d = new Date(now);
     d.setDate(now.getDate() - i);
     const dateStr = d.toISOString().split("T")[0];
 
     const count = 60;
-    const qualified = i < qualifiedDays;
-    const mistakeNum = qualified ? 1 : 3;
+    const qualified = true;
+    const mistakeNum = 1;
 
     const rec = {
       user_id: userId,


### PR DESCRIPTION
## Summary
- generate mock growth data for a specified number of qualified days
- remove yellow frame around growth progress bar
- update debug option labels/messages to reflect 4 day mock generation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683d997909ec83238a6bea6dbdeffc31