### PR TITLE
Remove obsolete signInWithIdToken mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ALTER TABLE training_records ADD COLUMN chords_required jsonb NOT NULL DEFAULT '
 
 ## Troubleshooting
 
-Supabase へのサインインに失敗し `Custom OIDC provider "firebase" not allowed` と表示される場合、古い実装で `supabase.auth.signInWithIdToken` を使用している可能性があります。現在の実装では Firebase ユーザーのメールアドレスを用いて次のようにダミーパスワードでサインアップ・サインインする方式に切り替えています。
+Supabase へのサインインに失敗し `Custom OIDC provider "firebase" not allowed` と表示される場合は、過去のコードを利用している可能性があります。現在の実装では Firebase ユーザーのメールアドレスを用いて次のようにダミーパスワードでサインアップ・サインインする方式に切り替えています。
 
 ```javascript
 const firebaseUser = firebase.auth().currentUser;


### PR DESCRIPTION
## Summary
- update README troubleshooting section
- ensure signInWithIdToken calls are gone

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6844dca15adc8323aad9536b87ccbae3