### PR TITLE
Add information menu and static info pages

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -24,20 +24,41 @@ export function renderHeader(container) {
         <button id="logout-btn">🚪 ログアウト</button>
       </div>
     </div>
+
+    <div class="info-menu">
+      <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
+      <div id="info-dropdown" class="info-dropdown">
+        <a href="terms.html">利用規約</a>
+        <a href="privacy.html">プライバシーポリシー</a>
+        <a href="contact.html">お問い合わせ</a>
+        <a href="law.html">特定商取引法に基づく表示</a>
+        <a href="external.html">外部送信ポリシー</a>
+      </div>
+    </div>
   `;
 
   // ▼ ドロップダウン制御（クリックで開閉）
   const parentMenuBtn = header.querySelector("#parent-menu-btn");
   const dropdown = header.querySelector("#parent-dropdown");
+  const infoMenuBtn = header.querySelector("#info-menu-btn");
+  const infoDropdown = header.querySelector("#info-dropdown");
 
   parentMenuBtn.onclick = (e) => {
     e.stopPropagation();
     dropdown.classList.toggle("show");
   };
 
+  infoMenuBtn.onclick = (e) => {
+    e.stopPropagation();
+    infoDropdown.classList.toggle("show");
+  };
+
   document.addEventListener("click", (e) => {
     if (!dropdown.contains(e.target) && e.target !== parentMenuBtn) {
       dropdown.classList.remove("show");
+    }
+    if (!infoDropdown.contains(e.target) && e.target !== infoMenuBtn) {
+      infoDropdown.classList.remove("show");
     }
   });
 

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>お問い合わせ</title>
+</head>
+<body>
+  <h1>お問い合わせ</h1>
+  <p>ここにお問い合わせページの本文が入ります。</p>
+</body>
+</html>

--- a/css/header.css
+++ b/css/header.css
@@ -89,6 +89,64 @@
   background-color: #f5f5f5;
 }
 
+/* ▼ インフォメーションメニュー */
+.info-menu {
+  position: relative;
+  display: inline-block;
+  margin-left: 0.2em;
+}
+
+#info-menu-btn {
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  cursor: pointer;
+  padding: 0.5em 1em;
+  transition: background-color 0.2s ease;
+  border-radius: 5px;
+}
+
+#info-menu-btn:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.info-dropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  padding: 0.5em 0;
+  min-width: 180px;
+  z-index: 1000;
+
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.info-dropdown.show {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.info-dropdown a {
+  display: block;
+  padding: 0.8em 1em;
+  text-decoration: none;
+  color: inherit;
+  font-size: 1rem;
+  transition: background 0.2s ease;
+}
+
+.info-dropdown a:hover {
+  background-color: #f5f5f5;
+}
+
 /* ▼ ログアウトボタン（従来のスタイル） */
 .logout-btn {
   padding: 0.4em 1em;
@@ -118,6 +176,21 @@
   }
 
   .parent-dropdown button {
+    padding: 0.6em 1em;
+  }
+
+  #info-menu-btn {
+    font-size: 1.2rem;
+    padding: 0.5em 0.8em;
+  }
+
+  .info-dropdown {
+    min-width: 140px;
+    font-size: 0.9rem;
+    right: 0.5em;
+  }
+
+  .info-dropdown a {
     padding: 0.6em 1em;
   }
 }

--- a/external.html
+++ b/external.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>外部送信ポリシー</title>
+</head>
+<body>
+  <h1>外部送信ポリシー</h1>
+  <p>ここに外部送信ポリシーの本文が入ります。</p>
+</body>
+</html>

--- a/law.html
+++ b/law.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>特定商取引法に基づく表示</title>
+</head>
+<body>
+  <h1>特定商取引法に基づく表示</h1>
+  <p>ここに特定商取引法に基づく表示の本文が入ります。</p>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>プライバシーポリシー</title>
+</head>
+<body>
+  <h1>プライバシーポリシー</h1>
+  <p>ここにプライバシーポリシーの本文が入ります。</p>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>利用規約</title>
+</head>
+<body>
+  <h1>利用規約</h1>
+  <p>ここに利用規約の本文が入ります。</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create simple static pages for terms, privacy, law, external policy and contact
- add new Info dropdown in header
- style Info dropdown and button

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_b_683edb56bd14832389b8a5315d65cbd6