### PR TITLE
Update settings buttons and training names

### DIFF
--- a/components/result_easy.js
+++ b/components/result_easy.js
@@ -6,7 +6,7 @@ import { switchScreen } from "../main.js";
 export function renderTrainingEasyResultScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = `
-    <h2>単音テスト（簡易）結果</h2>
+    <h2>単音テスト（3オクターブ）結果</h2>
     <div class="score-wrapper">
       <img id="score-image" class="score-image" />
     </div>

--- a/components/result_full.js
+++ b/components/result_full.js
@@ -6,7 +6,7 @@ import { switchScreen } from "../main.js";
 export function renderTrainingFullResultScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = `
-    <h2>単音テスト（本気） 結果</h2>
+    <h2>単音テスト（全88鍵）結果</h2>
     <div class="score-wrapper">
       <img id="score-image" class="score-image" />
     </div>

--- a/components/result_white.js
+++ b/components/result_white.js
@@ -6,7 +6,7 @@ import { switchScreen } from "../main.js";
 export function renderTrainingWhiteResultScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = `
-    <h2>白鍵だけの単音テスト 結果</h2>
+    <h2>単音テスト（白鍵のみ）結果</h2>
     <div class="score-wrapper">
       <img id="score-image" class="score-image" />
     </div>

--- a/components/settings.js
+++ b/components/settings.js
@@ -80,7 +80,7 @@ export async function renderSettingsScreen(user) {
 
   const buttonGroup = document.createElement("div");
 const resetBtn = document.createElement("button");
-resetBtn.textContent = "↩ 推奨出題にする";
+resetBtn.textContent = "推奨出題にする";
 resetBtn.onclick = () => {
   if (confirm("本当に推奨出題にしますか？")) {
     resetToRecommendedChords(unlockedKeys, user); // ← user を渡す！
@@ -93,7 +93,7 @@ buttonGroup.appendChild(resetBtn);
 
   const bulkDropdown = document.createElement("select");
   bulkDropdown.innerHTML = `
-    <option value="">✔ 一括出題回数</option>
+    <option value="">一括出題回数</option>
     <option value="1">1回ずつ</option>
     <option value="2">2回ずつ</option>
     <option value="3">3回ずつ</option>
@@ -308,9 +308,9 @@ buttonGroup.appendChild(resetBtn);
   section.innerHTML = `
     <h3>その他のトレーニング</h3>
     <ul>
-      <li><button id="btn-easy">単音音あて（簡易モード）</button></li>
-      <li><button id="btn-full">単音音あて（本気モード）</button></li>
-      <li><button id="btn-white">白鍵だけの単音テスト</button></li>
+      <li><button id="btn-white">単音テスト（白鍵のみ）</button></li>
+      <li><button id="btn-easy">単音テスト（3オクターブ）</button></li>
+      <li><button id="btn-full">単音テスト（全88鍵）</button></li>
     </ul>
   `;
   app.appendChild(section);

--- a/components/training_easy_note.js
+++ b/components/training_easy_note.js
@@ -49,7 +49,7 @@ export function renderTrainingScreen(user) {
   isSoundPlaying = false;
   questionCount = 0;
   app.innerHTML = `
-    <h2>単音テスト（簡易）</h2>
+    <h2>単音テスト（3オクターブ）</h2>
     <div id="feedback"></div>
     <div class="piano-container">
       <div class="white-keys"></div>

--- a/components/training_full.js
+++ b/components/training_full.js
@@ -47,7 +47,7 @@ export function renderTrainingScreen(user) {
   isSoundPlaying = false;
   questionCount = 0;
   app.innerHTML = `
-    <h2>単音テスト（本気）</h2>
+    <h2>単音テスト（全88鍵）</h2>
     <div id="feedback"></div>
     <div class="piano-container">
       <div class="white-keys"></div>

--- a/components/training_white_keys.js
+++ b/components/training_white_keys.js
@@ -39,7 +39,7 @@ export function renderTrainingScreen(user) {
   isSoundPlaying = false;
   questionCount = 0;
   app.innerHTML = `
-    <h2>白鍵だけの単音テスト</h2>
+    <h2>単音テスト（白鍵のみ）</h2>
     <div id="feedback"></div>
     <div class="piano-container">
       <div class="white-keys"></div>

--- a/main.js
+++ b/main.js
@@ -2,9 +2,9 @@
 
 import { renderHomeScreen } from "./components/home.js";
 import { renderTrainingScreen } from "./components/training.js"; // 和音トレーニング
-import { renderTrainingScreen as renderTrainingFull } from "./components/training_full.js"; // 単音（本気）
-import { renderTrainingScreen as renderTrainingEasy } from "./components/training_easy_note.js"; // 単音（簡易）
-import { renderTrainingScreen as renderTrainingWhite } from "./components/training_white_keys.js"; // 白鍵テスト
+import { renderTrainingScreen as renderTrainingFull } from "./components/training_full.js"; // 単音（全88鍵）
+import { renderTrainingScreen as renderTrainingEasy } from "./components/training_easy_note.js"; // 単音（3オクターブ）
+import { renderTrainingScreen as renderTrainingWhite } from "./components/training_white_keys.js"; // 単音（白鍵のみ）
 import { renderTrainingFullResultScreen } from "./components/result_full.js";
 import { renderTrainingEasyResultScreen } from "./components/result_easy.js";
 import { renderTrainingWhiteResultScreen } from "./components/result_white.js";


### PR DESCRIPTION
## Summary
- remove emoji from Settings header buttons
- reorder and rename other training options
- update headings for training and result screens
- refresh training comments in main.js

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6843948b3ff883239ac4226971dc8a75