### PR TITLE
Use custom modals for login/logout messages

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -5,6 +5,7 @@ import { checkRecentUnlockCriteria } from "../utils/progressStatus.js";
 import { loadGrowthFlags } from "../utils/growthStore_supabase.js";
 import { getCurrentTargetChord } from "../utils/growthUtils.js";
 import { supabase } from "../utils/supabaseClient.js";
+import { showCustomAlert } from "./home.js";
 
 export function renderHeader(container, user) {
   const header = document.createElement("header");
@@ -161,10 +162,11 @@ export function renderHeader(container, user) {
         console.error("❌ Supabaseサインアウト処理でエラー:", e);
       }
       sessionStorage.removeItem("currentPassword");
-      alert("ログアウトしました！");
-      switchScreen("intro");
+      showCustomAlert("ログアウトしました！", () => {
+        switchScreen("intro");
+      });
     } catch (e) {
-      alert("ログアウトに失敗しました：" + e.message);
+      showCustomAlert("ログアウトに失敗しました：" + e.message);
     }
   });
 

--- a/components/home.js
+++ b/components/home.js
@@ -201,3 +201,12 @@ export function showCustomConfirm(message, onConfirm, options = {}) {
   modal.callback = onConfirm;
   modal.style.display = "flex";
 }
+
+export function showCustomAlert(message, onOk, options = {}) {
+  if (typeof message === "function") {
+    onOk = message;
+    message = "";
+    options = {};
+  }
+  showCustomConfirm(message, onOk, { ...options, showCancel: false });
+}

--- a/components/login.js
+++ b/components/login.js
@@ -11,6 +11,7 @@ import { switchScreen } from "../main.js";
 import { supabase } from "../utils/supabaseClient.js";
 import { ensureSupabaseAuth } from "../utils/supabaseAuthHelper.js";
 import { chords } from "../data/chords.js";
+import { showCustomAlert } from "./home.js";
 
 const DUMMY_PASSWORD = "secure_dummy_password";
 
@@ -135,7 +136,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
     try {
       const methods = await fetchSignInMethodsForEmail(firebaseAuth, email);
       if (methods.includes('google.com') && !methods.includes('password')) {
-        alert('このメールアドレスはGoogleログイン専用です。Googleログインをご利用ください。');
+        showCustomAlert('このメールアドレスはGoogleログイン専用です。Googleログインをご利用ください。');
         return;
       }
 
@@ -151,7 +152,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       await ensureUserAndProgress(user);
       onLoginSuccess();
     } catch (err) {
-      alert("ログイン失敗：" + err.message);
+      showCustomAlert("ログイン失敗：" + err.message);
     }
   });
 
@@ -164,7 +165,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       const methods = await fetchSignInMethodsForEmail(firebaseAuth, user.email);
       if (methods.includes('password') && !methods.includes('google.com')) {
         await signOut(firebaseAuth);
-        alert('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。');
+        showCustomAlert('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。');
         return;
       }
       try {
@@ -177,9 +178,9 @@ export function renderLoginScreen(container, onLoginSuccess) {
       onLoginSuccess();
     } catch (err) {
       if (err.code === 'auth/account-exists-with-different-credential') {
-        alert('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。');
+        showCustomAlert('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。');
       } else {
-        alert("Googleログイン失敗：" + err.message);
+        showCustomAlert("Googleログイン失敗：" + err.message);
       }
     }
   });


### PR DESCRIPTION
## Summary
- add `showCustomAlert` helper
- replace alert dialogs in logout and login with custom modal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6849c05b6fdc8323ab7757b761485cfb