### PR TITLE
Add headers to information pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -4,8 +4,26 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>お問い合わせ | オトロン</title>
+  <link rel="stylesheet" href="css/common.css" />
+  <link rel="stylesheet" href="css/header.css" />
 </head>
-<body>
+<body class="app-root with-header">
+  <header class="app-header">
+    <a class="home-icon" href="/">
+      <img src="images/otolon_face.webp" alt="ホーム" />
+    </a>
+    <a class="training-header-button" href="/">とれーにんぐ</a>
+    <div class="info-menu">
+      <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
+      <div id="info-dropdown" class="info-dropdown">
+        <a href="terms.html">利用規約</a>
+        <a href="privacy.html">プライバシーポリシー</a>
+        <a href="contact.html">お問い合わせ</a>
+        <a href="law.html">特定商取引法に基づく表示</a>
+        <a href="external.html">外部送信ポリシー</a>
+      </div>
+    </div>
+  </header>
   <h1>お問い合わせ</h1>
 
   <p>オトロンをご利用いただきありがとうございます。<br>
@@ -23,4 +41,17 @@
   <hr />
   <p>2025年6月 作成</p>
 </body>
+<script>
+  const infoBtn = document.getElementById('info-menu-btn');
+  const infoDropdown = document.getElementById('info-dropdown');
+  infoBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    infoDropdown.classList.toggle('show');
+  });
+  document.addEventListener('click', (e) => {
+    if (!infoDropdown.contains(e.target) && e.target !== infoBtn) {
+      infoDropdown.classList.remove('show');
+    }
+  });
+</script>
 </html>

--- a/css/common.css
+++ b/css/common.css
@@ -35,7 +35,8 @@
 }
 
 /* ヘッダー表示時に余白を確保 */
-#app.with-header {
+#app.with-header,
+body.with-header {
   padding-top: 56px;
 }
 

--- a/external.html
+++ b/external.html
@@ -4,8 +4,26 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>外部送信ポリシー | オトロン</title>
+  <link rel="stylesheet" href="css/common.css" />
+  <link rel="stylesheet" href="css/header.css" />
 </head>
-<body>
+<body class="app-root with-header">
+  <header class="app-header">
+    <a class="home-icon" href="/">
+      <img src="images/otolon_face.webp" alt="ホーム" />
+    </a>
+    <a class="training-header-button" href="/">とれーにんぐ</a>
+    <div class="info-menu">
+      <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
+      <div id="info-dropdown" class="info-dropdown">
+        <a href="terms.html">利用規約</a>
+        <a href="privacy.html">プライバシーポリシー</a>
+        <a href="contact.html">お問い合わせ</a>
+        <a href="law.html">特定商取引法に基づく表示</a>
+        <a href="external.html">外部送信ポリシー</a>
+      </div>
+    </div>
+  </header>
   <h1>外部送信ポリシー</h1>
 
   <p>この外部送信ポリシー（以下、「本ポリシー」といいます）は、オトロン（以下、「本サービス」といいます）をご利用いただく際に、ユーザーの端末から第三者に送信される情報とその目的・送信先等についてご案内するものです。</p>
@@ -40,4 +58,17 @@
   <hr />
   <p>2025年6月 作成</p>
 </body>
+<script>
+  const infoBtn = document.getElementById('info-menu-btn');
+  const infoDropdown = document.getElementById('info-dropdown');
+  infoBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    infoDropdown.classList.toggle('show');
+  });
+  document.addEventListener('click', (e) => {
+    if (!infoDropdown.contains(e.target) && e.target !== infoBtn) {
+      infoDropdown.classList.remove('show');
+    }
+  });
+</script>
 </html>

--- a/law.html
+++ b/law.html
@@ -4,8 +4,26 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>特定商取引法に基づく表示 | オトロン</title>
+  <link rel="stylesheet" href="css/common.css" />
+  <link rel="stylesheet" href="css/header.css" />
 </head>
-<body>
+<body class="app-root with-header">
+  <header class="app-header">
+    <a class="home-icon" href="/">
+      <img src="images/otolon_face.webp" alt="ホーム" />
+    </a>
+    <a class="training-header-button" href="/">とれーにんぐ</a>
+    <div class="info-menu">
+      <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
+      <div id="info-dropdown" class="info-dropdown">
+        <a href="terms.html">利用規約</a>
+        <a href="privacy.html">プライバシーポリシー</a>
+        <a href="contact.html">お問い合わせ</a>
+        <a href="law.html">特定商取引法に基づく表示</a>
+        <a href="external.html">外部送信ポリシー</a>
+      </div>
+    </div>
+  </header>
   <h1>特定商取引法に基づく表示</h1>
 
   <h2>事業者</h2>
@@ -47,4 +65,17 @@
   <hr />
   <p>2025年6月 作成</p>
 </body>
+<script>
+  const infoBtn = document.getElementById('info-menu-btn');
+  const infoDropdown = document.getElementById('info-dropdown');
+  infoBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    infoDropdown.classList.toggle('show');
+  });
+  document.addEventListener('click', (e) => {
+    if (!infoDropdown.contains(e.target) && e.target !== infoBtn) {
+      infoDropdown.classList.remove('show');
+    }
+  });
+</script>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -4,8 +4,26 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>プライバシーポリシー | オトロン</title>
+  <link rel="stylesheet" href="css/common.css" />
+  <link rel="stylesheet" href="css/header.css" />
 </head>
-<body>
+<body class="app-root with-header">
+  <header class="app-header">
+    <a class="home-icon" href="/">
+      <img src="images/otolon_face.webp" alt="ホーム" />
+    </a>
+    <a class="training-header-button" href="/">とれーにんぐ</a>
+    <div class="info-menu">
+      <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
+      <div id="info-dropdown" class="info-dropdown">
+        <a href="terms.html">利用規約</a>
+        <a href="privacy.html">プライバシーポリシー</a>
+        <a href="contact.html">お問い合わせ</a>
+        <a href="law.html">特定商取引法に基づく表示</a>
+        <a href="external.html">外部送信ポリシー</a>
+      </div>
+    </div>
+  </header>
   <h1>プライバシーポリシー</h1>
 
   <p>本プライバシーポリシー（以下、「本ポリシー」といいます。）は、オトロン（以下、「本サービス」といいます。）の提供にあたり、ユーザーの個人情報を適切に取り扱う方針を定めたものです。個人運営者である当方は、関連する法令（個人情報保護法など）を遵守し、本サービスを利用するすべてのユーザー（以下、「ユーザー」といいます。）のプライバシーを尊重します。</p>
@@ -61,4 +79,17 @@
   <h2>第9条（プライバシーポリシーの変更）</h2>
   <p>本ポリシーは、必要に応じて事前の予告なく変更されることがあります。重要な変更がある場合は、Webサイト上またはサービス内で通知します。</p>
 </body>
+<script>
+  const infoBtn = document.getElementById('info-menu-btn');
+  const infoDropdown = document.getElementById('info-dropdown');
+  infoBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    infoDropdown.classList.toggle('show');
+  });
+  document.addEventListener('click', (e) => {
+    if (!infoDropdown.contains(e.target) && e.target !== infoBtn) {
+      infoDropdown.classList.remove('show');
+    }
+  });
+</script>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -4,8 +4,26 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>利用規約 | オトロン</title>
+  <link rel="stylesheet" href="css/common.css" />
+  <link rel="stylesheet" href="css/header.css" />
 </head>
-<body>
+<body class="app-root with-header">
+  <header class="app-header">
+    <a class="home-icon" href="/">
+      <img src="images/otolon_face.webp" alt="ホーム" />
+    </a>
+    <a class="training-header-button" href="/">とれーにんぐ</a>
+    <div class="info-menu">
+      <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
+      <div id="info-dropdown" class="info-dropdown">
+        <a href="terms.html">利用規約</a>
+        <a href="privacy.html">プライバシーポリシー</a>
+        <a href="contact.html">お問い合わせ</a>
+        <a href="law.html">特定商取引法に基づく表示</a>
+        <a href="external.html">外部送信ポリシー</a>
+      </div>
+    </div>
+  </header>
   <h1>利用規約</h1>
 
   <p>この利用規約（以下、「本規約」といいます。）は、オトロン（以下、「本サービス」といいます。）の利用条件を定めるものであり、本サービスを利用するすべてのユーザー（以下、「ユーザー」といいます。）に適用されます。本サービスは、個人により運営されており、関連する法令およびガイドライン（消費者契約法、電気通信事業法など）を遵守しています。</p>
@@ -72,4 +90,17 @@
   <hr />
   <p>2025年6月 作成</p>
 </body>
+<script>
+  const infoBtn = document.getElementById('info-menu-btn');
+  const infoDropdown = document.getElementById('info-dropdown');
+  infoBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    infoDropdown.classList.toggle('show');
+  });
+  document.addEventListener('click', (e) => {
+    if (!infoDropdown.contains(e.target) && e.target !== infoBtn) {
+      infoDropdown.classList.remove('show');
+    }
+  });
+</script>
 </html>


### PR DESCRIPTION
## Summary
- add common header markup to contact, external, law, privacy and terms pages
- include header styles and simple JS for dropdown on each page
- support body.with-header in common.css

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683ee540d4a88323b65c7e72820fcf70