### PR TITLE
Hide plan option for premium users

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -103,7 +103,14 @@ export function renderHeader(container, user) {
   header.querySelector("#settings-btn").onclick = () => switchScreen("settings");
   header.querySelector("#summary-btn").onclick = () => switchScreen("result");
   header.querySelector("#growth-btn").onclick = () => switchScreen("growth");
-  header.querySelector("#pricing-btn").onclick = () => switchScreen("pricing");
+  const pricingBtn = header.querySelector("#pricing-btn");
+  if (pricingBtn) {
+    if (user?.is_premium) {
+      pricingBtn.style.display = "none";
+    } else {
+      pricingBtn.onclick = () => switchScreen("pricing");
+    }
+  }
 
   header.querySelector("#mypage-btn").onclick = () => switchScreen("mypage");
 

--- a/components/planInfo.js
+++ b/components/planInfo.js
@@ -62,7 +62,9 @@ async function createPlanInfoContent(user) {
     const exp = new Date(sub.ended_at);
     const expireEl = document.createElement('div');
     expireEl.className = 'expire-date';
-    expireEl.textContent = formatDate(exp);
+    const diffMs = exp.getTime() - Date.now();
+    const remaining = Math.max(0, Math.ceil(diffMs / (1000 * 60 * 60 * 24)));
+    expireEl.textContent = `${formatDate(exp)} (残り${remaining}日)`;
     container.appendChild(expireEl);
   }
 


### PR DESCRIPTION
## Summary
- hide the `プラン` menu item for premium users
- show remaining days for current plan

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6845a1a5446c83239f80f017b269dfc7