### PR TITLE
Fix info menu width

### DIFF
--- a/css/header.css
+++ b/css/header.css
@@ -154,6 +154,7 @@
 .info-dropdown button,
 .info-dropdown a {
   display: block;
+  width: 100%;
   padding: 0.8em 1em;
   text-decoration: none;
   background: none;
@@ -216,6 +217,7 @@
 
   .info-dropdown button,
   .info-dropdown a {
+    width: 100%;
     padding: 0.6em 1em;
   }
 }


### PR DESCRIPTION
## Summary
- make info dropdown buttons consistent width

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68403527fbd483238158625fa06f6e7d