### PR TITLE
Implement conditional Supabase sign-up/sign-in

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -7,6 +7,7 @@ import {
 import { firebaseAuth } from "../firebase/firebase-init.js";
 import { switchScreen } from "../main.js";
 import { supabase } from "../utils/supabaseClient.js";
+import { ensureSupabaseAuth } from "../utils/supabaseAuthHelper.js";
 import { chords } from "../data/chords.js";
 
 const DUMMY_PASSWORD = "secure_dummy_password";
@@ -134,51 +135,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       sessionStorage.setItem("currentPassword", password);
       const user = firebaseAuth.currentUser;
       try {
-        const { data: existingUser } = await supabase
-          .from("users")
-          .select("*")
-          .eq("firebase_uid", user.uid)
-          .maybeSingle();
-
-        if (!existingUser) {
-          const { error: signUpError } = await supabase.auth.signUp({
-            email: user.email,
-            password: DUMMY_PASSWORD,
-          });
-          if (signUpError && !signUpError.message.includes("User already registered")) {
-            console.error("❌ Supabaseユーザー作成失敗:", signUpError.message);
-            return;
-          }
-
-          const { error: signInError } = await supabase.auth.signInWithPassword({
-            email: user.email,
-            password: DUMMY_PASSWORD,
-          });
-          if (signInError) {
-            console.error("❌ Supabaseログイン失敗:", signInError.message);
-            return;
-          }
-
-          const { data: inserted, error: insertError } = await supabase
-            .from("users")
-            .insert([{ firebase_uid: user.uid, email: user.email }])
-            .select()
-            .maybeSingle();
-
-          if (insertError || !inserted) {
-            console.error("❌ Supabaseユーザー登録失敗:", insertError);
-            return;
-          }
-        } else {
-          const { error: signInError } = await supabase.auth.signInWithPassword({
-            email: user.email,
-            password: DUMMY_PASSWORD,
-          });
-          if (signInError) {
-            console.error("❌ Supabaseログイン失敗:", signInError.message);
-            return;
-          }
-        }
+        await ensureSupabaseAuth(user);
       } catch (e) {
         console.error("❌ Supabaseサインイン処理でエラー:", e);
         return;
@@ -197,51 +154,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       const result = await signInWithPopup(firebaseAuth, provider);
       const user = result.user;
       try {
-        const { data: existingUser } = await supabase
-          .from("users")
-          .select("*")
-          .eq("firebase_uid", user.uid)
-          .maybeSingle();
-
-        if (!existingUser) {
-          const { error: signUpError } = await supabase.auth.signUp({
-            email: user.email,
-            password: DUMMY_PASSWORD,
-          });
-          if (signUpError && !signUpError.message.includes("User already registered")) {
-            console.error("❌ Supabaseユーザー作成失敗:", signUpError.message);
-            return;
-          }
-
-          const { error: signInError } = await supabase.auth.signInWithPassword({
-            email: user.email,
-            password: DUMMY_PASSWORD,
-          });
-          if (signInError) {
-            console.error("❌ Supabaseログイン失敗:", signInError.message);
-            return;
-          }
-
-          const { data: inserted, error: insertError } = await supabase
-            .from("users")
-            .insert([{ firebase_uid: user.uid, email: user.email }])
-            .select()
-            .maybeSingle();
-
-          if (insertError || !inserted) {
-            console.error("❌ Supabaseユーザー登録失敗:", insertError);
-            return;
-          }
-        } else {
-          const { error: signInError } = await supabase.auth.signInWithPassword({
-            email: user.email,
-            password: DUMMY_PASSWORD,
-          });
-          if (signInError) {
-            console.error("❌ Supabaseログイン失敗:", signInError.message);
-            return;
-          }
-        }
+        await ensureSupabaseAuth(user);
       } catch (e) {
         console.error("❌ Supabaseサインイン処理でエラー:", e);
         return;

--- a/utils/supabaseAuthHelper.js
+++ b/utils/supabaseAuthHelper.js
@@ -1,0 +1,98 @@
+import { supabase } from './supabaseClient.js';
+
+const DUMMY_PASSWORD = 'secure_dummy_password';
+
+export async function ensureSupabaseAuth(firebaseUser) {
+  if (!firebaseUser) return { user: null, isNew: false };
+  const email = firebaseUser.email;
+
+  // Check our users table
+  const { data: existingUser, error: checkError } = await supabase
+    .from('users')
+    .select('*')
+    .eq('firebase_uid', firebaseUser.uid)
+    .maybeSingle();
+  if (checkError) {
+    console.error('❌ Supabaseユーザー確認エラー:', checkError);
+    throw checkError;
+  }
+
+  const signIn = async () => {
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password: DUMMY_PASSWORD,
+    });
+    return error;
+  };
+
+  if (!existingUser) {
+    const { error: signUpError } = await supabase.auth.signUp({
+      email,
+      password: DUMMY_PASSWORD,
+    });
+    if (signUpError && !signUpError.message.includes('User already registered')) {
+      console.error('❌ Supabaseユーザー作成失敗:', signUpError.message);
+      throw signUpError;
+    }
+
+    const signInError = await signIn();
+    if (signInError) {
+      console.error('❌ Supabaseログイン失敗:', signInError.message);
+      throw signInError;
+    }
+
+    const { data: inserted, error: insertError } = await supabase
+      .from('users')
+      .insert([
+        {
+          firebase_uid: firebaseUser.uid,
+          name: firebaseUser.displayName || '名前未設定',
+          email,
+        },
+      ])
+      .select()
+      .maybeSingle();
+
+    if (insertError || !inserted) {
+      console.error('❌ Supabaseユーザー登録失敗:', insertError);
+      throw insertError || new Error('insert failed');
+    }
+
+    return { user: inserted, isNew: true };
+  } else {
+    let signInError = await signIn();
+    if (signInError) {
+      // If credentials mismatch, attempt sign up once
+      if (signInError.message.includes('Invalid login credentials')) {
+        const { error: signUpError } = await supabase.auth.signUp({
+          email,
+          password: DUMMY_PASSWORD,
+        });
+        if (signUpError && !signUpError.message.includes('User already registered')) {
+          console.error('❌ Supabaseユーザー作成失敗:', signUpError.message);
+          throw signUpError;
+        }
+        signInError = await signIn();
+      }
+      if (signInError) {
+        console.error('❌ Supabaseログイン失敗:', signInError.message);
+        throw signInError;
+      }
+    }
+
+    let user = existingUser;
+    if (!user.email || user.email !== email) {
+      const { data: updated, error: updateError } = await supabase
+        .from('users')
+        .update({ email })
+        .eq('id', user.id)
+        .select()
+        .maybeSingle();
+      if (!updateError && updated) {
+        user = updated;
+      }
+    }
+
+    return { user, isNew: false };
+  }
+}


### PR DESCRIPTION
## Summary
- add `ensureSupabaseAuth` helper for Supabase auth management
- replace duplicated auth logic in login and main scripts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684522ee6f308323962438091fda9ccd