### PR TITLE
Add pricing page

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -33,6 +33,7 @@ export function renderHeader(container) {
           <button id="summary-btn">📊 分析画面</button>
           <button id="mypage-btn">👤 マイページ</button>
           <button id="growth-btn">🌱 育成モード</button>
+          <button id="pricing-btn">💳 プラン</button>
           <button id="logout-btn">🚪 ログアウト</button>
         </div>
       </div>
@@ -94,6 +95,7 @@ export function renderHeader(container) {
   header.querySelector("#settings-btn").onclick = () => switchScreen("settings");
   header.querySelector("#summary-btn").onclick = () => switchScreen("result");
   header.querySelector("#growth-btn").onclick = () => switchScreen("growth");
+  header.querySelector("#pricing-btn").onclick = () => switchScreen("pricing");
 
   header.querySelector("#mypage-btn").onclick = () => switchScreen("mypage");
   // ▼ ログアウト処理

--- a/components/pricing.js
+++ b/components/pricing.js
@@ -1,0 +1,87 @@
+import { renderHeader } from './header.js';
+import { startCheckout } from '../utils/stripeCheckout.js';
+
+export function renderPricingScreen() {
+  const app = document.getElementById('app');
+  app.innerHTML = '';
+  renderHeader(app);
+
+  const main = document.createElement('main');
+  main.className = 'pricing-page';
+
+  const plans = [
+    {
+      months: 12,
+      monthly: 990,
+      total: 11880,
+      benefit: '約4ヶ月分お得',
+      priceId: 'price_1RWGURGGyh8a8OqPruLWkksD',
+      recommended: true,
+    },
+    {
+      months: 6,
+      monthly: 1290,
+      total: 7740,
+      benefit: '約1ヶ月分お得',
+      priceId: 'price_1RWGnSGGyh8a8OqPQxFPJXg0',
+      recommended: false,
+    },
+    {
+      months: 1,
+      monthly: 1490,
+      total: 1490,
+      benefit: '',
+      priceId: 'price_1RWGmmGGyh8a8OqPBX1DSJ8I',
+      recommended: false,
+    },
+  ];
+
+  plans.forEach((p) => {
+    const card = document.createElement('div');
+    card.className = 'plan-card' + (p.recommended ? ' recommended' : '');
+
+    if (p.recommended) {
+      const rec = document.createElement('div');
+      rec.className = 'recommend-badge';
+      rec.textContent = 'おすすめ';
+      card.appendChild(rec);
+    }
+
+    const title = document.createElement('div');
+    title.className = 'plan-title';
+    title.textContent = `${p.months}ヶ月プラン`;
+    card.appendChild(title);
+
+    const price = document.createElement('div');
+    price.className = 'monthly-price';
+    price.textContent = `税込 ${p.monthly.toLocaleString()}円／月`;
+    card.appendChild(price);
+
+    const total = document.createElement('div');
+    total.className = 'total-price';
+    total.textContent = `一括：${p.total.toLocaleString()}円`;
+    card.appendChild(total);
+
+    if (p.benefit) {
+      const badge = document.createElement('div');
+      badge.className = 'plan-badge';
+      badge.textContent = p.benefit;
+      card.appendChild(badge);
+    }
+
+    const btn = document.createElement('button');
+    btn.className = 'choose-plan';
+    btn.textContent = 'このプランを選ぶ';
+    btn.onclick = () => startCheckout(p.priceId);
+    card.appendChild(btn);
+
+    main.appendChild(card);
+  });
+
+  const note = document.createElement('p');
+  note.className = 'plan-note';
+  note.textContent = '※ プランの料金は、登録時に一括でお支払いいただきます';
+  main.appendChild(note);
+
+  app.appendChild(main);
+}

--- a/css/pricing.css
+++ b/css/pricing.css
@@ -1,0 +1,79 @@
+.pricing-page {
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 1em;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+}
+
+.plan-card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 1.2em;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6em;
+}
+
+.plan-card.recommended {
+  border: 2px solid #ff9900;
+}
+
+.plan-title {
+  font-size: 1.1rem;
+  font-weight: bold;
+}
+
+.monthly-price {
+  font-size: 1.6rem;
+  font-weight: bold;
+  color: #c15e00;
+}
+
+.total-price {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.plan-badge {
+  align-self: center;
+  background: #ffe6a5;
+  color: #c15e00;
+  border-radius: 999px;
+  padding: 0.2em 0.8em;
+  font-size: 0.8rem;
+}
+
+.recommend-badge {
+  align-self: flex-start;
+  background: #ff9900;
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.2em 0.8em;
+  font-size: 0.8rem;
+}
+
+.plan-card button {
+  margin-top: 0.6em;
+  padding: 0.8em;
+  font-size: 1rem;
+  background: #ffa500;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.plan-card button:hover {
+  background: #e38c00;
+}
+
+.plan-note {
+  font-size: 0.8rem;
+  text-align: center;
+  color: #666;
+  margin-top: 0.5em;
+}

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
   <link rel="stylesheet" href="css/growth.css" />
   <link rel="stylesheet" href="css/mypage.css" />
   <link rel="stylesheet" href="css/info.css" />
+  <link rel="stylesheet" href="css/pricing.css" />
   <link rel="stylesheet" href="css/setup.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
 </head>

--- a/main.js
+++ b/main.js
@@ -23,6 +23,7 @@ import { renderPrivacyScreen } from "./components/info/privacy.js";
 import { renderContactScreen } from "./components/info/contact.js";
 import { renderLawScreen } from "./components/info/law.js";
 import { renderExternalScreen } from "./components/info/external.js";
+import { renderPricingScreen } from "./components/pricing.js";
 
 
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.11.0/firebase-app.js";
@@ -91,6 +92,7 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   else if (screen === "contact") renderContactScreen();
   else if (screen === "law") renderLawScreen();
   else if (screen === "external") renderExternalScreen();
+  else if (screen === "pricing") renderPricingScreen();
 };
 
 // ブラウザ戻る/進む操作に対応


### PR DESCRIPTION
## Summary
- add `pricing.js` component to show subscription plans and Stripe checkout button
- add `pricing.css` for mobile friendly plan cards
- include pricing stylesheet in `index.html`
- route `#pricing` in main router and header menu

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68405a1429c88323a51a439497cbc147