### PR TITLE
Keep training end message until result screen

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -602,15 +602,17 @@ function showSingleNoteQuiz(chord, onFinish, isLast = false) {
   });
 }
 
-function showFeedback(message, type = "good") {
+function showFeedback(message, type = "good", duration = 1000) {
   const fb = document.getElementById("feedback");
   if (!fb) return;
   fb.textContent = message;
   fb.className = type === "good" ? "good" : "bad";
   fb.style.display = "block";
-  setTimeout(() => {
-    fb.style.display = "none";
-  }, 1000);
+  if (duration !== 0) {
+    setTimeout(() => {
+      fb.style.display = "none";
+    }, duration);
+  }
 }
 
 function updateProgressUI() {
@@ -661,7 +663,7 @@ function checkAnswer(selected) {
       if (questionQueue.length === 0) {
         console.log("📌 nextQuestion: セッション終了に到達");
 
-        showFeedback("トレーニング終了！", "good");
+        showFeedback("トレーニング終了！", "good", 0);
         nextQuestion();
       } else {
         nextQuestion();

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -317,15 +317,17 @@ function playChordFile(filename) {
   currentAudio.play();
 }
 
-function showFeedback(message, type = "good") {
+function showFeedback(message, type = "good", duration = 1000) {
   const fb = document.getElementById("feedback");
   if (!fb) return;
   fb.textContent = message;
   fb.className = type === "good" ? "good" : "bad";
   fb.style.display = "block";
-  setTimeout(() => {
-    fb.style.display = "none";
-  }, 1000);
+  if (duration !== 0) {
+    setTimeout(() => {
+      fb.style.display = "none";
+    }, duration);
+  }
 }
 
 function checkAnswer(selected) {
@@ -362,7 +364,7 @@ function checkAnswer(selected) {
     });
 
     if (questionQueue.length === 0) {
-      showFeedback("トレーニング終了！", "good");
+      showFeedback("トレーニング終了！", "good", 0);
       const sound = (correctCount === questionCount) ? "perfect" : "end";
       saveSessionToHistory();
       playSoundThen(sound, () => {


### PR DESCRIPTION
## Summary
- allow specifying feedback duration to keep messages visible
- keep 'トレーニング終了！' displayed while playing the end audio

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_b_6841a44c9bb883238051e12e9f46493a