### PR TITLE
Fix cancel subscription endpoint

### DIFF
--- a/components/planInfo.js
+++ b/components/planInfo.js
@@ -88,7 +88,7 @@ async function createPlanInfoContent(user) {
           const res = await fetch('/api/cancel-subscription', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ email: user.email }),
+            body: JSON.stringify({ userId: user.id }),
           });
           if (res.ok) {
             const data = await res.json();


### PR DESCRIPTION
## Summary
- cancel subscription via user id
- allow API to resolve user from user id or email

## Testing
- `npm run reset-expired-premiums` *(fails: Cannot find package '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_b_684c461d1a4c832384bf57e7e3b651b0