### PR TITLE
Unify info pages with main style

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -4,15 +4,31 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>お問い合わせ | オトロン</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="css/common.css" />
   <link rel="stylesheet" href="css/header.css" />
+  <link rel="stylesheet" href="css/info.css" />
 </head>
 <body class="app-root with-header">
   <header class="app-header">
-    <a class="home-icon" href="/">
+    <a class="home-icon" href="index.html#home">
       <img src="images/otolon_face.webp" alt="ホーム" />
     </a>
-    <a class="training-header-button" href="/">とれーにんぐ</a>
+    <a class="training-header-button" href="index.html#training">とれーにんぐ</a>
+
+    <div class="parent-menu">
+      <button id="parent-menu-btn" aria-label="設定">⚙️</button>
+      <div id="parent-dropdown" class="parent-dropdown">
+        <a href="index.html#settings">⚙️ 設定</a>
+        <a href="index.html#result">📊 分析画面</a>
+        <a href="index.html#mypage">👤 マイページ</a>
+        <a href="index.html#growth">🌱 育成モード</a>
+        <a href="index.html#intro">🚪 ログアウト</a>
+      </div>
+    </div>
+
     <div class="info-menu">
       <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
       <div id="info-dropdown" class="info-dropdown">
@@ -24,34 +40,24 @@
       </div>
     </div>
   </header>
-  <h1>お問い合わせ</h1>
+  <main class="info-page">
+    <h1>お問い合わせ</h1>
 
-  <p>オトロンをご利用いただきありがとうございます。<br>
-  ご不明な点やご質問は、下記のメールアドレス宛にご連絡ください。</p>
+    <p>オトロンをご利用いただきありがとうございます。<br>
+    ご不明な点やご質問は、下記のメールアドレス宛にご連絡ください。</p>
 
-  <h2>連絡先</h2>
-  <p>メールアドレス：<strong>otoron.app@example.com</strong></p>
+    <h2>連絡先</h2>
+    <p>メールアドレス：<strong>otoron.app@example.com</strong></p>
 
-  <p>※内容により返信まで数日いただく場合があります。<br>
-  ※迷惑メールフォルダもご確認ください。</p>
+    <p>※内容により返信まで数日いただく場合があります。<br>
+    ※迷惑メールフォルダもご確認ください。</p>
 
-  <h2>よくあるご質問</h2>
-  <p>お急ぎの方は、<a href="/help.html">ヘルプ・操作マニュアル</a> もあわせてご覧ください。</p>
+    <h2>よくあるご質問</h2>
+    <p>お急ぎの方は、<a href="/help.html">ヘルプ・操作マニュアル</a> もあわせてご覧ください。</p>
 
-  <hr />
-  <p>2025年6月 作成</p>
+    <hr />
+    <p>2025年6月 作成</p>
+  </main>
 </body>
-<script>
-  const infoBtn = document.getElementById('info-menu-btn');
-  const infoDropdown = document.getElementById('info-dropdown');
-  infoBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    infoDropdown.classList.toggle('show');
-  });
-  document.addEventListener('click', (e) => {
-    if (!infoDropdown.contains(e.target) && e.target !== infoBtn) {
-      infoDropdown.classList.remove('show');
-    }
-  });
-</script>
+<script type="module" src="info-page.js"></script>
 </html>

--- a/css/header.css
+++ b/css/header.css
@@ -89,6 +89,20 @@
   background-color: #f5f5f5;
 }
 
+/* Anchor style for static pages */
+.parent-dropdown a {
+  display: block;
+  padding: 0.8em 1em;
+  text-decoration: none;
+  color: inherit;
+  font-size: 1rem;
+  transition: background 0.2s ease;
+}
+
+.parent-dropdown a:hover {
+  background-color: #f5f5f5;
+}
+
 /* ▼ インフォメーションメニュー */
 .info-menu {
   position: relative;

--- a/css/info.css
+++ b/css/info.css
@@ -1,0 +1,23 @@
+.info-page {
+  max-width: 800px;
+  margin: 1em auto;
+  padding: 0 1em 2em;
+  box-sizing: border-box;
+  color: #543014;
+  line-height: 1.7;
+}
+
+.info-page h1 {
+  text-align: center;
+  font-size: 1.6rem;
+  margin-bottom: 0.8em;
+}
+
+.info-page h2 {
+  margin-top: 1.4em;
+  font-size: 1.3rem;
+}
+
+.info-page a {
+  color: #0645ad;
+}

--- a/external.html
+++ b/external.html
@@ -4,15 +4,31 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>外部送信ポリシー | オトロン</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="css/common.css" />
   <link rel="stylesheet" href="css/header.css" />
+  <link rel="stylesheet" href="css/info.css" />
 </head>
 <body class="app-root with-header">
   <header class="app-header">
-    <a class="home-icon" href="/">
+    <a class="home-icon" href="index.html#home">
       <img src="images/otolon_face.webp" alt="ホーム" />
     </a>
-    <a class="training-header-button" href="/">とれーにんぐ</a>
+    <a class="training-header-button" href="index.html#training">とれーにんぐ</a>
+
+    <div class="parent-menu">
+      <button id="parent-menu-btn" aria-label="設定">⚙️</button>
+      <div id="parent-dropdown" class="parent-dropdown">
+        <a href="index.html#settings">⚙️ 設定</a>
+        <a href="index.html#result">📊 分析画面</a>
+        <a href="index.html#mypage">👤 マイページ</a>
+        <a href="index.html#growth">🌱 育成モード</a>
+        <a href="index.html#intro">🚪 ログアウト</a>
+      </div>
+    </div>
+
     <div class="info-menu">
       <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
       <div id="info-dropdown" class="info-dropdown">
@@ -24,7 +40,8 @@
       </div>
     </div>
   </header>
-  <h1>外部送信ポリシー</h1>
+  <main class="info-page">
+    <h1>外部送信ポリシー</h1>
 
   <p>この外部送信ポリシー（以下、「本ポリシー」といいます）は、オトロン（以下、「本サービス」といいます）をご利用いただく際に、ユーザーの端末から第三者に送信される情報とその目的・送信先等についてご案内するものです。</p>
 
@@ -55,20 +72,9 @@
   <h2>更新について</h2>
   <p>本ポリシーは必要に応じて変更されることがあります。重要な変更がある場合には、本サービス内またはWebサイト上でお知らせいたします。</p>
 
-  <hr />
-  <p>2025年6月 作成</p>
+    <hr />
+    <p>2025年6月 作成</p>
+  </main>
 </body>
-<script>
-  const infoBtn = document.getElementById('info-menu-btn');
-  const infoDropdown = document.getElementById('info-dropdown');
-  infoBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    infoDropdown.classList.toggle('show');
-  });
-  document.addEventListener('click', (e) => {
-    if (!infoDropdown.contains(e.target) && e.target !== infoBtn) {
-      infoDropdown.classList.remove('show');
-    }
-  });
-</script>
+<script type="module" src="info-page.js"></script>
 </html>

--- a/info-page.js
+++ b/info-page.js
@@ -1,0 +1,33 @@
+import { getTimeOfDay } from './utils/timeOfDay.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.body.classList.add(getTimeOfDay());
+
+  const parentBtn = document.getElementById('parent-menu-btn');
+  const parentDropdown = document.getElementById('parent-dropdown');
+  const infoBtn = document.getElementById('info-menu-btn');
+  const infoDropdown = document.getElementById('info-dropdown');
+
+  if (parentBtn && parentDropdown) {
+    parentBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      parentDropdown.classList.toggle('show');
+    });
+  }
+
+  if (infoBtn && infoDropdown) {
+    infoBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      infoDropdown.classList.toggle('show');
+    });
+  }
+
+  document.addEventListener('click', (e) => {
+    if (parentDropdown && !parentDropdown.contains(e.target) && e.target !== parentBtn) {
+      parentDropdown.classList.remove('show');
+    }
+    if (infoDropdown && !infoDropdown.contains(e.target) && e.target !== infoBtn) {
+      infoDropdown.classList.remove('show');
+    }
+  });
+});

--- a/law.html
+++ b/law.html
@@ -4,15 +4,31 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>特定商取引法に基づく表示 | オトロン</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="css/common.css" />
   <link rel="stylesheet" href="css/header.css" />
+  <link rel="stylesheet" href="css/info.css" />
 </head>
 <body class="app-root with-header">
   <header class="app-header">
-    <a class="home-icon" href="/">
+    <a class="home-icon" href="index.html#home">
       <img src="images/otolon_face.webp" alt="ホーム" />
     </a>
-    <a class="training-header-button" href="/">とれーにんぐ</a>
+    <a class="training-header-button" href="index.html#training">とれーにんぐ</a>
+
+    <div class="parent-menu">
+      <button id="parent-menu-btn" aria-label="設定">⚙️</button>
+      <div id="parent-dropdown" class="parent-dropdown">
+        <a href="index.html#settings">⚙️ 設定</a>
+        <a href="index.html#result">📊 分析画面</a>
+        <a href="index.html#mypage">👤 マイページ</a>
+        <a href="index.html#growth">🌱 育成モード</a>
+        <a href="index.html#intro">🚪 ログアウト</a>
+      </div>
+    </div>
+
     <div class="info-menu">
       <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
       <div id="info-dropdown" class="info-dropdown">
@@ -24,7 +40,8 @@
       </div>
     </div>
   </header>
-  <h1>特定商取引法に基づく表示</h1>
+  <main class="info-page">
+    <h1>特定商取引法に基づく表示</h1>
 
   <h2>事業者</h2>
   <p>個人運営（氏名・住所は取引時に請求があれば開示いたします）</p>
@@ -64,18 +81,7 @@
 
   <hr />
   <p>2025年6月 作成</p>
+  </main>
 </body>
-<script>
-  const infoBtn = document.getElementById('info-menu-btn');
-  const infoDropdown = document.getElementById('info-dropdown');
-  infoBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    infoDropdown.classList.toggle('show');
-  });
-  document.addEventListener('click', (e) => {
-    if (!infoDropdown.contains(e.target) && e.target !== infoBtn) {
-      infoDropdown.classList.remove('show');
-    }
-  });
-</script>
+<script type="module" src="info-page.js"></script>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -4,15 +4,31 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>プライバシーポリシー | オトロン</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="css/common.css" />
   <link rel="stylesheet" href="css/header.css" />
+  <link rel="stylesheet" href="css/info.css" />
 </head>
 <body class="app-root with-header">
   <header class="app-header">
-    <a class="home-icon" href="/">
+    <a class="home-icon" href="index.html#home">
       <img src="images/otolon_face.webp" alt="ホーム" />
     </a>
-    <a class="training-header-button" href="/">とれーにんぐ</a>
+    <a class="training-header-button" href="index.html#training">とれーにんぐ</a>
+
+    <div class="parent-menu">
+      <button id="parent-menu-btn" aria-label="設定">⚙️</button>
+      <div id="parent-dropdown" class="parent-dropdown">
+        <a href="index.html#settings">⚙️ 設定</a>
+        <a href="index.html#result">📊 分析画面</a>
+        <a href="index.html#mypage">👤 マイページ</a>
+        <a href="index.html#growth">🌱 育成モード</a>
+        <a href="index.html#intro">🚪 ログアウト</a>
+      </div>
+    </div>
+
     <div class="info-menu">
       <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
       <div id="info-dropdown" class="info-dropdown">
@@ -24,7 +40,8 @@
       </div>
     </div>
   </header>
-  <h1>プライバシーポリシー</h1>
+  <main class="info-page">
+    <h1>プライバシーポリシー</h1>
 
   <p>本プライバシーポリシー（以下、「本ポリシー」といいます。）は、オトロン（以下、「本サービス」といいます。）の提供にあたり、ユーザーの個人情報を適切に取り扱う方針を定めたものです。個人運営者である当方は、関連する法令（個人情報保護法など）を遵守し、本サービスを利用するすべてのユーザー（以下、「ユーザー」といいます。）のプライバシーを尊重します。</p>
 
@@ -78,18 +95,7 @@
 
   <h2>第9条（プライバシーポリシーの変更）</h2>
   <p>本ポリシーは、必要に応じて事前の予告なく変更されることがあります。重要な変更がある場合は、Webサイト上またはサービス内で通知します。</p>
+  </main>
 </body>
-<script>
-  const infoBtn = document.getElementById('info-menu-btn');
-  const infoDropdown = document.getElementById('info-dropdown');
-  infoBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    infoDropdown.classList.toggle('show');
-  });
-  document.addEventListener('click', (e) => {
-    if (!infoDropdown.contains(e.target) && e.target !== infoBtn) {
-      infoDropdown.classList.remove('show');
-    }
-  });
-</script>
+<script type="module" src="info-page.js"></script>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -4,15 +4,31 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>利用規約 | オトロン</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="css/common.css" />
   <link rel="stylesheet" href="css/header.css" />
+  <link rel="stylesheet" href="css/info.css" />
 </head>
 <body class="app-root with-header">
   <header class="app-header">
-    <a class="home-icon" href="/">
+    <a class="home-icon" href="index.html#home">
       <img src="images/otolon_face.webp" alt="ホーム" />
     </a>
-    <a class="training-header-button" href="/">とれーにんぐ</a>
+    <a class="training-header-button" href="index.html#training">とれーにんぐ</a>
+
+    <div class="parent-menu">
+      <button id="parent-menu-btn" aria-label="設定">⚙️</button>
+      <div id="parent-dropdown" class="parent-dropdown">
+        <a href="index.html#settings">⚙️ 設定</a>
+        <a href="index.html#result">📊 分析画面</a>
+        <a href="index.html#mypage">👤 マイページ</a>
+        <a href="index.html#growth">🌱 育成モード</a>
+        <a href="index.html#intro">🚪 ログアウト</a>
+      </div>
+    </div>
+
     <div class="info-menu">
       <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
       <div id="info-dropdown" class="info-dropdown">
@@ -24,7 +40,8 @@
       </div>
     </div>
   </header>
-  <h1>利用規約</h1>
+  <main class="info-page">
+    <h1>利用規約</h1>
 
   <p>この利用規約（以下、「本規約」といいます。）は、オトロン（以下、「本サービス」といいます。）の利用条件を定めるものであり、本サービスを利用するすべてのユーザー（以下、「ユーザー」といいます。）に適用されます。本サービスは、個人により運営されており、関連する法令およびガイドライン（消費者契約法、電気通信事業法など）を遵守しています。</p>
 
@@ -89,18 +106,7 @@
 
   <hr />
   <p>2025年6月 作成</p>
+  </main>
 </body>
-<script>
-  const infoBtn = document.getElementById('info-menu-btn');
-  const infoDropdown = document.getElementById('info-dropdown');
-  infoBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    infoDropdown.classList.toggle('show');
-  });
-  document.addEventListener('click', (e) => {
-    if (!infoDropdown.contains(e.target) && e.target !== infoBtn) {
-      infoDropdown.classList.remove('show');
-    }
-  });
-</script>
+<script type="module" src="info-page.js"></script>
 </html>


### PR DESCRIPTION
## Summary
- add `info.css` styling for information pages
- create `info-page.js` to apply header behaviors and time-of-day styles
- update header.css to style dropdown links
- redesign information pages with new header markup and layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683ee6ce276c8323aed43b2349c27e8d