### PR TITLE
Add email storage and display

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -29,6 +29,7 @@ export function renderHeader(container) {
       <div class="parent-menu">
         <button id="parent-menu-btn" aria-label="設定">⚙️</button>
         <div id="parent-dropdown" class="parent-dropdown">
+          <div class="user-email" style="display:none"></div>
           <button id="settings-btn">⚙️ 設定</button>
           <button id="summary-btn">📊 分析画面</button>
           <button id="mypage-btn">👤 マイページ</button>
@@ -98,6 +99,12 @@ export function renderHeader(container) {
   header.querySelector("#pricing-btn").onclick = () => switchScreen("pricing");
 
   header.querySelector("#mypage-btn").onclick = () => switchScreen("mypage");
+  const emailDiv = header.querySelector(".user-email");
+  const email = firebaseAuth.currentUser?.email;
+  if (emailDiv && email) {
+    emailDiv.textContent = email;
+    emailDiv.style.display = "block";
+  }
   // ▼ ログアウト処理
   header.querySelector("#logout-btn").addEventListener("click", async () => {
     try {

--- a/components/login.js
+++ b/components/login.js
@@ -53,6 +53,18 @@ export function renderLoginScreen(container, onLoginSuccess) {
       .select("*")
       .eq("firebase_uid", user.uid)
       .maybeSingle();
+
+    if (existingUser && (!existingUser.email || existingUser.email !== user.email)) {
+      const { data: updated } = await supabase
+        .from("users")
+        .update({ email: user.email })
+        .eq("id", existingUser.id)
+        .select()
+        .maybeSingle();
+      if (updated) {
+        existingUser.email = updated.email;
+      }
+    }
   
     let userId;
   

--- a/css/header.css
+++ b/css/header.css
@@ -68,6 +68,14 @@
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
+/* User email display */
+.parent-dropdown .user-email {
+  padding: 0.5em 1em;
+  font-size: 0.9rem;
+  border-bottom: 1px solid #eee;
+  color: #555;
+}
+
 /* ▼ 表示状態 */
 .parent-dropdown.show {
   opacity: 1;

--- a/main.js
+++ b/main.js
@@ -122,6 +122,19 @@ onAuthStateChanged(auth, async (firebaseUser) => {
     return;
   }
 
+  // Ensure email is stored when existing user has no email
+  if (existingUser && (!existingUser.email || existingUser.email !== firebaseUser.email)) {
+    const { data: updated, error: updateError } = await supabase
+      .from("users")
+      .update({ email: firebaseUser.email })
+      .eq("id", existingUser.id)
+      .select()
+      .maybeSingle();
+    if (!updateError && updated) {
+      existingUser.email = updated.email;
+    }
+  }
+
   let user = existingUser;
 
   if (!user) {


### PR DESCRIPTION
## Summary
- update login flows to persist email in Supabase
- show current email inside header dropdown
- style email text in dropdown menu

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68408128ea5c83239e6da084027ae3bc