### PR TITLE
Add early user id checks in supabase utils

### DIFF
--- a/utils/growthStore_supabase.js
+++ b/utils/growthStore_supabase.js
@@ -14,6 +14,10 @@ import { chordOrder } from "../data/chords.js";
  * @returns {Promise<Object>} 例: { "aka": { unlocked: true }, ... }
  */
 export async function loadGrowthFlags(userId) {
+  if (!userId) {
+    console.warn("loadGrowthFlags called without valid user ID");
+    return {};
+  }
   const { data, error } = await supabase
     .from("user_chord_progress")
     .select("chord_key, status")
@@ -42,6 +46,10 @@ export async function loadGrowthFlags(userId) {
  * @param {string} chordKey - 和音識別子（例: "aka"）
  */
 export async function markChordAsUnlocked(userId, chordKey) {
+  if (!userId) {
+    console.warn("markChordAsUnlocked called without valid user ID");
+    return;
+  }
   const { error } = await supabase
     .from("user_chord_progress")
     .update({
@@ -65,6 +73,10 @@ export async function markChordAsUnlocked(userId, chordKey) {
  * @param {number} [days=7] - 生成する合格記録の日数
  */
 export async function generateMockGrowthData(userId, days = 7) {
+  if (!userId) {
+    console.warn("generateMockGrowthData called without valid user ID");
+    return;
+  }
   const now = new Date();
 
   // 現在進行中の和音の解放日を days 日前に調整して解放条件を満たす

--- a/utils/growthUtils.js
+++ b/utils/growthUtils.js
@@ -87,6 +87,10 @@ export function getToday() {
  * @returns {Promise<boolean>}
  */
 export async function isQualifiedToday(userId) {
+  if (!userId) {
+    console.warn("isQualifiedToday called without valid user ID");
+    return false;
+  }
   const today = getToday();
   const { data, error } = await supabase
     .from("qualified_days")
@@ -108,6 +112,10 @@ export async function isQualifiedToday(userId) {
  * @returns {Promise<number>}
  */
 export async function getPassedDays(userId) {
+  if (!userId) {
+    console.warn("getPassedDays called without valid user ID");
+    return 0;
+  }
   const passed = await getConsecutiveQualifiedDays(userId);
 
   const resetFlag = localStorage.getItem(STORAGE_FORCE_FLAG);
@@ -132,6 +140,10 @@ export function forceUnlock() {
  * @returns {Promise<Array<{date, count, correct, sets}>>}
  */
 export async function getSortedRecordArray(userId) {
+  if (!userId) {
+    console.warn("getSortedRecordArray called without valid user ID");
+    return [];
+  }
   const data = await loadTrainingRecords(userId);
   const sortedKeys = Object.keys(data).sort();
   return sortedKeys.map(date => ({
@@ -145,6 +157,10 @@ export async function getSortedRecordArray(userId) {
  * @param {string} userId - SupabaseユーザーID
  */
 export async function applyRecommendedSelection(userId) {
+  if (!userId) {
+    console.warn("applyRecommendedSelection called without valid user ID");
+    return;
+  }
   const flags = await loadGrowthFlags(userId);
   const queue = generateRecommendedQueue(flags);
 

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -9,6 +9,10 @@ const PASS_DAYS = 7;
 const POST_UNLOCK_DAYS = 7;
 
 export async function checkRecentUnlockCriteria(userId) {
+  if (!userId) {
+    console.warn("checkRecentUnlockCriteria called without valid user ID");
+    return false;
+  }
   const days = await getConsecutiveQualifiedDays(userId, PASS_DAYS);
   if (days < PASS_DAYS) return false;
 
@@ -29,10 +33,23 @@ export async function checkRecentUnlockCriteria(userId) {
 }
 
 export async function countQualifiedDays(userId) {
+  if (!userId) {
+    console.warn("countQualifiedDays called without valid user ID");
+    return 0;
+  }
   return getConsecutiveQualifiedDays(userId, PASS_DAYS);
 }
 
 export async function getUnlockCriteriaStatus(userId) {
+  if (!userId) {
+    console.warn("getUnlockCriteriaStatus called without valid user ID");
+    return {
+      consecutiveDays: 0,
+      requiredDays: PASS_DAYS,
+      daysSinceUnlock: null,
+      requiredInterval: POST_UNLOCK_DAYS
+    };
+  }
   const consecutiveDays = await getConsecutiveQualifiedDays(userId, PASS_DAYS);
 
   const { data: progress } = await supabase

--- a/utils/progressUtils.js
+++ b/utils/progressUtils.js
@@ -5,6 +5,10 @@ import { chords } from "../data/chords.js"; // ✅ 必須
 
 // ✅ 新規ユーザー用：赤からスタート、他はlocked
 export async function createInitialChordProgress(userId) {
+  if (!userId) {
+    console.warn("createInitialChordProgress called without valid user ID");
+    return;
+  }
   const chordKeys = chords.map(chord => chord.key); // すべての和音に対応
 
   const insertData = chordKeys.map((key, index) => ({
@@ -27,6 +31,10 @@ export async function createInitialChordProgress(userId) {
 
 // ✅ 経験者向け：任意の和音からスタートできるよう進捗を設定
 export async function applyStartChordIndex(userId, startIndex) {
+  if (!userId) {
+    console.warn("applyStartChordIndex called without valid user ID");
+    return;
+  }
   const chordKeys = chords.map((c) => c.key);
   const completed = chordKeys.slice(0, startIndex);
   const current = chordKeys[startIndex];
@@ -97,6 +105,10 @@ export async function autoUnlockNextChord(user) {
 
 // ✅ 和音を解放（in_progressに）
 export async function unlockChord(userId, chordKey) {
+  if (!userId) {
+    console.warn("unlockChord called without valid user ID");
+    return false;
+  }
   // 現在進行中の和音を完了状態に更新
   const { data: current, error: fetchErr } = await supabase
     .from("user_chord_progress")
@@ -131,6 +143,10 @@ export async function unlockChord(userId, chordKey) {
 
 // ✅ 和音を再ロック（lockedに）
 export async function lockChord(userId, chordKey) {
+  if (!userId) {
+    console.warn("lockChord called without valid user ID");
+    return false;
+  }
   const { error } = await supabase
     .from("user_chord_progress")
     .update({ status: "locked" })
@@ -141,6 +157,10 @@ export async function lockChord(userId, chordKey) {
 
 // ✅ 進捗をリセットして赤のみ in_progress に戻す（デバッグ用）
 export async function resetChordProgressToRed(userId) {
+  if (!userId) {
+    console.warn("resetChordProgressToRed called without valid user ID");
+    return false;
+  }
   const { error: lockError } = await supabase
     .from("user_chord_progress")
     .update({ status: "locked" })

--- a/utils/qualifiedStore_supabase.js
+++ b/utils/qualifiedStore_supabase.js
@@ -46,6 +46,10 @@ function sessionMeetsStats(stats, totalCount) {
 }
 
 export async function markQualifiedDayIfNeeded(userId, isoDate) {
+  if (!userId) {
+    console.warn("markQualifiedDayIfNeeded called without valid user ID");
+    return;
+  }
   const dayStart = isoDate.split("T")[0];
   const nextDay = new Date(dayStart);
   nextDay.setDate(nextDay.getDate() + 1);
@@ -107,6 +111,10 @@ export async function markQualifiedDayIfNeeded(userId, isoDate) {
 }
 
 export async function getConsecutiveQualifiedDays(userId, days = REQUIRED_DAYS) {
+  if (!userId) {
+    console.warn("getConsecutiveQualifiedDays called without valid user ID");
+    return 0;
+  }
   const today = new Date();
   const from = new Date();
   from.setDate(today.getDate() - (days - 1));

--- a/utils/recordStore_supabase.js
+++ b/utils/recordStore_supabase.js
@@ -16,6 +16,10 @@ export async function updateTrainingRecord({
   total = 1,
   chordsRequired = []
 }) {
+  if (!userId) {
+    console.warn("updateTrainingRecord called without valid user ID");
+    return;
+  }
   const today = getToday();
 
   const { data: existing, error: fetchError } = await supabase
@@ -62,6 +66,10 @@ export async function updateTrainingRecord({
  * 今日のセット数（1セット完了）を +1 加算
  */
 export async function incrementSetCount(userId) {
+  if (!userId) {
+    console.warn("incrementSetCount called without valid user ID");
+    return;
+  }
   const today = getToday();
 
   const { data: existing, error: fetchError } = await supabase
@@ -91,6 +99,10 @@ export async function incrementSetCount(userId) {
  * @returns {Promise<Object>} 日付をキーにした記録オブジェクト
  */
 export async function loadTrainingRecords(userId) {
+  if (!userId) {
+    console.warn("loadTrainingRecords called without valid user ID");
+    return {};
+  }
   const { data, error } = await supabase
     .from("training_records")
     .select("*")

--- a/utils/trainingStore_supabase.js
+++ b/utils/trainingStore_supabase.js
@@ -16,6 +16,10 @@ import { convertMistakesJsonToStructuredForm } from "./mistakeUtils.js";
  * @param {string} param0.date - セッション日時（ISO形式）
  */
 export async function saveTrainingSession({ userId, results, stats, mistakes, correctCount, totalCount, date }) {
+  if (!userId) {
+    console.warn("saveTrainingSession called without valid user ID");
+    return;
+  }
   console.log("🟡 saveTrainingSession 実行:", {
     userId,
     results,
@@ -49,6 +53,10 @@ export async function saveTrainingSession({ userId, results, stats, mistakes, co
 }
 
 export async function loadLatestTrainingSession(userId) {
+  if (!userId) {
+    console.warn("loadLatestTrainingSession called without valid user ID");
+    return null;
+  }
   const { data, error } = await supabase
     .from("training_sessions")
     .select("*")
@@ -66,6 +74,10 @@ export async function loadLatestTrainingSession(userId) {
 }
 
 export async function loadTrainingSessionsForDate(userId, date) {
+  if (!userId) {
+    console.warn("loadTrainingSessionsForDate called without valid user ID");
+    return [];
+  }
   const nextDay = new Date(date);
   nextDay.setDate(nextDay.getDate() + 1);
   const nextStr = nextDay.toISOString().split("T")[0];
@@ -87,6 +99,10 @@ export async function loadTrainingSessionsForDate(userId, date) {
 }
 
 export async function deleteTrainingDataThisWeek(userId) {
+  if (!userId) {
+    console.warn("deleteTrainingDataThisWeek called without valid user ID");
+    return false;
+  }
   const today = new Date();
   const day = today.getDay(); // 0: Sun
   const diffToMonday = (day + 6) % 7; // days since Monday


### PR DESCRIPTION
## Summary
- guard Supabase utility functions against missing `userId`
- warn when user id is missing and return default values

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68444ef86be88323a48b8da730dc78c2