### PR TITLE
Fix header pricing visibility and settings scroll

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -106,10 +106,10 @@ export function renderHeader(container, user) {
   header.querySelector("#growth-btn").onclick = () => switchScreen("growth");
   const pricingBtn = header.querySelector("#pricing-btn");
   if (pricingBtn) {
-    if (user?.is_premium) {
-      pricingBtn.style.display = "none";
-    } else {
+    if (user && !user.is_premium) {
       pricingBtn.onclick = () => switchScreen("pricing");
+    } else {
+      pricingBtn.style.display = "none";
     }
   }
 

--- a/components/settings.js
+++ b/components/settings.js
@@ -308,7 +308,6 @@ buttonGroup.appendChild(resetBtn);
   });
 
   container.appendChild(chordSettings);
-  app.appendChild(container);
 
   // ✅ その他のトレーニングセクション
   const section = document.createElement("div");
@@ -321,7 +320,8 @@ buttonGroup.appendChild(resetBtn);
       <li><button id="btn-full">単音テスト（全88鍵）</button></li>
     </ul>
   `;
-  app.appendChild(section);
+  container.appendChild(section);
+  app.appendChild(container);
 
   document.getElementById("btn-easy").onclick = () => switchScreen("training_easy");
   document.getElementById("btn-full").onclick = () => switchScreen("training_full");


### PR DESCRIPTION
## Summary
- show Pricing link only when logged in and not premium
- append extra training section inside settings screen so the page scrolls correctly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run reset-expired-premiums` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_b_684c4b3a688c8323bcc7047ad1ffa6d8