### PR TITLE
Prevent Supabase auto signin

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,6 +38,8 @@ const DUMMY_PASSWORD = "secure_dummy_password";
 
 const DEBUG_AUTO_LOGIN = false;
 
+await supabase.auth.signOut();
+
 
 let currentUser = null;
 

--- a/utils/supabaseClient.js
+++ b/utils/supabaseClient.js
@@ -4,4 +4,10 @@ import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js
 const supabaseUrl = 'https://xnccwydcesyvqvyqafbg.supabase.co';
 const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhuY2N3eWRjZXN5dnF2eXFhZmJnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY4MDExMTEsImV4cCI6MjA2MjM3NzExMX0.84ELOFGZFJaBNaiHM4roAVmw4o4JMEj4mHnxox1k7Gs';
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+    detectSessionInUrl: false,
+  },
+});


### PR DESCRIPTION
## Summary
- disable automatic token handling when creating the Supabase client
- explicitly sign out from Supabase on startup to avoid id_token authentication

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6844de8b9b948323b65bf998220c9935