### PR TITLE
Add info button next to settings

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -14,25 +14,27 @@ export function renderHeader(container) {
       とれーにんぐ
     </button>
 
-    <div class="info-menu">
-      <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
-      <div id="info-dropdown" class="info-dropdown">
-        <button id="terms-btn">利用規約</button>
-        <button id="privacy-btn">プライバシーポリシー</button>
-        <button id="contact-btn">お問い合わせ</button>
-        <button id="law-btn">特定商取引法に基づく表示</button>
-        <button id="external-btn">外部送信ポリシー</button>
+    <div class="header-right">
+      <div class="info-menu">
+        <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
+        <div id="info-dropdown" class="info-dropdown">
+          <button id="terms-btn">利用規約</button>
+          <button id="privacy-btn">プライバシーポリシー</button>
+          <button id="contact-btn">お問い合わせ</button>
+          <button id="law-btn">特定商取引法に基づく表示</button>
+          <button id="external-btn">外部送信ポリシー</button>
+        </div>
       </div>
-    </div>
 
-    <div class="parent-menu">
-      <button id="parent-menu-btn" aria-label="設定">⚙️</button>
-      <div id="parent-dropdown" class="parent-dropdown">
-        <button id="settings-btn">⚙️ 設定</button>
-        <button id="summary-btn">📊 分析画面</button>
-        <button id="mypage-btn">👤 マイページ</button>
-        <button id="growth-btn">🌱 育成モード</button>
-        <button id="logout-btn">🚪 ログアウト</button>
+      <div class="parent-menu">
+        <button id="parent-menu-btn" aria-label="設定">⚙️</button>
+        <div id="parent-dropdown" class="parent-dropdown">
+          <button id="settings-btn">⚙️ 設定</button>
+          <button id="summary-btn">📊 分析画面</button>
+          <button id="mypage-btn">👤 マイページ</button>
+          <button id="growth-btn">🌱 育成モード</button>
+          <button id="logout-btn">🚪 ログアウト</button>
+        </div>
       </div>
     </div>
   `;

--- a/css/header.css
+++ b/css/header.css
@@ -20,23 +20,25 @@
   font-size: 1.2rem;
 }
 
+
 .header-right {
   display: flex;
   align-items: center;
+  margin-left: auto;
 }
 
 /* ▼ 親メニュー全体 */
 .parent-menu {
-  margin-left: auto;
   position: relative;
   display: inline-block;
+  margin-left: 0.2em;
 }
 
 /* ▼ 親メニューボタン */
 #parent-menu-btn {
   background: transparent;
   border: none;
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   cursor: pointer;
   padding: 0.5em 1em;
   transition: background-color 0.2s ease;
@@ -187,7 +189,7 @@
 /* ▼ モバイル対応 */
 @media (max-width: 600px) {
   #parent-menu-btn {
-    font-size: 1.2rem;
+    font-size: 1.4rem;
     padding: 0.5em 0.8em;
   }
 


### PR DESCRIPTION
## Summary
- group info and settings buttons on the header's right side
- enlarge the settings button size

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_683ef1afedd88323ad9f643299e5e38a