### PR TITLE
Fix checkout env docs and add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ Vercel などの環境でデプロイする際は次の環境変数を設定し�
 - `STRIPE_WEBHOOK_SECRET`
 - `SUPABASE_URL`
 - `SUPABASE_SERVICE_ROLE_KEY`
+- `PRICE_ID_1M`
+- `PRICE_ID_6M`
+- `PRICE_ID_12M`
 
+`PRICE_ID_*` は Stripe で発行した各プラン(1ヶ月/6ヶ月/12ヶ月)の価格IDです。
 これらは `.env.example` にも記載しているので参考にしてください。
 
 ## Supabase Database Schema

--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -10,6 +10,7 @@ const priceMap = {
 
 export default async function handler(req, res) {
   console.log('Stripe Checkout API called');
+  console.log('Current price map:', priceMap);
 
   if (req.method !== 'POST') {
     return res.status(405).send('Method Not Allowed');
@@ -20,6 +21,7 @@ export default async function handler(req, res) {
   console.log('Received email:', email, 'plan:', plan, '-> priceId:', priceId);
 
   if (!priceId) {
+    console.error('Invalid plan received. Plan:', plan, 'Price map:', priceMap);
     return res.status(400).json({ error: 'Invalid plan' });
   }
 


### PR DESCRIPTION
## Summary
- log the configured Stripe price map in the checkout API and include more info on invalid plan
- document the PRICE_ID_* variables in README so production deployments have the required config

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684546e71a8c83239d2498b38f6f9457