### PR TITLE
Fix sugoroku cell positions

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -159,14 +159,23 @@
   box-sizing: border-box;
 }
 
+.sugoroku-cell.start,
+.sugoroku-cell.goal {
+  border-radius: 12px;
+}
+
+.sugoroku-cell.start {
+  background-color: #fffde7;
+}
+
 .sugoroku-cell:nth-child(odd) {
   background-color: #d9f1ff;
-  margin-top: 16px;
+  margin-top: 0;
 }
 
 .sugoroku-cell:nth-child(even) {
   background-color: #ffe6f0;
-  margin-top: 0;
+  margin-top: 8px;
 }
 
 .sugoroku-cell.goal {

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -109,6 +109,7 @@ export async function renderGrowthScreen(user) {
     const cell = document.createElement("div");
     cell.className = "sugoroku-cell";
     if (i === 0) {
+      cell.classList.add("start");
       cell.textContent = "START";
     } else if (i === stepCount - 1) {
       cell.classList.add("goal");


### PR DESCRIPTION
## Summary
- tweak margins so board cells line up with the wavy path
- give the start cell its own class
- style start and goal as rounded rectangles

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683dba04b09c8323b5e74438f4ec8259