### PR TITLE
Fix menu toggling in header

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -52,12 +52,20 @@ export function renderHeader(container) {
 
   parentMenuBtn.onclick = (e) => {
     e.stopPropagation();
+    const willShow = !dropdown.classList.contains("show");
     dropdown.classList.toggle("show");
+    if (willShow) {
+      infoDropdown.classList.remove("show");
+    }
   };
 
   infoMenuBtn.onclick = (e) => {
     e.stopPropagation();
+    const willShow = !infoDropdown.classList.contains("show");
     infoDropdown.classList.toggle("show");
+    if (willShow) {
+      dropdown.classList.remove("show");
+    }
   };
 
   document.addEventListener("click", (e) => {


### PR DESCRIPTION
## Summary
- update header.js to close the info dropdown when opening the settings menu and vice versa

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684015bdf6b48323a03ca05094d86822