### PR TITLE
Fix password input overflow

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -103,6 +103,7 @@ button:hover {
 .password-wrapper input {
   width: 100%;
   padding-right: 2.5rem;
+  box-sizing: border-box;
 }
 
 .password-wrapper .toggle-password {

--- a/css/login.css
+++ b/css/login.css
@@ -38,6 +38,7 @@
   border: 1px solid #bbb;
   border-radius: 6px;
   font-size: 1rem;
+  box-sizing: border-box;
 }
 
 /* Ensure space for the visibility toggle inside password fields */

--- a/css/mypage.css
+++ b/css/mypage.css
@@ -76,6 +76,7 @@
   border: 1px solid #ccc;
   border-radius: 6px;
   font-size: 1rem;
+  box-sizing: border-box;
 }
 
 /* Reserve space for the visibility toggle */

--- a/css/signup.css
+++ b/css/signup.css
@@ -32,6 +32,7 @@
   border: 1px solid #bbb;
   border-radius: 6px;
   font-size: 1rem;
+  box-sizing: border-box;
 }
 
 /* Reserve space for the eye icon inside password inputs */


### PR DESCRIPTION
## Summary
- prevent password input fields from overflowing
- ensure all form inputs use `box-sizing: border-box`

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_b_68416a961790832399276b588bcc0486