### PR TITLE
Fix password field width

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -101,6 +101,7 @@ button:hover {
 }
 
 .password-wrapper input {
+  width: 100%;
   padding-right: 2.5rem;
 }
 

--- a/css/login.css
+++ b/css/login.css
@@ -28,6 +28,7 @@
 }
 
 .login-form input {
+  width: 100%;
   padding: 0.75rem;
   border: 1px solid #bbb;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- ensure password toggle sits inside the text box
- align password field width with email field

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68407ee797488323a56beda130a74d46