### PR TITLE
Manage premium flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ Vercel などの環境でデプロイする際は次の環境変数を設定し�
 以前は `training_records` に `chords_required` カラムを追加する案がありましたが、
 現在の構成では使用していません。
 
+## Premium Management
+
+Stripe Checkout 完了時の Webhook では `users` テーブルの `is_premium` を `true`
+に更新します。また有効期限が切れたユーザーを定期的にチェックし、
+`is_premium` を `false` に戻すバッチスクリプト
+`scripts/resetExpiredPremiums.js` を用意しています。
+
+```bash
+npm run reset-expired-premiums
+```
+
+このスクリプトは日次ジョブ等で実行してください。
+
 ## Troubleshooting
 
 Supabase へのサインインに失敗し `Custom OIDC provider "firebase" not allowed` と表示される場合は、過去のコードを利用している可能性があります。現在の実装では Firebase ユーザーのメールアドレスを用いて次のようにダミーパスワードでサインアップ・サインインする方式に切り替えています。

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "stripe": "^12.15.0",
     "@supabase/supabase-js": "^2.39.7",
     "micro": "^9.3.4"
+  },
+  "scripts": {
+    "reset-expired-premiums": "node scripts/resetExpiredPremiums.js"
   }
 }
 

--- a/scripts/resetExpiredPremiums.js
+++ b/scripts/resetExpiredPremiums.js
@@ -1,0 +1,47 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  }
+);
+
+async function resetExpiredPremiums() {
+  const { data: subscriptions, error } = await supabase
+    .from('user_subscriptions')
+    .select('user_id')
+    .lt('ended_at', new Date().toISOString())
+    .eq('status', 'active');
+
+  if (error) {
+    console.error('Failed to fetch expired subscriptions:', error);
+    process.exit(1);
+  }
+
+  const userIds = subscriptions.map((s) => s.user_id);
+  if (userIds.length === 0) {
+    console.log('No expired subscriptions found');
+    return;
+  }
+
+  const { error: updateError } = await supabase
+    .from('users')
+    .update({ is_premium: false })
+    .in('id', userIds)
+    .eq('is_premium', true);
+
+  if (updateError) {
+    console.error('Failed to update users:', updateError);
+    process.exit(1);
+  }
+
+  console.log(`Updated ${userIds.length} users to is_premium=false`);
+}
+
+resetExpiredPremiums();


### PR DESCRIPTION
## Summary
- handle additional Stripe webhook events
- add script to reset expired premium users
- document Premium management in README

## Testing
- `node scripts/resetExpiredPremiums.js` *(fails: Cannot find package '@supabase/supabase-js' ...)*
- `npm run reset-expired-premiums` *(fails: Cannot find package '@supabase/supabase-js' ...)*

------
https://chatgpt.com/codex/tasks/task_b_6845ac39cfc48323bceec15632e5b752