### PR TITLE
Allow premium users to change plans

### DIFF
--- a/components/pricing.js
+++ b/components/pricing.js
@@ -1,12 +1,6 @@
 import { renderHeader } from './header.js';
 import { startCheckout } from '../utils/stripeCheckout.js';
-import { renderPlanInfoScreen } from './planInfo.js';
-
 export function renderPricingScreen(user) {
-  if (user?.is_premium) {
-    renderPlanInfoScreen(user);
-    return;
-  }
   const app = document.getElementById('app');
   app.innerHTML = '';
   renderHeader(app, user);


### PR DESCRIPTION
## Summary
- remove redirect in pricing page so premium users can view plan list

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684c3c5838d48323b1d78218b9a61859