### PR TITLE
Display current qualified day streak

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -18,7 +18,7 @@ import { chords } from "../data/chords.js";
 import { renderHeader } from "../components/header.js";
 import { unlockChord, resetChordProgressToRed } from "../utils/progressUtils.js";
 import { getAudio } from "../utils/audioCache.js";
-import { updateGrowthStatusBar } from "../utils/progressStatus.js";
+import { updateGrowthStatusBar, countQualifiedDays } from "../utils/progressStatus.js";
 import { showCustomConfirm } from "../components/home.js";
 
 export async function renderGrowthScreen(user) {
@@ -32,6 +32,8 @@ export async function renderGrowthScreen(user) {
 
   const today = getToday();
   const passed = await getPassedDays(user.id);
+  const qualifiedDays = await countQualifiedDays(user.id);
+  console.log(`\u9023\u7D9A\u5408\u683C\u65E5\u6570: ${qualifiedDays}`);
   const qualifiedToday = await isQualifiedToday(user.id);
   const flags = await loadGrowthFlags(user.id);
   const target = getCurrentTargetChord(flags); // ← chordOrder に沿った未解放の最初の1つ
@@ -44,7 +46,8 @@ export async function renderGrowthScreen(user) {
   info.className = "today-info";
   info.innerHTML = `
     今日の日付: <strong>${today}</strong><br/>
-    今日の状態: ${qualifiedToday ? "✅ 合格済み" : "❌ 未合格"}
+    今日の状態: ${qualifiedToday ? "✅ 合格済み" : "❌ 未合格"}<br/>
+    連続合格日数: ${qualifiedDays} 日
   `;
   container.appendChild(info);
 
@@ -188,6 +191,8 @@ export async function renderGrowthScreen(user) {
     } else if (val.startsWith("mock")) {
       const days = parseInt(val.replace("mock", ""), 10);
       await generateMockGrowthData(user.id, days);
+      const count = await countQualifiedDays(user.id);
+      console.log(`DEBUG: 現在の連続合格日数は ${count} 日です`);
       alert(`モックデータ(${days}日分)を生成しました`);
     }
     await renderGrowthScreen(user);

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -64,6 +64,9 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
   const progress = btn?.querySelector(".progress");
   if (!msg || !btn || !progress || !card) return;
 
+  const consecutive = await countQualifiedDays(user.id);
+  console.log(`\u73FE\u5728\u306E\u9023\u7D9A\u5408\u683C\u65E5\u6570: ${consecutive}`);
+
   const canUnlock = await checkRecentUnlockCriteria(user.id);
   const holdTime = 1500;
   let timer;
@@ -75,7 +78,7 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
   };
 
   if (canUnlock) {
-    msg.textContent = "合格条件（7日間の合格）を達成しました！\n次の和音を解放できます。";
+    msg.textContent = `合格条件（7日間の合格）を達成しました！\n次の和音を解放できます。\n連続合格日数: ${consecutive} 日`;
     msg.classList.add("can-unlock");
     card.classList.add("highlight");
     btn.style.display = "block";
@@ -110,7 +113,7 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
     btn.onpointerleave = cancelProgress;
   } else {
     const label = target ? target.label : "";
-    msg.textContent = `いま ${label} の解放条件を満たしていません`;
+    msg.textContent = `いま ${label} の解放条件を満たしていません\n連続合格日数: ${consecutive} 日`;
     msg.classList.remove("can-unlock");
     card.classList.remove("highlight");
     btn.style.display = "none";


### PR DESCRIPTION
## Summary
- log qualified day count and show the streak on the growth screen
- show streak in unlock status message and log to console
- output streak after creating mock growth data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683dc272417c8323ae1b1c83e7143e46