### PR TITLE
Remove mock generation button

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -150,14 +150,6 @@ export async function renderGrowthScreen(user) {
     actionSelect.appendChild(o);
   });
 
-  const mock4Btn = document.createElement("button");
-  mock4Btn.textContent = "4日分モック生成";
-  mock4Btn.style.marginLeft = "0.5em";
-  mock4Btn.onclick = async () => {
-    await generateMockGrowthData(user.id, 4);
-    alert("モックデータ(4日分)を生成しました");
-    await renderGrowthScreen(user);
-  };
 
   actionSelect.onchange = async () => {
     const val = actionSelect.value;
@@ -191,7 +183,6 @@ export async function renderGrowthScreen(user) {
   };
 
   debugPanel.appendChild(actionSelect);
-  debugPanel.appendChild(mock4Btn);
   container.appendChild(debugPanel);
 
 


### PR DESCRIPTION
## Summary
- drop the redundant `4日分モック生成` button from the growth screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683db6a1f2708323a7a13bac57f7612d