### PR TITLE
Remove home button from growth screen

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -262,11 +262,6 @@ export async function renderGrowthScreen(user) {
   }
 
 
-  const backBtn = document.createElement("button");
-  backBtn.textContent = "🏠 ホームに戻る";
-  backBtn.onclick = () => switchScreen("home", user);
-  backBtn.style.marginTop = "2em";
-  container.appendChild(backBtn);
 
   app.appendChild(container);
 


### PR DESCRIPTION
## Summary
- remove the bottom home link from the growth screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684086e1c5a883239b5dc218ce7f3c9f