### PR TITLE
Add white-key single note training

### DIFF
--- a/components/question_white.js
+++ b/components/question_white.js
@@ -1,0 +1,32 @@
+// components/question_white.js
+
+// White key notes from C3 to B5
+const availableNotes = [
+  "C3","D3","E3","F3","G3","A3","B3",
+  "C4","D4","E4","F4","G4","A4","B4",
+  "C5","D5","E5","F5","G5","A5","B5"
+];
+
+export function getRandomWhiteNoteSequence(count = 21) {
+  const notes = [...availableNotes];
+  for (let i = notes.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [notes[i], notes[j]] = [notes[j], notes[i]];
+  }
+  if (count <= notes.length) {
+    return notes.slice(0, count);
+  }
+  const result = [];
+  let pool = [...notes];
+  while (result.length < count) {
+    if (pool.length === 0) {
+      pool = [...availableNotes];
+      for (let i = pool.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [pool[i], pool[j]] = [pool[j], pool[i]];
+      }
+    }
+    result.push(pool.pop());
+  }
+  return result;
+}

--- a/components/result_white.js
+++ b/components/result_white.js
@@ -1,0 +1,161 @@
+// components/result_white.js
+// Uses global VexFlow loaded in index.html
+
+import { switchScreen } from "../main.js";
+
+export function renderTrainingWhiteResultScreen(user) {
+  const app = document.getElementById("app");
+  app.innerHTML = `
+    <h2>白鍵だけの単音テスト 結果</h2>
+    <div class="score-wrapper">
+      <img id="score-image" class="score-image" />
+    </div>
+    <div id="score-modal" class="modal hidden">
+      <img id="full-score-image" />
+    </div>
+    <div id="summary"></div>
+    <button id="back-btn">設定に戻る</button>`;
+
+  const history = JSON.parse(sessionStorage.getItem("noteHistory") || "[]");
+
+  const vexDiv = document.createElement("div");
+  vexDiv.id = "vexflow-staff";
+  vexDiv.style.margin = "2em 0";
+  app.insertBefore(vexDiv, document.querySelector(".score-wrapper"));
+
+  const VF = (typeof Vex !== "undefined" && Vex.Flow) ? Vex.Flow : null;
+
+  const summary = {};
+  history.forEach(entry => {
+    if (!summary[entry.question]) summary[entry.question] = { correct: 0, total: 0 };
+    summary[entry.question].total++;
+    if (entry.correct) summary[entry.question].correct++;
+  });
+
+  function convertForStaff(note) {
+    const m = note.match(/^([A-G]#?)(\d)$/);
+    if (!m) return { clef: "treble", key: "c/4", accidental: null };
+    const [_, base, octave] = m;
+    const accidental = base.includes("#") ? "#" : null;
+    const pitch = base.replace("#", "");
+    const midi = (parseInt(octave) + 1) * 12 + {C:0,D:2,E:4,F:5,G:7,A:9,B:11}[pitch] + (accidental?1:0);
+    const clef = midi < 60 ? "bass" : "treble";
+    const key = `${pitch.toLowerCase()}${accidental?"#" : ""}/${octave}`;
+    return { key, accidental, clef };
+  }
+
+  if (VF) {
+    const measures = Array.from({ length: Math.ceil(history.length / 3) }, () => ({ treble: [], bass: [] }));
+
+    history.forEach((entry, idx) => {
+      const conv = convertForStaff(entry.question);
+      const vNote = new VF.StaveNote({ clef: conv.clef, keys: [conv.key], duration: "q" });
+      if (conv.accidental) vNote.addAccidental(0, new VF.Accidental(conv.accidental));
+      if (!entry.correct) {
+        vNote.setStyle({ fillStyle: "red", strokeStyle: "red" });
+      }
+      const ghost = new VF.GhostNote("q");
+      const mIdx = Math.floor(idx / 3);
+      if (conv.clef === "treble") {
+        measures[mIdx].treble.push(vNote);
+        measures[mIdx].bass.push(ghost);
+      } else {
+        measures[mIdx].treble.push(ghost);
+        measures[mIdx].bass.push(vNote);
+      }
+    });
+
+    const measureWidth = 180;
+    const lineHeight = 180;
+    const measuresPerLine = 4;
+    const renderer = new VF.Renderer("vexflow-staff", VF.Renderer.Backends.SVG);
+    const numLines = Math.ceil(measures.length / measuresPerLine);
+    const width = Math.min(measures.length, measuresPerLine) * measureWidth + 40;
+    renderer.resize(width, lineHeight * numLines + 40);
+    const context = renderer.getContext();
+
+    for (let line = 0; line < numLines; line++) {
+      for (let m = 0; m < measuresPerLine; m++) {
+        const idx = line * measuresPerLine + m;
+        if (idx >= measures.length) break;
+        const x = 20 + m * measureWidth;
+        const y = 20 + line * lineHeight;
+
+        const treble = new VF.Stave(x, y, measureWidth);
+        if (m === 0) treble.addClef("treble");
+        if (idx === measures.length - 1) treble.setEndBarType(VF.Barline.type.END);
+        treble.setContext(context).draw();
+
+        const bass = new VF.Stave(x, y + 80, measureWidth);
+        if (m === 0) bass.addClef("bass");
+        if (idx === measures.length - 1) bass.setEndBarType(VF.Barline.type.END);
+        bass.setContext(context).draw();
+
+        if (m === 0) {
+          new VF.StaveConnector(treble, bass)
+            .setType(VF.StaveConnector.type.BRACE)
+            .setContext(context)
+            .draw();
+        }
+        new VF.StaveConnector(treble, bass)
+          .setType(VF.StaveConnector.type.SINGLE)
+          .setContext(context)
+          .draw();
+
+        const voiceTreble = new VF.Voice({ num_beats: measures[idx].treble.length, beat_value: 4 }).setStrict(false);
+        voiceTreble.addTickables(measures[idx].treble);
+        const voiceBass = new VF.Voice({ num_beats: measures[idx].bass.length, beat_value: 4 }).setStrict(false);
+        voiceBass.addTickables(measures[idx].bass);
+
+        new VF.Formatter().joinVoices([voiceTreble, voiceBass]).format([voiceTreble, voiceBass], measureWidth - 20);
+        voiceTreble.draw(context, treble);
+        voiceBass.draw(context, bass);
+      }
+    }
+
+    const svg = vexDiv.querySelector("svg");
+    const data = new XMLSerializer().serializeToString(svg);
+    const base64 = "data:image/svg+xml;base64," + btoa(unescape(encodeURIComponent(data)));
+    document.getElementById("score-image").src = base64;
+    document.getElementById("full-score-image").src = base64;
+    vexDiv.innerHTML = "";
+
+    document.getElementById("score-image").addEventListener("click", () => {
+      document.getElementById("score-modal").classList.remove("hidden");
+    });
+
+    document.getElementById("score-modal").addEventListener("click", () => {
+      document.getElementById("score-modal").classList.add("hidden");
+    });
+  }
+
+  const summaryDiv = document.getElementById("summary");
+  const totalQuestions = history.length;
+  const correctCount = history.filter(e => e.correct).length;
+  const overallAccuracy = totalQuestions ? Math.round((correctCount / totalQuestions) * 100) : 0;
+
+  const summaryText = document.createElement("p");
+  summaryText.textContent = `正解率 ${overallAccuracy}％（${correctCount}/${totalQuestions}）`;
+  summaryDiv.appendChild(summaryText);
+  const table = document.createElement("table");
+  table.innerHTML = `<tr><th>音</th><th>正解数</th><th>出題数</th><th>正答率</th></tr>`;
+
+  Object.keys(summary).sort().forEach(note => {
+    const data = summary[note];
+    const accuracy = ((data.correct / data.total) * 100).toFixed(1);
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td>${note}</td>
+      <td>${data.correct}</td>
+      <td>${data.total}</td>
+      <td>${accuracy}%</td>
+    `;
+    table.appendChild(row);
+  });
+
+  summaryDiv.appendChild(table);
+
+  document.getElementById("back-btn").onclick = () => {
+    switchScreen("settings", user);
+  };
+}

--- a/components/settings.js
+++ b/components/settings.js
@@ -293,12 +293,14 @@ buttonGroup.appendChild(resetBtn);
     <ul>
       <li><button id="btn-easy">単音音あて（簡易モード）</button></li>
       <li><button id="btn-full">単音音あて（本気モード）</button></li>
+      <li><button id="btn-white">白鍵だけの単音テスト</button></li>
     </ul>
   `;
   app.appendChild(section);
 
   document.getElementById("btn-easy").onclick = () => switchScreen("training_easy");
   document.getElementById("btn-full").onclick = () => switchScreen("training_full");
+  document.getElementById("btn-white").onclick = () => switchScreen("training_white");
 
   updateSelection();
 }

--- a/components/training_white_keys.js
+++ b/components/training_white_keys.js
@@ -1,0 +1,133 @@
+// components/training_white_keys.js
+
+import { getRandomWhiteNoteSequence } from "./question_white.js";
+import { playNote } from "./soundPlayer.js";
+import { switchScreen } from "../main.js";
+
+let currentNote = null;
+let noteSequence = [];
+let noteHistory = [];
+let isAnswering = false;
+let isSoundPlaying = false;
+let questionCount = 0;
+const FEEDBACK_DELAY = 1000;
+const maxQuestions = 21;
+
+const noteLabels = {
+  "C": "ど",
+  "D": "れ",
+  "E": "み",
+  "F": "ふぁ",
+  "G": "そ",
+  "A": "ら",
+  "B": "し"
+};
+
+function kanaToHiragana(str) {
+  return str.replace(/[ァ-ン]/g, ch =>
+    String.fromCharCode(ch.charCodeAt(0) - 0x60)
+  );
+}
+
+export function renderTrainingScreen(user) {
+  const app = document.getElementById("app");
+  // reset session state
+  currentNote = null;
+  noteSequence = [];
+  noteHistory = [];
+  isAnswering = false;
+  isSoundPlaying = false;
+  questionCount = 0;
+  app.innerHTML = `
+    <h2>白鍵だけの単音テスト</h2>
+    <div id="feedback"></div>
+    <div class="piano-container">
+      <div class="white-keys"></div>
+    </div>
+    <button id="finish-btn">やめる</button>
+  `;
+
+  const debugAnswer = document.createElement("div");
+  debugAnswer.style.position = "absolute";
+  debugAnswer.style.top = "10px";
+  debugAnswer.style.right = "10px";
+  debugAnswer.style.fontSize = "0.9em";
+  debugAnswer.style.color = "gray";
+  app.appendChild(debugAnswer);
+
+  const whiteOrder = ["C", "D", "E", "F", "G", "A", "B"];
+
+  const whiteContainer = app.querySelector(".white-keys");
+  whiteOrder.forEach(n => {
+    const btn = document.createElement("button");
+    btn.className = "key-white";
+    btn.dataset.note = n;
+    btn.textContent = noteLabels[n];
+    whiteContainer.appendChild(btn);
+  });
+
+  const piano = app.querySelector(".piano-container");
+  const finishBtn = document.getElementById("finish-btn");
+
+  function setInteraction(enabled) {
+    if (enabled) {
+      piano.classList.remove("disabled");
+      finishBtn.classList.remove("disabled");
+      finishBtn.disabled = false;
+    } else {
+      piano.classList.add("disabled");
+      finishBtn.classList.add("disabled");
+      finishBtn.disabled = true;
+    }
+  }
+
+  piano.addEventListener("click", (e) => {
+    const btn = e.target.closest("button");
+    if (!btn || isAnswering || isSoundPlaying) return;
+    setInteraction(false);
+    const note = btn.dataset.note;
+    const correct = note === currentNote.replace(/[0-9]/g, "");
+    noteHistory.push({ question: currentNote, answer: note, correct });
+
+    const feedback = document.getElementById("feedback");
+    feedback.textContent = correct ? "🎉 正解!" : "❌ 不正解";
+    feedback.style.color = correct ? "green" : "red";
+
+    isAnswering = true;
+    const proceed = () => {
+      setTimeout(() => {
+        feedback.textContent = "";
+        isAnswering = false;
+        questionCount++;
+        if (questionCount < maxQuestions) {
+          nextQuestion();
+        } else {
+          sessionStorage.setItem("noteHistory", JSON.stringify(noteHistory));
+          switchScreen("result_white", user);
+        }
+      }, FEEDBACK_DELAY);
+    };
+
+    proceed();
+  });
+
+  finishBtn.onclick = () => {
+    switchScreen("settings", user);
+  };
+
+  function nextQuestion() {
+    if (noteSequence.length === 0) {
+      noteSequence = getRandomWhiteNoteSequence(maxQuestions);
+    }
+    currentNote = noteSequence.pop();
+    debugAnswer.textContent = `【デバッグ】正解: ${kanaToHiragana(noteLabels[currentNote.replace(/[0-9]/g, "")])}（${currentNote}）`;
+    isSoundPlaying = true;
+    setInteraction(false);
+    playNote(currentNote).then(() => {
+      isSoundPlaying = false;
+      setInteraction(true);
+    });
+  }
+
+  nextQuestion();
+}

--- a/main.js
+++ b/main.js
@@ -4,8 +4,10 @@ import { renderHomeScreen } from "./components/home.js";
 import { renderTrainingScreen } from "./components/training.js"; // 和音トレーニング
 import { renderTrainingScreen as renderTrainingFull } from "./components/training_full.js"; // 単音（本気）
 import { renderTrainingScreen as renderTrainingEasy } from "./components/training_easy_note.js"; // 単音（簡易）
+import { renderTrainingScreen as renderTrainingWhite } from "./components/training_white_keys.js"; // 白鍵テスト
 import { renderTrainingFullResultScreen } from "./components/result_full.js";
 import { renderTrainingEasyResultScreen } from "./components/result_easy.js";
+import { renderTrainingWhiteResultScreen } from "./components/result_white.js";
 import { renderSettingsScreen } from "./components/settings.js";
 import { renderResultScreen } from "./components/result.js";
 import { renderSummaryScreen } from "./components/summary.js";
@@ -78,6 +80,7 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   else if (screen === "training") renderTrainingScreen(user);
   else if (screen === "training_easy") renderTrainingEasy(user);
   else if (screen === "training_full") renderTrainingFull(user);
+  else if (screen === "training_white") renderTrainingWhite(user);
   else if (screen === "settings") renderSettingsScreen(user);
   else if (screen === "summary") renderSummaryScreen(user);
   else if (screen === "growth") renderGrowthScreen(user);
@@ -87,6 +90,7 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   else if (screen === "result") renderResultScreen(user);
   else if (screen === "result_easy") renderTrainingEasyResultScreen(user);
   else if (screen === "result_full") renderTrainingFullResultScreen(user);
+  else if (screen === "result_white") renderTrainingWhiteResultScreen(user);
   else if (screen === "terms") renderTermsScreen();
   else if (screen === "privacy") renderPrivacyScreen();
   else if (screen === "contact") renderContactScreen();


### PR DESCRIPTION
## Summary
- implement question generator for white key notes
- add training UI for white key single note test
- show results page for white-key test
- hook new screen into settings and router

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68438c1b7eb08323a48639ad5ddd6e18