### PR TITLE
Add debug output to intro screen

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -3,7 +3,17 @@ import { switchScreen } from '../main.js';
 
 export function renderIntroScreen() {
   const app = document.getElementById('app');
-  console.log('app element:', app);
+  console.log('Intro: app element:', app);
+  if (!app) {
+    console.error('Intro: #app element not found');
+    return;
+  }
+
+  // Debug: minimal content to ensure something is rendered
+  app.innerHTML = '<h1 id="intro-debug">Intro Screen Debug</h1>';
+  const debugElem = document.getElementById('intro-debug');
+  console.log('Intro: debug element inserted?', !!debugElem);
+
   app.innerHTML = `
     <div class="intro-wrapper">
       <h1 class="intro-title">絶対音感トレーニング「オトロン」</h1>


### PR DESCRIPTION
## Summary
- improve logging in `renderIntroScreen`
- insert debug `<h1>` before rendering full intro markup

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6844f38036488323b490c0b603667d0f