### PR TITLE
Disable Stripe SDK on frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
       console.error("❌ VexFlow 読み込み失敗");
     }
   </script>
-  <script src="https://js.stripe.com/v3/"></script>
+  <!-- <script src="https://js.stripe.com/v3/"></script> -->
 
   <!-- ✅ 最後に main.js をモジュールとして読み込む -->
   <script type="module" src="main.js"></script>

--- a/utils/stripeCheckout.js
+++ b/utils/stripeCheckout.js
@@ -17,6 +17,10 @@ export async function startCheckout(priceId) {
 
     const data = await response.json();
     if (data.id) {
+      if (typeof window.Stripe !== 'function') {
+        console.warn('Stripe SDK is not loaded; skipping redirect');
+        return;
+      }
       const stripe = Stripe('pk_test_51RUmpu4aOXt1PnHZ4QI4ED8IqIZstCQTAMzMm6isjY34QP5ESFYKClhQSwRI8d52n80G4c2FgPQTvFXLjOQG9Yl400wFCPpXca');
       await stripe.redirectToCheckout({ sessionId: data.id });
     } else {


### PR DESCRIPTION
## Summary
- comment out Stripe script inclusion in index.html
- add a runtime guard in Stripe checkout helper so the app doesn't fail when the SDK is missing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6844e3550c9c8323a1bdf9dec2b794d0