### PR TITLE
Update day qualification based on dynamic chord counts

### DIFF
--- a/utils/chordQueue.js
+++ b/utils/chordQueue.js
@@ -27,7 +27,7 @@ export function generateChordQueue(chordNames) {
   return queue;
 }
 
-function getCounts(n) {
+export function getCounts(n) {
   const counts = [];
   if (n === 1) {
     counts.push(20);


### PR DESCRIPTION
## Summary
- export `getCounts` from `chordQueue.js`
- compute dynamic per-chord requirements and accuracy in `sessionMeetsStats`
- revise `markQualifiedDayIfNeeded` to aggregate all sessions and use the dynamic thresholds

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683f7aea3108832384fb8bdced4b4202