### PR TITLE
Adjust white key test length and single note defaults

### DIFF
--- a/components/question_white.js
+++ b/components/question_white.js
@@ -7,7 +7,7 @@ const availableNotes = [
   "C5","D5","E5","F5","G5","A5","B5"
 ];
 
-export function getRandomWhiteNoteSequence(count = 21) {
+export function getRandomWhiteNoteSequence(count = 24) {
   const notes = [...availableNotes];
   for (let i = notes.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));

--- a/components/settings.js
+++ b/components/settings.js
@@ -157,7 +157,7 @@ buttonGroup.appendChild(resetBtn);
     <option value="random">ランダム</option>
     <option value="top">最上音のみ</option>
   `;
-  singleSelect.value = localStorage.getItem('singleNoteStrategy') || 'random';
+  singleSelect.value = localStorage.getItem('singleNoteStrategy') || 'top';
   singleSelect.onchange = () => {
     localStorage.setItem('singleNoteStrategy', singleSelect.value);
   };

--- a/components/training.js
+++ b/components/training.js
@@ -21,7 +21,7 @@ let questionQueue = [];
 let isForcedAnswer = false;
 let currentUser = null; // ← 追加
 let singleNoteMode = false;
-let singleNoteStrategy = 'random';
+let singleNoteStrategy = 'top';
 let chordProgressCount = 0;
 let chordSoundOn = true;
 
@@ -89,7 +89,7 @@ export async function renderTrainingScreen(user) {
   console.log("🟢 renderTrainingScreen: user.id =", user?.id);
   currentUser = user;
   singleNoteMode = localStorage.getItem("singleNoteMode") === "on";
-  singleNoteStrategy = localStorage.getItem("singleNoteStrategy") || 'random';
+  singleNoteStrategy = localStorage.getItem("singleNoteStrategy") || 'top';
   chordSoundOn = localStorage.getItem("chordSound") !== "off";
   const flags = await loadGrowthFlags(user.id);
   chordProgressCount = Object.values(flags).filter(f => f.unlocked).length;

--- a/components/training_white_keys.js
+++ b/components/training_white_keys.js
@@ -11,7 +11,7 @@ let isAnswering = false;
 let isSoundPlaying = false;
 let questionCount = 0;
 const FEEDBACK_DELAY = 1000;
-const maxQuestions = 21;
+const maxQuestions = 24;
 
 const noteLabels = {
   "C": "ど",


### PR DESCRIPTION
## Summary
- extend white-key single note test to 24 questions
- default single-note strategy to "最上音のみ"

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_6843928ddb348323aa6ecf98ccbf784e