### PR TITLE
Fix Stripe webhook user lookup

### DIFF
--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -53,10 +53,10 @@ export default async function handler(req, res) {
         stripe_customer_id: customerId,
       });
 
-    if (email) {
-      query = query.eq('email', email);
-    } else {
+    if (customerId) {
       query = query.eq('stripe_customer_id', customerId);
+    } else if (email) {
+      query = query.eq('email', email);
     }
 
     const { error } = await query;

--- a/pages/api/stripe-webhook.js
+++ b/pages/api/stripe-webhook.js
@@ -52,10 +52,10 @@ export default async function handler(req, res) {
         stripe_customer_id: customerId,
       });
 
-    if (email) {
-      query = query.eq('email', email);
-    } else {
+    if (customerId) {
       query = query.eq('stripe_customer_id', customerId);
+    } else if (email) {
+      query = query.eq('email', email);
     }
 
     const { error } = await query;


### PR DESCRIPTION
## Summary
- handle webhook customerId lookup first so email change doesn't fail

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run reset-expired-premiums` *(fails: Cannot find package '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_b_6848435e599c8323926809bc9e842b17