### PR TITLE
Add extra debugging logs

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -43,4 +43,6 @@ export function renderIntroScreen() {
   } else {
     console.log('Intro: ボタンがDOMに存在しません (signup)');
   }
+
+  console.log('Intro screen rendered');
 }

--- a/main.js
+++ b/main.js
@@ -32,6 +32,8 @@ import { renderPricingScreen } from "./components/pricing.js";
 import { firebaseAuth } from "./firebase/firebase-init.js";
 import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
+console.log("\uD83D\uDE9A main.js module loaded");
+
 const DUMMY_PASSWORD = "secure_dummy_password";
 
 // console.log("🧭 main.js にて全コンポーネント統合済み");
@@ -58,6 +60,7 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   const { replace = false } = options;
 
   const app = document.getElementById("app");
+  console.log("switchScreen: app element", app);
   app.innerHTML = "";
 
   if (screen !== "home") {
@@ -111,6 +114,7 @@ window.addEventListener("popstate", (e) => {
 });
 
 onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
+  console.log("onAuthStateChanged triggered", firebaseUser);
   if (!firebaseUser) {
     console.log("🔒 ログインしていません");
     return;
@@ -205,4 +209,9 @@ window.addEventListener("DOMContentLoaded", () => {
   const startScreen = hash || initial;
   console.log("➡ startScreen is:", startScreen);
   switchScreen(startScreen, undefined, { replace: true });
+  console.log("switchScreen finished for", startScreen);
+});
+
+window.addEventListener("load", () => {
+  console.log("\u2728 load event fired");
 });


### PR DESCRIPTION
## Summary
- add debug log when main.js loads
- log `app` element and `onAuthStateChanged` state in main.js
- log DOMContentLoaded and load events
- confirm intro screen renders

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68450cbb3ff48323885064b990f5074c