### PR TITLE
Handle Supabase users more carefully

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -134,23 +134,54 @@ export function renderLoginScreen(container, onLoginSuccess) {
       sessionStorage.setItem("currentPassword", password);
       const user = firebaseAuth.currentUser;
       try {
-        const { error: signUpError } = await supabase.auth.signUp({
-          email: user.email,
-          password: DUMMY_PASSWORD,
-        });
-        if (signUpError && signUpError.message !== "User already registered") {
-          console.error("❌ Supabaseユーザー作成失敗:", signUpError.message);
-        }
+        const { data: existingUser } = await supabase
+          .from("users")
+          .select("*")
+          .eq("firebase_uid", user.uid)
+          .maybeSingle();
 
-        const { error: signInError } = await supabase.auth.signInWithPassword({
-          email: user.email,
-          password: DUMMY_PASSWORD,
-        });
-        if (signInError) {
-          console.error("❌ Supabaseログイン失敗:", signInError.message);
+        if (!existingUser) {
+          const { error: signUpError } = await supabase.auth.signUp({
+            email: user.email,
+            password: DUMMY_PASSWORD,
+          });
+          if (signUpError && !signUpError.message.includes("User already registered")) {
+            console.error("❌ Supabaseユーザー作成失敗:", signUpError.message);
+            return;
+          }
+
+          const { error: signInError } = await supabase.auth.signInWithPassword({
+            email: user.email,
+            password: DUMMY_PASSWORD,
+          });
+          if (signInError) {
+            console.error("❌ Supabaseログイン失敗:", signInError.message);
+            return;
+          }
+
+          const { data: inserted, error: insertError } = await supabase
+            .from("users")
+            .insert([{ firebase_uid: user.uid, email: user.email }])
+            .select()
+            .maybeSingle();
+
+          if (insertError || !inserted) {
+            console.error("❌ Supabaseユーザー登録失敗:", insertError);
+            return;
+          }
+        } else {
+          const { error: signInError } = await supabase.auth.signInWithPassword({
+            email: user.email,
+            password: DUMMY_PASSWORD,
+          });
+          if (signInError) {
+            console.error("❌ Supabaseログイン失敗:", signInError.message);
+            return;
+          }
         }
       } catch (e) {
         console.error("❌ Supabaseサインイン処理でエラー:", e);
+        return;
       }
       await ensureUserAndProgress(user);
       onLoginSuccess();
@@ -166,23 +197,54 @@ export function renderLoginScreen(container, onLoginSuccess) {
       const result = await signInWithPopup(firebaseAuth, provider);
       const user = result.user;
       try {
-        const { error: signUpError } = await supabase.auth.signUp({
-          email: user.email,
-          password: DUMMY_PASSWORD,
-        });
-        if (signUpError && signUpError.message !== "User already registered") {
-          console.error("❌ Supabaseユーザー作成失敗:", signUpError.message);
-        }
+        const { data: existingUser } = await supabase
+          .from("users")
+          .select("*")
+          .eq("firebase_uid", user.uid)
+          .maybeSingle();
 
-        const { error: signInError } = await supabase.auth.signInWithPassword({
-          email: user.email,
-          password: DUMMY_PASSWORD,
-        });
-        if (signInError) {
-          console.error("❌ Supabaseログイン失敗:", signInError.message);
+        if (!existingUser) {
+          const { error: signUpError } = await supabase.auth.signUp({
+            email: user.email,
+            password: DUMMY_PASSWORD,
+          });
+          if (signUpError && !signUpError.message.includes("User already registered")) {
+            console.error("❌ Supabaseユーザー作成失敗:", signUpError.message);
+            return;
+          }
+
+          const { error: signInError } = await supabase.auth.signInWithPassword({
+            email: user.email,
+            password: DUMMY_PASSWORD,
+          });
+          if (signInError) {
+            console.error("❌ Supabaseログイン失敗:", signInError.message);
+            return;
+          }
+
+          const { data: inserted, error: insertError } = await supabase
+            .from("users")
+            .insert([{ firebase_uid: user.uid, email: user.email }])
+            .select()
+            .maybeSingle();
+
+          if (insertError || !inserted) {
+            console.error("❌ Supabaseユーザー登録失敗:", insertError);
+            return;
+          }
+        } else {
+          const { error: signInError } = await supabase.auth.signInWithPassword({
+            email: user.email,
+            password: DUMMY_PASSWORD,
+          });
+          if (signInError) {
+            console.error("❌ Supabaseログイン失敗:", signInError.message);
+            return;
+          }
         }
       } catch (e) {
         console.error("❌ Supabaseサインイン処理でエラー:", e);
+        return;
       }
       await ensureUserAndProgress(user);
       onLoginSuccess();

--- a/main.js
+++ b/main.js
@@ -136,13 +136,23 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
   let user;
 
   if (!existingUser) {
-    // Supabase Auth にもユーザーを登録
+    // Supabase Auth にユーザー登録（初回のみ）
     const { error: signUpError } = await supabase.auth.signUp({
       email: firebaseUser.email,
       password: DUMMY_PASSWORD,
     });
     if (signUpError && !signUpError.message.includes("User already registered")) {
       console.error("❌ Supabaseユーザー作成失敗:", signUpError.message);
+      return;
+    }
+
+    // Sign in so that we have a valid session
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email: firebaseUser.email,
+      password: DUMMY_PASSWORD,
+    });
+    if (signInError) {
+      console.error("❌ Supabaseログイン失敗:", signInError.message);
       return;
     }
 


### PR DESCRIPTION
## Summary
- sign in to Supabase after creating a user in `main.js`
- avoid calling `signUp` for existing users in login flow

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68451fbb52b083238ef20652760ba1c4