### PR TITLE
Fix checkout handling and remove console logs

### DIFF
--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -9,16 +9,23 @@ const priceMap = {
 };
 
 export default async function handler(req, res) {
-  console.log('Stripe Checkout API called');
-  console.log('Current price map:', priceMap);
 
   if (req.method !== 'POST') {
     return res.status(405).send('Method Not Allowed');
   }
 
-  const { email, plan } = req.body;
+  let body = req.body;
+  if (typeof body === 'string') {
+    try {
+      body = JSON.parse(body);
+    } catch (err) {
+      console.error('Invalid JSON body');
+      return res.status(400).json({ error: 'Invalid request' });
+    }
+  }
+
+  const { email, plan } = body || {};
   const priceId = priceMap[plan];
-  console.log('Received email:', email, 'plan:', plan, '-> priceId:', priceId);
 
   if (!priceId) {
     console.error('Invalid plan received. Plan:', plan, 'Price map:', priceMap);
@@ -42,7 +49,6 @@ export default async function handler(req, res) {
       customer_email: email,
     });
 
-    console.log('Created session:', session.id);
     res.status(200).json({ id: session.id });
   } catch (error) {
     console.error('❌ Error creating Stripe session:', error);

--- a/components/intro.js
+++ b/components/intro.js
@@ -1,11 +1,8 @@
 // components/intro.js
 import { switchScreen } from '../main.js';
 
-console.log("\ud83d\udce6 intro.js has been loaded!");
-
 export function renderIntroScreen() {
   const app = document.getElementById('app');
-  console.log('Intro: app element:', app);
   if (!app) {
     console.error('Intro: #app element not found');
     return;
@@ -31,8 +28,6 @@ export function renderIntroScreen() {
     loginBtn.addEventListener('click', () => {
       switchScreen('login');
     });
-  } else {
-    console.log('Intro: ボタンがDOMに存在しません (login)');
   }
 
   const signupBtn = document.getElementById('signup-btn');
@@ -40,9 +35,5 @@ export function renderIntroScreen() {
     signupBtn.addEventListener('click', () => {
       switchScreen('signup');
     });
-  } else {
-    console.log('Intro: ボタンがDOMに存在しません (signup)');
   }
-
-  console.log('Intro screen rendered');
 }

--- a/components/login.js
+++ b/components/login.js
@@ -89,10 +89,10 @@ export function renderLoginScreen(container, onLoginSuccess) {
         return;
       }
       userId = inserted.id;
-      console.log("✅ Supabaseユーザーを新規登録:", inserted);
+      
     } else {
       userId = existingUser.id;
-      console.log("✅ Supabaseに既存ユーザー:", existingUser);
+      
     }
   
     // user_chord_progress にすでにデータがあるか確認
@@ -117,7 +117,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       if (error) {
         console.error("❌ 和音進捗の初期登録失敗:", error);
       } else {
-        console.log("✅ 和音進捗を初期化しました");
+        
       }
     }
   }

--- a/components/training.js
+++ b/components/training.js
@@ -86,7 +86,6 @@ function shuffleArray(array) {
 }
 
 export async function renderTrainingScreen(user) {
-  console.log("🟢 renderTrainingScreen: user.id =", user?.id);
   currentUser = user;
   singleNoteMode = localStorage.getItem("singleNoteMode") === "on";
   singleNoteStrategy = localStorage.getItem("singleNoteStrategy") || 'top';
@@ -146,11 +145,7 @@ async function nextQuestion() {
     console.error("❌ currentUser が null または id が未定義です");
     return;
   }
-  console.log("🧩 nextQuestion():",
-  "queue.length =", questionQueue.length,
-  "questionCount =", questionCount,
-  "quitFlag =", quitFlag
-);
+  
   alreadyTried = false;
   isForcedAnswer = false;
   if (questionQueue.length === 0 || quitFlag) {
@@ -679,8 +674,6 @@ function checkAnswer(selected) {
 
     const proceed = () => {
       if (questionQueue.length === 0) {
-        console.log("📌 nextQuestion: セッション終了に到達");
-
         showFeedback("トレーニング終了！", "good", 0);
         nextQuestion();
       } else {

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -33,7 +33,6 @@ export async function renderGrowthScreen(user) {
   const today = getToday();
   const passed = await getPassedDays(user.id);
   const qualifiedDays = await countQualifiedDays(user.id);
-  console.log(`\u9023\u7D9A\u5408\u683C\u65E5\u6570: ${qualifiedDays}`);
   const qualifiedToday = await isQualifiedToday(user.id);
   const flags = await loadGrowthFlags(user.id);
   const target = getCurrentTargetChord(flags); // ← chordOrder に沿った未解放の最初の1つ
@@ -192,7 +191,6 @@ export async function renderGrowthScreen(user) {
       const days = parseInt(val.replace("mock", ""), 10);
       await generateMockGrowthData(user.id, days);
       const count = await countQualifiedDays(user.id);
-      console.log(`DEBUG: 現在の連続合格日数は ${count} 日です`);
       alert(`モックデータ(${days}日分)を生成しました`);
     }
     await renderGrowthScreen(user);

--- a/main.js
+++ b/main.js
@@ -33,8 +33,6 @@ import { renderPricingScreen } from "./components/pricing.js";
 import { firebaseAuth } from "./firebase/firebase-init.js";
 import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
-console.log("\uD83D\uDE9A main.js module loaded");
-
 const DUMMY_PASSWORD = "secure_dummy_password";
 
 // console.log("🧭 main.js にて全コンポーネント統合済み");
@@ -57,11 +55,9 @@ window.addEventListener("error", (e) => {
 let currentUser = null;
 
 export const switchScreen = (screen, user = currentUser, options = {}) => {
-  console.log("🔀 switchScreen called with:", screen);
   const { replace = false } = options;
 
   const app = document.getElementById("app");
-  console.log("switchScreen: app element", app);
   app.innerHTML = "";
 
   if (screen !== "home") {
@@ -78,7 +74,6 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   }
 
   if (screen === "intro") {
-    console.log("📺 calling renderIntroScreen");
     renderIntroScreen();
   }
   else if (screen === "login") renderLoginScreen(app, () => {});
@@ -115,9 +110,7 @@ window.addEventListener("popstate", (e) => {
 });
 
 onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
-  console.log("onAuthStateChanged triggered", firebaseUser);
   if (!firebaseUser) {
-    console.log("🔒 ログインしていません");
     return;
   }
 
@@ -145,13 +138,12 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 });
 
 const initApp = () => {
-  console.log("🚀 DOMContentLoaded fired");
   const initial = DEBUG_AUTO_LOGIN ? "home" : "intro";
   const hash = location.hash.replace("#", "");
   const startScreen = hash || initial;
-  console.log("➡ startScreen is:", startScreen);
+  
   switchScreen(startScreen, undefined, { replace: true });
-  console.log("switchScreen finished for", startScreen);
+  
 };
 
 if (document.readyState !== "loading") {
@@ -160,6 +152,4 @@ if (document.readyState !== "loading") {
   window.addEventListener("DOMContentLoaded", initApp);
 }
 
-window.addEventListener("load", () => {
-  console.log("\u2728 load event fired");
-});
+window.addEventListener("load", () => {});

--- a/utils/growthStore_supabase.js
+++ b/utils/growthStore_supabase.js
@@ -62,8 +62,6 @@ export async function markChordAsUnlocked(userId, chordKey) {
 
   if (error) {
     console.error(`❌ 和音 ${chordKey} の任意解放に失敗:`, error);
-  } else {
-    console.log(`✅ 和音 ${chordKey} を手動で解放しました`);
   }
 }
 

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -82,7 +82,6 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
   if (!msg || !btn || !progress || !card) return;
 
   const consecutive = await countQualifiedDays(user.id);
-  console.log(`\u73FE\u5728\u306E\u9023\u7D9A\u5408\u683C\u65E5\u6570: ${consecutive}`);
 
   const canUnlock = await checkRecentUnlockCriteria(user.id);
   const holdTime = 1500;

--- a/utils/progressUtils.js
+++ b/utils/progressUtils.js
@@ -24,8 +24,6 @@ export async function createInitialChordProgress(userId) {
 
   if (error) {
     console.error("❌ 初期進捗の登録失敗:", error);
-  } else {
-    console.log("✅ 初期進捗を登録しました（1件目を in_progress）");
   }
 }
 
@@ -100,7 +98,6 @@ export async function autoUnlockNextChord(user) {
     .eq("user_id", user.id)
     .eq("chord_key", nextChord);
 
-  console.log(`✅ ${currentChord} 完了 → ${nextChord} 開始`);
 }
 
 // ✅ 和音を解放（in_progressに）

--- a/utils/stripeCheckout.js
+++ b/utils/stripeCheckout.js
@@ -2,7 +2,6 @@ import { firebaseAuth } from '../firebase/firebase-init.js';
 
 export async function startCheckout(plan) {
   const email = firebaseAuth.currentUser?.email || '未取得';
-  console.log('✨ checkout email:', email);
   if (!firebaseAuth.currentUser?.email) {
     alert('ログイン情報がありません');
     return;

--- a/utils/supabaseClient.js
+++ b/utils/supabaseClient.js
@@ -26,7 +26,6 @@ try {
 if (typeof supabase.auth.signIn === "function") {
   const orig = supabase.auth.signIn.bind(supabase.auth);
   supabase.auth.signIn = async (...args) => {
-    console.log("[debug] supabase.auth.signIn called", args);
     if (args[0] && args[0].provider === "firebase") {
       console.warn("[debug] signIn with provider 'firebase' blocked");
       return { data: null, error: new Error("signIn with firebase provider disallowed") };
@@ -36,7 +35,6 @@ if (typeof supabase.auth.signIn === "function") {
 }
 if (typeof supabase.auth.signInWithIdToken === "function") {
   supabase.auth.signInWithIdToken = async (...args) => {
-    console.log("[debug] supabase.auth.signInWithIdToken called", args);
     console.warn("[debug] signInWithIdToken blocked");
     return { data: null, error: new Error("signInWithIdToken disabled") };
   };

--- a/utils/trainingStore_supabase.js
+++ b/utils/trainingStore_supabase.js
@@ -20,15 +20,7 @@ export async function saveTrainingSession({ userId, results, stats, mistakes, co
     console.warn("saveTrainingSession called without valid user ID");
     return;
   }
-  console.log("🟡 saveTrainingSession 実行:", {
-    userId,
-    results,
-    stats,
-    mistakes,
-    correctCount,
-    totalCount,
-    date
-  });
+  
   const structuredMistakes = convertMistakesJsonToStructuredForm(mistakes, results);
   const isQualified = sessionMeetsStats(stats, totalCount);
   const { data, error } = await supabase.from("training_sessions").insert([
@@ -47,7 +39,6 @@ export async function saveTrainingSession({ userId, results, stats, mistakes, co
   if (error) {
     console.error("❌ セッション保存に失敗:", error);
   } else {
-    console.log("✅ セッション保存に成功:", data);
     await markQualifiedDayIfNeeded(userId, date);
   }
 }


### PR DESCRIPTION
## Summary
- parse body in `create-checkout-session` to avoid invalid plan errors
- clean unnecessary `console.log` calls across the app

## Testing
- `node --check api/create-checkout-session.js`
- `node --check components/intro.js`
- `node --check main.js`
- `node --check components/training.js`
- `node --check utils/progressStatus.js`
- `node --check utils/progressUtils.js`
- `node --check utils/trainingStore_supabase.js`
- `node --check utils/supabaseClient.js`
- `node --check utils/growthStore_supabase.js`
- `node --check components/login.js`


------
https://chatgpt.com/codex/tasks/task_b_684547eed03c83238b509ad55dcc62a4