### PR TITLE
Disable auto session management for server functions

### DIFF
--- a/api/cancel-subscription.js
+++ b/api/cancel-subscription.js
@@ -4,7 +4,14 @@ import { createClient } from '@supabase/supabase-js';
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 const supabase = createClient(
   process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  }
 );
 
 export default async function handler(req, res) {

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -11,7 +11,14 @@ export const config = {
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 const supabase = createClient(
   process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  }
 );
 
 const endpointSecret = process.env.STRIPE_WEBHOOK_SECRET;

--- a/pages/api/stripe-webhook.js
+++ b/pages/api/stripe-webhook.js
@@ -11,7 +11,14 @@ export const config = {
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 const supabase = createClient(
   process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  }
 );
 
 const endpointSecret = process.env.STRIPE_WEBHOOK_SECRET;


### PR DESCRIPTION
## Summary
- disable auto session handling in server-side Supabase clients
- ensure consistent auth client options across API functions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6844e1938e888323ad7c5070d820c772