### PR TITLE
Add debug logs for intro screen loading

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -3,6 +3,7 @@ import { switchScreen } from '../main.js';
 
 export function renderIntroScreen() {
   const app = document.getElementById('app');
+  console.log('app element:', app);
   app.innerHTML = `
     <div class="intro-wrapper">
       <h1 class="intro-title">絶対音感トレーニング「オトロン」</h1>

--- a/main.js
+++ b/main.js
@@ -72,7 +72,10 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
     history.pushState(state, "", `#${screen}`);
   }
 
-  if (screen === "intro") renderIntroScreen();
+  if (screen === "intro") {
+    console.log("📺 calling renderIntroScreen");
+    renderIntroScreen();
+  }
   else if (screen === "login") renderLoginScreen(app, () => {});
   else if (screen === "home") renderHomeScreen(user);
   else if (screen === "training") renderTrainingScreen(user);
@@ -195,9 +198,10 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 });
 
 window.addEventListener("DOMContentLoaded", () => {
+  console.log("🚀 DOMContentLoaded fired");
   const initial = DEBUG_AUTO_LOGIN ? "home" : "intro";
   const hash = location.hash.replace("#", "");
   const startScreen = hash || initial;
-  console.log("📱 DOMContentLoaded - switching to", startScreen);
+  console.log("➡ startScreen is:", startScreen);
   switchScreen(startScreen, undefined, { replace: true });
 });


### PR DESCRIPTION
## Summary
- log when `DOMContentLoaded` fires and which start screen we will show
- log when `renderIntroScreen` is called
- log the `app` element inside `renderIntroScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6844f273ca60832391e8a543c8381009