### PR TITLE
Fix intro not displayed with Supabase sign out

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,7 +38,17 @@ const DUMMY_PASSWORD = "secure_dummy_password";
 
 const DEBUG_AUTO_LOGIN = false;
 
-await supabase.auth.signOut();
+window.addEventListener("error", (e) => {
+  console.error("Uncaught error", e.error);
+});
+
+(async () => {
+  try {
+    await supabase.auth.signOut();
+  } catch (e) {
+    console.error("signOut error", e);
+  }
+})();
 
 
 let currentUser = null;
@@ -188,5 +198,6 @@ window.addEventListener("DOMContentLoaded", () => {
   const initial = DEBUG_AUTO_LOGIN ? "home" : "intro";
   const hash = location.hash.replace("#", "");
   const startScreen = hash || initial;
+  console.log("📱 DOMContentLoaded - switching to", startScreen);
   switchScreen(startScreen, undefined, { replace: true });
 });


### PR DESCRIPTION
## Summary
- wrap global `supabase.auth.signOut()` in a self‑invoking async function
- log uncaught errors and the screen switched on DOMContentLoaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6844f125a1bc8323a04b734b7077b28f