### PR TITLE
Toggle password visibility with icons

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -15,7 +15,10 @@ export function renderLoginScreen(container, onLoginSuccess) {
       <h2 class="login-title">ログイン</h2>
       <form class="login-form">
         <input type="email" id="email" placeholder="メールアドレス" required />
-        <input type="password" id="password" placeholder="パスワード" required />
+        <div class="password-wrapper">
+          <input type="password" id="password" placeholder="パスワード" required />
+          <img src="images/Visibility_off.svg" class="toggle-password" alt="表示切替" />
+        </div>
         <button type="submit">ログイン</button>
       </form>
 
@@ -29,6 +32,14 @@ export function renderLoginScreen(container, onLoginSuccess) {
       </div>
     </div>
   `;
+
+  const pwInput = container.querySelector("#password");
+  const pwToggle = container.querySelector(".toggle-password");
+  pwToggle.addEventListener("click", () => {
+    const visible = pwInput.type === "text";
+    pwInput.type = visible ? "password" : "text";
+    pwToggle.src = visible ? "images/Visibility_off.svg" : "images/Visibility.svg";
+  });
 
 
 

--- a/components/mypage.js
+++ b/components/mypage.js
@@ -189,7 +189,21 @@ export function renderMyPageScreen(user) {
         input.value = sessionStorage.getItem("currentPassword") || "";
       }
 
-      field.appendChild(input);
+      const wrap = document.createElement("div");
+      wrap.className = "password-wrapper";
+      const toggle = document.createElement("img");
+      toggle.src = "images/Visibility_off.svg";
+      toggle.alt = "表示切替";
+      toggle.className = "toggle-password";
+      wrap.appendChild(input);
+      wrap.appendChild(toggle);
+      field.appendChild(wrap);
+
+      toggle.addEventListener("click", () => {
+        const visible = input.type === "text";
+        input.type = visible ? "password" : "text";
+        toggle.src = visible ? "images/Visibility_off.svg" : "images/Visibility.svg";
+      });
 
       return { field, input };
     }

--- a/components/signup.js
+++ b/components/signup.js
@@ -18,7 +18,10 @@ export function renderSignUpScreen() {
       <input type="email" id="signup-email" required />
 
       <label for="signup-password">パスワード（6文字以上）</label>
-      <input type="password" id="signup-password" required />
+      <div class="password-wrapper">
+        <input type="password" id="signup-password" required />
+        <img src="images/Visibility_off.svg" class="toggle-password" alt="表示切替" />
+      </div>
 
       <button type="submit" class="signup-button">アカウントを作成</button>
     </form>
@@ -32,6 +35,14 @@ export function renderSignUpScreen() {
   `;
 
   app.appendChild(container);
+
+  const pwInput = container.querySelector("#signup-password");
+  const pwToggle = container.querySelector(".toggle-password");
+  pwToggle.addEventListener("click", () => {
+    const visible = pwInput.type === "text";
+    pwInput.type = visible ? "password" : "text";
+    pwToggle.src = visible ? "images/Visibility_off.svg" : "images/Visibility.svg";
+  });
 
 
 

--- a/css/common.css
+++ b/css/common.css
@@ -95,4 +95,24 @@ button:hover {
   }
 }
 
+/* Password visibility toggle */
+.password-wrapper {
+  position: relative;
+}
+
+.password-wrapper input {
+  padding-right: 2.5rem;
+}
+
+.password-wrapper .toggle-password {
+  position: absolute;
+  top: 50%;
+  right: 0.6rem;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+}
+
+
 


### PR DESCRIPTION
## Summary
- add password visibility toggle icons and logic in login & signup screens
- support show/hide for password change form
- add shared CSS styles for the visibility toggle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684066225eb883239c027e1604274c7d