### PR TITLE
Fix qualification check for generated mock sessions

### DIFF
--- a/utils/growthStore_supabase.js
+++ b/utils/growthStore_supabase.js
@@ -155,7 +155,9 @@ export async function generateMockGrowthData(userId, days = 7) {
         .from("training_sessions")
         .insert(ses);
       if (sesErr) console.error("❌ モックセッション挿入失敗:", sesErr);
-      await markQualifiedDayIfNeeded(userId, `${dateStr}${time}`);
     }
+
+    // 両セッションの保存後に日付単位の合格判定を実施
+    await markQualifiedDayIfNeeded(userId, `${dateStr}${sessionTimes[0]}`);
   }
 }


### PR DESCRIPTION
## Summary
- after creating mock sessions for a day, run the qualification check once all sessions are saved

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6844472061248323a7ba0cabe149c79a