### PR TITLE
Add 4‑day mock data button

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -119,6 +119,15 @@ export async function renderGrowthScreen(user) {
     actionSelect.appendChild(o);
   });
 
+  const mock4Btn = document.createElement("button");
+  mock4Btn.textContent = "4日分モック生成";
+  mock4Btn.style.marginLeft = "0.5em";
+  mock4Btn.onclick = async () => {
+    await generateMockGrowthData(user.id, 4);
+    alert("モックデータ(4日分)を生成しました");
+    await renderGrowthScreen(user);
+  };
+
   actionSelect.onchange = async () => {
     const val = actionSelect.value;
     actionSelect.value = "";
@@ -151,6 +160,7 @@ export async function renderGrowthScreen(user) {
   };
 
   debugPanel.appendChild(actionSelect);
+  debugPanel.appendChild(mock4Btn);
   container.appendChild(debugPanel);
 
 


### PR DESCRIPTION
## Summary
- add a debug button to create 4 days of passing records

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683d9b86cf248323b20c79588c8f7713