### PR TITLE
Fix info page styling

### DIFF
--- a/components/info/contact.js
+++ b/components/info/contact.js
@@ -5,7 +5,6 @@ export function renderContactScreen() {
   const app = document.getElementById("app");
   app.innerHTML = "";
   renderHeader(app);
-  document.body.classList.add(getTimeOfDay());
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/external.js
+++ b/components/info/external.js
@@ -5,7 +5,6 @@ export function renderExternalScreen() {
   const app = document.getElementById("app");
   app.innerHTML = "";
   renderHeader(app);
-  document.body.classList.add(getTimeOfDay());
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/law.js
+++ b/components/info/law.js
@@ -5,7 +5,6 @@ export function renderLawScreen() {
   const app = document.getElementById("app");
   app.innerHTML = "";
   renderHeader(app);
-  document.body.classList.add(getTimeOfDay());
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/privacy.js
+++ b/components/info/privacy.js
@@ -5,7 +5,6 @@ export function renderPrivacyScreen() {
   const app = document.getElementById("app");
   app.innerHTML = "";
   renderHeader(app);
-  document.body.classList.add(getTimeOfDay());
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/terms.js
+++ b/components/info/terms.js
@@ -5,7 +5,6 @@ export function renderTermsScreen() {
   const app = document.getElementById("app");
   app.innerHTML = "";
   renderHeader(app);
-  document.body.classList.add(getTimeOfDay());
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/css/header.css
+++ b/css/header.css
@@ -134,7 +134,7 @@
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   padding: 0.5em 0;
   min-width: 180px;
-  z-index: 1000;
+  z-index: 1100;
 
   opacity: 0;
   transform: translateY(-10px);

--- a/css/info.css
+++ b/css/info.css
@@ -3,8 +3,16 @@
   margin: 1em auto;
   padding: 0 1em 2em;
   box-sizing: border-box;
+  background: #fff;
   color: #543014;
   line-height: 1.7;
+  border-radius: 8px;
+}
+
+/* Ensure readability even when the body has a dark background */
+.app-root.night .info-page {
+  background: #fff;
+  color: #543014;
 }
 
 .info-page h1 {

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <link rel="stylesheet" href="css/summary.css" />
   <link rel="stylesheet" href="css/growth.css" />
   <link rel="stylesheet" href="css/mypage.css" />
+  <link rel="stylesheet" href="css/info.css" />
   <link rel="stylesheet" href="css/setup.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
 </head>


### PR DESCRIPTION
## Summary
- include `info.css` in `index.html`
- add background to info pages for readability
- ensure info pages don't apply time-of-day theme
- raise z-index of header info dropdown

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683eeac10370832397ee289347890202