### PR TITLE
Improve dropdown user info and menu order

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -2,7 +2,7 @@ import { signOut } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-aut
 import { firebaseAuth } from "../firebase/firebase-init.js"; // ✅ これだけでOK
 import { switchScreen } from "../main.js";
 
-export function renderHeader(container) {
+export function renderHeader(container, user) {
   const header = document.createElement("header");
   header.className = "app-header";
   header.innerHTML = `
@@ -29,11 +29,11 @@ export function renderHeader(container) {
       <div class="parent-menu">
         <button id="parent-menu-btn" aria-label="設定">⚙️</button>
         <div id="parent-dropdown" class="parent-dropdown">
-          <div class="user-email" style="display:none"></div>
+          <div class="user-info" style="display:none"></div>
           <button id="settings-btn">⚙️ 設定</button>
           <button id="summary-btn">📊 分析画面</button>
-          <button id="mypage-btn">👤 マイページ</button>
           <button id="growth-btn">🌱 育成モード</button>
+          <button id="mypage-btn">👤 マイページ</button>
           <button id="pricing-btn">💳 プラン</button>
           <button id="logout-btn">🚪 ログアウト</button>
         </div>
@@ -99,11 +99,18 @@ export function renderHeader(container) {
   header.querySelector("#pricing-btn").onclick = () => switchScreen("pricing");
 
   header.querySelector("#mypage-btn").onclick = () => switchScreen("mypage");
-  const emailDiv = header.querySelector(".user-email");
-  const email = firebaseAuth.currentUser?.email;
-  if (emailDiv && email) {
-    emailDiv.textContent = email;
-    emailDiv.style.display = "block";
+
+  const userDiv = header.querySelector(".user-info");
+  if (userDiv) {
+    const name =
+      user?.name ||
+      firebaseAuth.currentUser?.displayName ||
+      firebaseAuth.currentUser?.email;
+    if (name) {
+      const icon = user?.is_premium ? "⭐ " : "";
+      userDiv.textContent = icon + name;
+      userDiv.style.display = "block";
+    }
   }
   // ▼ ログアウト処理
   header.querySelector("#logout-btn").addEventListener("click", async () => {

--- a/components/home.js
+++ b/components/home.js
@@ -17,7 +17,7 @@ export function renderHomeScreen(user) {
   clearTimeOfDayStyling();
 
   // ✅ ヘッダー（固定表示、上部に表示）
-  renderHeader(app);
+  renderHeader(app, user);
 
   // ✅ メインコンテンツ（ヘッダーの下に表示）
   const container = document.createElement("div");

--- a/components/mypage.js
+++ b/components/mypage.js
@@ -16,7 +16,7 @@ import { createPlanInfoContent } from "./planInfo.js";
 export function renderMyPageScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app, () => renderMyPageScreen(user));
+  renderHeader(app, user);
 
   const container = document.createElement("div");
   container.className = "screen active mypage-screen";

--- a/components/planInfo.js
+++ b/components/planInfo.js
@@ -101,7 +101,7 @@ async function createPlanInfoContent(user) {
 export async function renderPlanInfoScreen(user) {
   const app = document.getElementById('app');
   app.innerHTML = '';
-  renderHeader(app, () => renderPlanInfoScreen(user));
+  renderHeader(app, user);
 
   const main = document.createElement('main');
   main.className = 'plan-info-screen';

--- a/components/pricing.js
+++ b/components/pricing.js
@@ -9,7 +9,7 @@ export function renderPricingScreen(user) {
   }
   const app = document.getElementById('app');
   app.innerHTML = '';
-  renderHeader(app);
+  renderHeader(app, user);
 
   const main = document.createElement('main');
   main.className = 'pricing-page';

--- a/components/result.js
+++ b/components/result.js
@@ -116,7 +116,7 @@ export async function renderResultScreen(user) {
 
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app);
+  renderHeader(app, user);
 
   const container = document.createElement("div");
   container.className = "screen active";

--- a/components/settings.js
+++ b/components/settings.js
@@ -65,7 +65,7 @@ export async function renderSettingsScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
 
-  renderHeader(app, () => renderSettingsScreen(user));
+  renderHeader(app, user);
 
   const container = document.createElement("div");
   container.className = "screen active";

--- a/components/summary.js
+++ b/components/summary.js
@@ -262,7 +262,7 @@ window.renderSummaryScreen = renderSummaryScreen;
 export async function renderSummaryScreenForDate(date, user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app, renderSummaryScreen);
+  renderHeader(app, user);
 
   const container = document.createElement("div");
   app.appendChild(container);

--- a/css/header.css
+++ b/css/header.css
@@ -68,8 +68,8 @@
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
-/* User email display */
-.parent-dropdown .user-email {
+/* User name display */
+.parent-dropdown .user-info {
   padding: 0.5em 1em;
   font-size: 0.9rem;
   border-bottom: 1px solid #eee;


### PR DESCRIPTION
## Summary
- show the signed-in user name in the settings dropdown
- add premium icon for paying members
- reorder dropdown links per new spec

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841a336ff0c8323b38075ef6c438c93