### PR TITLE
Update messages for chord unlock and mock data

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -111,7 +111,7 @@ export async function renderGrowthScreen(user) {
     { value: "reset", label: "進捗をリセット（赤のみ）" },
     { value: "unlock", label: "次の和音を解放" },
     { value: "mock4", label: "モック記録生成（4日分合格）" },
-    { value: "mock7", label: "モック記録生成（7/7合格）" }
+    { value: "mock7", label: "モック記録生成（7日分合格）" }
   ].forEach(opt => {
     const o = document.createElement("option");
     o.value = opt.value;
@@ -145,7 +145,7 @@ export async function renderGrowthScreen(user) {
       alert("モックデータ(4日分)を生成しました");
     } else if (val === "mock7") {
       await generateMockGrowthData(user.id, 7);
-      alert("モックデータ(7/7)を生成しました");
+      alert("モックデータ(7日分)を生成しました");
     }
     await renderGrowthScreen(user);
   };

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -75,7 +75,7 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
   };
 
   if (canUnlock) {
-    msg.textContent = "合格条件（7日間の合格）を満たしました。次の和音を解放できます。";
+    msg.textContent = "合格条件（7日間の合格）を達成しました！\n次の和音を解放できます。";
     msg.classList.add("can-unlock");
     card.classList.add("highlight");
     btn.style.display = "block";


### PR DESCRIPTION
## Summary
- tweak the unlock criteria message
- adjust debug labels and alerts for generating 7-day mock data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683d9a8e6b148323be88f67873fcf716