### PR TITLE
Handle missing chord selection

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -257,6 +257,14 @@ buttonGroup.appendChild(resetBtn);
       setEnabled(checked && isUnlocked);
 
       checkbox.addEventListener('change', () => {
+        if (!checkbox.checked) {
+          const others = document.querySelectorAll('.chord-toggle:checked');
+          if (others.length === 0) {
+            checkbox.checked = true;
+            return;
+          }
+        }
+
         const en = checkbox.checked;
         if (en && parseInt(numSpan.textContent) === 0) {
           numSpan.textContent = '4';

--- a/components/training.js
+++ b/components/training.js
@@ -129,6 +129,23 @@ export async function renderTrainingScreen(user) {
     localStorage.setItem("selectedChords", JSON.stringify(recommended));
     questionQueue = [...queue];
   }
+
+  if (selectedChords.length === 0) {
+    const queue = generateRecommendedQueue(flags);
+
+    const countMap = {};
+    queue.forEach(name => {
+      countMap[name] = (countMap[name] || 0) + 1;
+    });
+
+    const fallback = chords
+      .filter(ch => countMap[ch.name])
+      .map(ch => ({ name: ch.name, count: countMap[ch.name] }));
+
+    selectedChords.push(...fallback);
+    localStorage.setItem("selectedChords", JSON.stringify(fallback));
+    questionQueue = queue.length ? [...queue] : createQuestionQueue();
+  }
   questionCount = 0;
   quitFlag = false;
   alreadyTried = false;


### PR DESCRIPTION
## Summary
- fallback to recommended chords when none are selected
- prevent removing the final chord checkbox selection

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_b_684b561d231483238c22c01a2d37ae64