### PR TITLE
Fix password tab rendering

### DIFF
--- a/components/mypage.js
+++ b/components/mypage.js
@@ -219,7 +219,8 @@ export function renderMyPageScreen(user) {
     errorMsg.className = "password-error";
     errorMsg.textContent = "確認用パスワードが一致しません";
     errorMsg.style.display = "none";
-    confirm.field.insertBefore(errorMsg, confirm.field.querySelector("input"));
+    const wrapper = confirm.field.querySelector(".password-wrapper");
+    confirm.field.insertBefore(errorMsg, wrapper);
     form.appendChild(confirm.field);
 
     const btn = document.createElement("button");


### PR DESCRIPTION
## Summary
- fix insertBefore usage in password tab

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68406c64a0c08323afdfa5b72c13f0c1