### PR TITLE
Unify confirm dialogs with custom modal

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -111,8 +111,12 @@ export function showCustomConfirm(message, onConfirm, options = {}) {
     message = "本当に和音を解放しますか？";
     options = {};
   }
-  const { okText = "OK", cancelText = "キャンセル", showCancel = true } =
-    options;
+  const {
+    title = "",
+    okText = "OK",
+    cancelText = "キャンセル",
+    showCancel = true,
+  } = options;
   let modal = document.getElementById("custom-confirm");
   if (!modal) {
     modal = document.createElement("div");
@@ -134,6 +138,12 @@ export function showCustomConfirm(message, onConfirm, options = {}) {
     box.style.padding = "1.5em";
     box.style.borderRadius = "10px";
     box.style.textAlign = "center";
+
+    const titleNode = document.createElement("h3");
+    titleNode.id = "custom-confirm-title";
+    titleNode.textContent = title;
+    titleNode.style.margin = "0 0 0.5em";
+    box.appendChild(titleNode);
 
     const messageEl = document.createElement("p");
     messageEl.id = "custom-confirm-message";
@@ -165,6 +175,12 @@ export function showCustomConfirm(message, onConfirm, options = {}) {
     box.appendChild(buttons);
     modal.appendChild(box);
     document.body.appendChild(modal);
+  }
+
+  const titleEl = modal.querySelector("#custom-confirm-title");
+  if (titleEl) {
+    titleEl.textContent = title;
+    titleEl.style.display = title ? "block" : "none";
   }
 
   const msgEl = modal.querySelector("#custom-confirm-message");

--- a/components/planInfo.js
+++ b/components/planInfo.js
@@ -1,6 +1,7 @@
 import { renderHeader } from './header.js';
 import { supabase } from '../utils/supabaseClient.js';
 import { switchScreen } from '../main.js';
+import { showCustomConfirm } from './home.js';
 
 const planMap = {
   plan1: { name: '1ヶ月プラン', monthly: 1490, total: 1490 },
@@ -80,18 +81,19 @@ async function createPlanInfoContent(user) {
     const cancelBtn = document.createElement('button');
     cancelBtn.textContent = 'プレミア解約する';
     cancelBtn.onclick = async () => {
-      if (!confirm('本当に解約しますか？')) return;
-      const res = await fetch('/api/cancel-subscription', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email }),
+      showCustomConfirm('本当に解約しますか？', async () => {
+        const res = await fetch('/api/cancel-subscription', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: user.email }),
+        });
+        if (res.ok) {
+          alert('解約手続きを受け付けました');
+          switchScreen('home');
+        } else {
+          alert('解約に失敗しました');
+        }
       });
-      if (res.ok) {
-        alert('解約手続きを受け付けました');
-        switchScreen('home');
-      } else {
-        alert('解約に失敗しました');
-      }
     };
     btnWrap.appendChild(cancelBtn);
   }

--- a/components/settings.js
+++ b/components/settings.js
@@ -82,9 +82,9 @@ export async function renderSettingsScreen(user) {
 const resetBtn = document.createElement("button");
 resetBtn.textContent = "推奨出題にする";
 resetBtn.onclick = () => {
-  if (confirm("本当に推奨出題にしますか？")) {
+  showCustomConfirm("本当に推奨出題にしますか？", () => {
     resetToRecommendedChords(unlockedKeys, user); // ← user を渡す！
-  }
+  });
 };
 buttonGroup.appendChild(resetBtn);
 

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -165,11 +165,13 @@ export async function renderGrowthScreen(user) {
     actionSelect.value = "";
     if (!val) return;
     if (val === "reset") {
-      const ok = confirm("本当に進捗を赤だけに戻しますか？");
-      if (ok) {
-        const success = await resetChordProgressToRed(user.id);
-        alert(success ? "進捗をリセットしました" : "リセットに失敗しました");
-      }
+      showCustomConfirm(
+        "本当に進捗を赤だけに戻しますか？",
+        async () => {
+          const success = await resetChordProgressToRed(user.id);
+          alert(success ? "進捗をリセットしました" : "リセットに失敗しました");
+        }
+      );
     } else if (val === "unlock") {
       const freshFlags = await loadGrowthFlags(user.id);
       const next = getCurrentTargetChord(freshFlags);
@@ -182,11 +184,13 @@ export async function renderGrowthScreen(user) {
         alert("すべての和音が解放されています");
       }
     } else if (val === "clearWeek") {
-      const ok = confirm("今週のトレーニングデータを本当に削除しますか？");
-      if (ok) {
-        const success = await deleteTrainingDataThisWeek(user.id);
-        alert(success ? "今週のデータを削除しました" : "削除に失敗しました");
-      }
+      showCustomConfirm(
+        "今週のトレーニングデータを本当に削除しますか？",
+        async () => {
+          const success = await deleteTrainingDataThisWeek(user.id);
+          alert(success ? "今週のデータを削除しました" : "削除に失敗しました");
+        }
+      );
     } else if (val.startsWith("mock")) {
       const days = parseInt(val.replace("mock", ""), 10);
       await generateMockGrowthData(user.id, days);

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -1,7 +1,6 @@
 import { supabase } from "./supabaseClient.js";
 import { unlockChord } from "./progressUtils.js";
 import { applyRecommendedSelection, forceUnlock } from "./growthUtils.js";
-import { showCustomConfirm } from "../components/home.js";
 import { getAudio } from "./audioCache.js";
 import { getConsecutiveQualifiedDays } from "./qualifiedStore_supabase.js";
 


### PR DESCRIPTION
## Summary
- allow showCustomConfirm to display optional title
- swap all native `confirm()` calls for showCustomConfirm
- wire up showCustomConfirm in planInfo, growth, settings
- remove unused confirm import

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6849befa0e108323b776c19beb3a7cf6