### PR TITLE
Fix password visibility icon layout

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -35,6 +35,11 @@
   font-size: 1rem;
 }
 
+/* Ensure space for the visibility toggle inside password fields */
+.login-form .password-wrapper input {
+  padding-right: 2.5rem;
+}
+
 .login-button {
   padding: 0.75rem;
   background: #0077cc;

--- a/css/mypage.css
+++ b/css/mypage.css
@@ -78,6 +78,11 @@
   font-size: 1rem;
 }
 
+/* Reserve space for the visibility toggle */
+.password-form .password-wrapper input {
+  padding-right: 2.5rem;
+}
+
 .profile-form button,
 .password-form button {
   padding: 0.8em;

--- a/css/signup.css
+++ b/css/signup.css
@@ -34,6 +34,11 @@
   font-size: 1rem;
 }
 
+/* Reserve space for the eye icon inside password inputs */
+.signup-form .password-wrapper input {
+  padding-right: 2.5rem;
+}
+
 .signup-button {
   padding: 0.75rem;
   background: #28a745;


### PR DESCRIPTION
## Summary
- keep login password eye icon inside the input
- reserve space in signup screen for password eye icon
- align password icon in My Page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840805043c0832388ae9ab69bd5e010