### PR TITLE
Add simple service worker caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,5 +52,12 @@
 
   <!-- ✅ 最後に main.js をモジュールとして読み込む -->
   <script type="module" src="main.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js').catch(e => console.error('SW registration failed:', e));
+      });
+    }
+  </script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,61 @@
+const CACHE_NAME = 'otoron-cache-v1';
+const STATIC_ASSETS = [
+  '/',
+  '/index.html',
+  '/main.js',
+  '/style.css',
+  '/generated-icon.png',
+  '/favicon.ico',
+  // CSS files
+  '/css/common.css',
+  '/css/intro.css',
+  '/css/login.css',
+  '/css/result.css',
+  '/css/signup.css',
+  '/css/home.css',
+  '/css/header.css',
+  '/css/training.css',
+  '/css/training_full.css',
+  '/css/settings.css',
+  '/css/summary.css',
+  '/css/growth.css',
+  '/css/mypage.css',
+  '/css/info.css',
+  '/css/pricing.css',
+  '/css/setup.css',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+
+  // Prefer cache for local assets and audio
+  if (request.url.includes('/audio/') || request.url.includes('/sounds/') || request.url.startsWith(self.location.origin)) {
+    event.respondWith(
+      caches.match(request).then(cached => {
+        if (cached) return cached;
+        return fetch(request).then(response => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+          return response;
+        });
+      })
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add service worker to cache CSS, JS and audio
- register the service worker from `index.html`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841a6243ab88323b838d55c95ec5b5b