### PR TITLE
Fix start cell color override

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -164,15 +164,6 @@
   border-radius: 12px;
 }
 
-.sugoroku-cell.start {
-  /* より濃い青色でスタート地点を強調 */
-  background-color: #00008b;
-  color: #fff;
-  position: relative;
-  width: 72px;
-  white-space: nowrap;
-}
-
 .sugoroku-cell:nth-child(odd) {
   background-color: #d9f1ff;
   
@@ -188,7 +179,17 @@
 .sugoroku-cell:nth-child(5) { margin-top: 26px; }
 .sugoroku-cell:nth-child(6) { margin-top: 38px; }
 .sugoroku-cell:nth-child(7) { margin-top: 26px; }
+
 .sugoroku-cell:nth-child(8) { margin-top: 32px; }
+
+.sugoroku-cell.start {
+  /* より濃い青色でスタート地点を強調 */
+  background-color: #00008b;
+  color: #fff;
+  position: relative;
+  width: 72px;
+  white-space: nowrap;
+}
 
 .sugoroku-cell.goal {
   background-color: #ff4d4d;


### PR DESCRIPTION
## Summary
- ensure that the start cell style comes after nth-child rules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683ed7530b10832382ff2e37fb46a6d3