### PR TITLE
Swap header icons and adjust dropdown styles

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -14,17 +14,6 @@ export function renderHeader(container) {
       とれーにんぐ
     </button>
 
-    <div class="parent-menu">
-      <button id="parent-menu-btn" aria-label="設定">⚙️</button>
-      <div id="parent-dropdown" class="parent-dropdown">
-        <button id="settings-btn">⚙️ 設定</button>
-        <button id="summary-btn">📊 分析画面</button>
-        <button id="mypage-btn">👤 マイページ</button>
-        <button id="growth-btn">🌱 育成モード</button>
-        <button id="logout-btn">🚪 ログアウト</button>
-      </div>
-    </div>
-
     <div class="info-menu">
       <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
       <div id="info-dropdown" class="info-dropdown">
@@ -33,6 +22,17 @@ export function renderHeader(container) {
         <button id="contact-btn">お問い合わせ</button>
         <button id="law-btn">特定商取引法に基づく表示</button>
         <button id="external-btn">外部送信ポリシー</button>
+      </div>
+    </div>
+
+    <div class="parent-menu">
+      <button id="parent-menu-btn" aria-label="設定">⚙️</button>
+      <div id="parent-dropdown" class="parent-dropdown">
+        <button id="settings-btn">⚙️ 設定</button>
+        <button id="summary-btn">📊 分析画面</button>
+        <button id="mypage-btn">👤 マイページ</button>
+        <button id="growth-btn">🌱 育成モード</button>
+        <button id="logout-btn">🚪 ログアウト</button>
       </div>
     </div>
   `;

--- a/css/header.css
+++ b/css/header.css
@@ -57,7 +57,7 @@
   border-radius: 8px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   padding: 0.5em 0;
-  min-width: 180px;
+  min-width: 220px;
   z-index: 1000;
 
   opacity: 0;
@@ -82,6 +82,7 @@
   text-align: left;
   font-size: 1rem;
   cursor: pointer;
+  white-space: nowrap;
   transition: background 0.2s ease;
 }
 
@@ -129,11 +130,11 @@
   right: 0;
   top: 100%;
   background: #fff;
-  border: 1px solid #ccc;
+  border: none;
   border-radius: 8px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   padding: 0.5em 0;
-  min-width: 180px;
+  min-width: 220px;
   z-index: 1100;
 
   opacity: 0;
@@ -148,15 +149,22 @@
   pointer-events: auto;
 }
 
+.info-dropdown button,
 .info-dropdown a {
   display: block;
   padding: 0.8em 1em;
   text-decoration: none;
+  background: none;
+  border: none;
   color: inherit;
   font-size: 1rem;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
   transition: background 0.2s ease;
 }
 
+.info-dropdown button:hover,
 .info-dropdown a:hover {
   background-color: #f5f5f5;
 }
@@ -184,7 +192,7 @@
   }
 
   .parent-dropdown {
-    min-width: 140px;
+    min-width: 180px;
     font-size: 0.9rem;
     right: 0.5em;
   }
@@ -199,11 +207,12 @@
   }
 
   .info-dropdown {
-    min-width: 140px;
+    min-width: 180px;
     font-size: 0.9rem;
     right: 0.5em;
   }
 
+  .info-dropdown button,
   .info-dropdown a {
     padding: 0.6em 1em;
   }


### PR DESCRIPTION
## Summary
- swap information and settings icon order
- widen dropdowns to prevent line wrapping
- remove info dropdown border and apply consistent styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683eeec472a08323a1bfe6ce5d2452e5