### PR TITLE
Implement sugoroku style progress board

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -120,6 +120,73 @@
   font-size: 24px;
 }
 
+/* === すごろく形式 === */
+.sugoroku-board {
+  position: relative;
+  width: 100%;
+  max-width: 560px;
+  margin: 2em auto;
+}
+
+.sugoroku-line {
+  position: absolute;
+  top: 28px;
+  left: 0;
+  width: 100%;
+  height: 60px;
+  pointer-events: none;
+}
+
+.sugoroku-cells {
+  display: flex;
+  justify-content: space-between;
+  position: relative;
+  padding: 0 0;
+}
+
+.sugoroku-cell {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: 3px solid #5b4636;
+  font-weight: bold;
+  font-size: 0.75em;
+  color: #5b4636;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+.sugoroku-cell:nth-child(odd) {
+  background-color: #d9f1ff;
+}
+
+.sugoroku-cell:nth-child(even) {
+  background-color: #ffe6f0;
+}
+
+.sugoroku-cell.goal {
+  background-color: #fff3b0;
+  position: relative;
+}
+
+.sugoroku-cell.goal::after {
+  content: "✨";
+  position: absolute;
+  top: -0.6em;
+  right: -0.6em;
+}
+
+.sugoroku-walker {
+  position: absolute;
+  bottom: 70px;
+  width: 56px;
+  transform: translateX(-50%);
+  pointer-events: none;
+  transition: left 0.3s ease;
+}
+
 /* 今日の情報 */
 .today-info {
   text-align: center;

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -72,46 +72,65 @@ export async function renderGrowthScreen(user) {
   statusBar.appendChild(unlockCard);
   container.appendChild(statusBar);
 
-  // 🎲 すごろく風の進捗バー
-  const progressWrapper = document.createElement("div");
-  progressWrapper.className = "progress-bar";
+  // 🎲 すごろく形式の進捗ボード
+  const board = document.createElement("div");
+  board.className = "sugoroku-board";
 
-  const progressBar = document.createElement("div");
-  progressBar.className = "growth-progress";
+  const stepCount = 8; // 0-7
+  const filled = Math.max(0, Math.min(passed, stepCount - 1));
 
-  const track = document.createElement("div");
-  track.className = "progress-track";
-
-  const stepCount = 7;
-  const filled = Math.max(0, Math.min(passed, stepCount));
-  for (let i = 0; i < stepCount; i++) {
-    const step = document.createElement("div");
-    step.className = "step";
-    if (i < filled) step.classList.add("filled");
-    track.appendChild(step);
+  // 波線SVG
+  const spacing = 80;
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.classList.add("sugoroku-line");
+  svg.setAttribute("viewBox", `0 0 ${(stepCount - 1) * spacing} 60`);
+  svg.setAttribute("width", "100%");
+  svg.setAttribute("height", "60");
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  let d = "M0 30";
+  for (let i = 1; i < stepCount; i++) {
+    const x = i * spacing;
+    const cpX = x - spacing / 2;
+    const cpY = i % 2 === 0 ? 10 : 50;
+    d += ` Q ${cpX} ${cpY} ${x} 30`;
   }
+  path.setAttribute("d", d);
+  path.setAttribute("fill", "none");
+  path.setAttribute("stroke", "#5b4636");
+  path.setAttribute("stroke-width", "4");
+  path.setAttribute("stroke-linecap", "round");
+  svg.appendChild(path);
+  board.appendChild(svg);
+
+  // マス目
+  const cells = document.createElement("div");
+  cells.className = "sugoroku-cells";
+  for (let i = 0; i < stepCount; i++) {
+    const cell = document.createElement("div");
+    cell.className = "sugoroku-cell";
+    if (i === 0) {
+      cell.textContent = "START";
+    } else if (i === stepCount - 1) {
+      cell.classList.add("goal");
+      cell.textContent = "GOAL";
+    } else {
+      cell.textContent = i.toString();
+    }
+    cells.appendChild(cell);
+  }
+  board.appendChild(cells);
 
   const walker = document.createElement("img");
   walker.src = "images/walk.webp";
   walker.alt = "オトロン";
-  walker.className = "walker";
-  track.appendChild(walker);
+  walker.className = "sugoroku-walker";
+  board.appendChild(walker);
 
-  progressBar.appendChild(track);
+  container.appendChild(board);
 
-  const goal = document.createElement("span");
-  goal.className = "goal";
-  goal.textContent = "🏁";
-  progressBar.appendChild(goal);
-
-  progressWrapper.appendChild(progressBar);
-  container.appendChild(progressWrapper);
-
-  // walker position
-  const STEP_WIDTH = 48;
-  const STEP_GAP = 12;
-  const index = Math.min(filled, stepCount - 1);
-  walker.style.left = `${index * (STEP_WIDTH + STEP_GAP) + STEP_WIDTH / 2}px`;
+  // キャラクター位置
+  const percent = (filled / (stepCount - 1)) * 100;
+  walker.style.left = `calc(${percent}% )`;
 
   // 🛠 デバッグ機能
   const debugPanel = document.createElement("div");


### PR DESCRIPTION
## Summary
- overhaul growth screen progress into sugoroku board
- show wavy line, circular cells and GOAL tile
- move Otoron image above current step

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683da82a9f508323ba58da5f024923d4