### PR TITLE
Require 2 sessions for daily pass

### DIFF
--- a/utils/qualifiedStore_supabase.js
+++ b/utils/qualifiedStore_supabase.js
@@ -4,6 +4,8 @@ import { getCounts } from "./chordQueue.js";
 
 const REQUIRED_DAYS = 7;
 const PASS_THRESHOLD = 0.98;
+// A day is only qualified when at least this many sessions were played
+const MIN_SESSIONS_PER_DAY = 2;
 
 const chordNameOrder = chordOrder
   .map(key => chords.find(c => c.key === key)?.name)
@@ -61,7 +63,7 @@ export async function markQualifiedDayIfNeeded(userId, isoDate) {
     return;
   }
 
-  if (!sessions || sessions.length === 0) return;
+  if (!sessions || sessions.length < MIN_SESSIONS_PER_DAY) return;
 
   const aggregated = {};
   let total = 0;

--- a/utils/weeklyReport.js
+++ b/utils/weeklyReport.js
@@ -193,7 +193,7 @@ export async function generateWeeklyReport(user, startDate, endDate) {
   const fullComment = [comments[0], comments[1], ...(comments.slice(2))].join(' ');
 
   const userLabel = userName ? `${userName}ちゃん` : userId;
-  const reportText = `\n【🎼 絶対音感トレーニング週次レポート】\n${userLabel}（${startDate}〜${endDate}）\n\n🗓 トレーニング実施日数：${totalSessions}日間\n✅ 合格日数：${passedDays}日間（1日あたり各和音4問以上・正答率98%以上）\n📊 合計出題数：${totalQuestions}問\n🎯 正答率：${accuracy}%\n\n🔓 解放済み和音（色）：\n${chordNames}\n\n🔍 ミス傾向：\n${inversionMistakes.concat(topBottomMistakes).join('\n')}\n${initialMistakeCount > 0 ? `・初回だけミス：${initialMistakeCount}回あり` : ''}\n\n📣 コメント：\n${fullComment}`.trim();
+  const reportText = `\n【🎼 絶対音感トレーニング週次レポート】\n${userLabel}（${startDate}〜${endDate}）\n\n🗓 トレーニング実施日数：${totalSessions}日間\n✅ 合格日数：${passedDays}日間（1日あたり2回以上のトレーニング・各和音4問以上・正答率98%以上）\n📊 合計出題数：${totalQuestions}問\n🎯 正答率：${accuracy}%\n\n🔓 解放済み和音（色）：\n${chordNames}\n\n🔍 ミス傾向：\n${inversionMistakes.concat(topBottomMistakes).join('\n')}\n${initialMistakeCount > 0 ? `・初回だけミス：${initialMistakeCount}回あり` : ''}\n\n📣 コメント：\n${fullComment}`.trim();
 
   return reportText;
 }


### PR DESCRIPTION
## Summary
- enforce at least two training sessions before marking a day as qualified
- update weekly report description to mention the new requirement

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6842b7070ed08323bac0bbfa8261ae9f