### PR TITLE
Update intro screen to landing page

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -1,5 +1,5 @@
 // components/intro.js
-import { switchScreen } from '../main.js';
+import { switchScreen } from "../main.js";
 
 export function renderIntroScreen() {
   const app = document.getElementById('app');
@@ -8,18 +8,84 @@ export function renderIntroScreen() {
     return;
   }
 
+  app.classList.add("with-header");
   app.innerHTML = `
-    <div class="intro-wrapper">
-      <h1 class="intro-title">絶対音感トレーニング「オトロン」</h1>
-      <p class="intro-description">
-        色で覚える、楽しい絶対音感トレーニング！<br>
-        「音の色」を覚えながら、遊ぶように絶対音感が身につくアプリです。<br>
-        はじめての音感トレーニングに、ちょうどいい。
-      </p>
-      <div class="intro-buttons">
-        <button id="login-btn">ログイン</button>
-        <button id="signup-btn">無料会員登録</button>
+    <header class="app-header intro-header">
+      <button class="home-icon" id="intro-home-btn">
+        <img src="images/otolon_face.webp" alt="トップへ" />
+      </button>
+      <div class="header-right">
+        <button id="login-btn" class="intro-login">ログイン</button>
+        <button id="signup-btn" class="intro-signup">無料会員登録</button>
       </div>
+    </header>
+    <div id="lp-top" class="intro-wrapper">
+      <section class="hero">
+        <h1 class="hero-title">もうドレミは、「ドレミ」から教えない。</h1>
+        <p class="hero-sub">2歳からはじめる、色と和音で育てる絶対音感トレーニングアプリ</p>
+        <div class="hero-visual">
+          <img src="images/otolon.webp" alt="アプリ画面イメージ" />
+        </div>
+        <button id="hero-cta" class="cta-button">今すぐ無料体験する</button>
+      </section>
+
+      <section class="problems">
+        <h2>こんなお悩みありませんか？</h2>
+        <ul class="problem-list">
+          <li>子どもが音感に興味を持ち始めたけど、どう教えればいいかわからない</li>
+          <li>ドレミを覚えるよりも“耳でわかる”力を育てたい</li>
+          <li>毎日少しだけでも練習を習慣化したい</li>
+          <li>ピアノ教室の教材に“遊び感覚”のものがほしい</li>
+        </ul>
+      </section>
+
+      <section class="features">
+        <h2>4ステップで身につく絶対音感</h2>
+        <div class="step">
+          <h3>Step 01：色と和音で楽しくトレーニング</h3>
+          <p>色旗×コードの組み合わせで、小さな子どもでも直感的に音を覚えていける</p>
+        </div>
+        <div class="step">
+          <h3>Step 02：進捗に応じて和音が増える「育成モード」</h3>
+          <p>毎日のがんばりで和音がアンロックされる、ゲーム感覚の育成モード搭載</p>
+        </div>
+        <div class="step">
+          <h3>Step 03：結果は保護者と共有して見守れる</h3>
+          <p>分析グラフは未搭載。代わりに、保護者と成績を「共有」できる機能を提供</p>
+        </div>
+        <div class="step">
+          <h3>Step 04：単音分化モードあり</h3>
+          <p>和音から単音への移行トレーニングも搭載。柔軟な設定も多数（出題比率、構成音限定など）</p>
+        </div>
+      </section>
+
+      <section class="result-example">
+        <h2>トレーニング結果表示例</h2>
+        <div class="result-block">
+          <p>🗓 トレーニング実施日数：8日間</p>
+          <p>✅ 合格日数：0日間（1日あたり2回以上のトレーニング・各和音4問以上・正答率98%以上）</p>
+          <p>📊 合計出題数：0問</p>
+          <p>🎯 正答率：0.0%</p>
+          <p>🔓 解放済み和音（色）：赤、黄色、青</p>
+          <p>🔍 ミス傾向：</p>
+          <p>📣 コメント：</p>
+        </div>
+      </section>
+
+      <section class="faq">
+        <h2>よくある質問</h2>
+        <details><summary>Q. 2歳半でも使えますか？</summary></details>
+        <details><summary>Q. 音楽の知識がなくても使えますか？</summary></details>
+        <details><summary>Q. ピアノ教室の教材として使えますか？</summary></details>
+        <details><summary>Q. どの端末で使えますか？</summary></details>
+        <details><summary>Q. 間違えても大丈夫ですか？</summary></details>
+        <details><summary>Q. 有料版はいくらで、何ができますか？</summary></details>
+      </section>
+
+      <footer class="lp-footer">
+        <button id="footer-cta" class="cta-button">無料体験する</button>
+        <p>&copy; 2024 Otoron</p>
+      </footer>
     </div>
   `;
 
@@ -34,6 +100,20 @@ export function renderIntroScreen() {
   if (signupBtn) {
     signupBtn.addEventListener('click', () => {
       switchScreen('signup');
+    });
+  }
+
+  const heroCta = document.getElementById('hero-cta');
+  const footerCta = document.getElementById('footer-cta');
+  [heroCta, footerCta].forEach((btn) => {
+    if (btn) btn.addEventListener('click', () => switchScreen('signup'));
+  });
+
+  const topBtn = document.getElementById('intro-home-btn');
+  if (topBtn) {
+    topBtn.addEventListener('click', () => {
+      const top = document.getElementById('lp-top');
+      top?.scrollIntoView({ behavior: 'smooth' });
     });
   }
 }

--- a/css/intro.css
+++ b/css/intro.css
@@ -1,65 +1,102 @@
-.intro-wrapper {
+/* Landing page styles */
+
+.intro-header .header-right {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  padding: 4em 1em;
-  min-height: 100vh;
-  box-sizing: border-box;
-  background-color: #fff8f2;
-  font-family: inherit;
+  gap: 0.6em;
+  margin-left: auto;
 }
 
-.intro-title {
-  font-size: 2.2em;
-  font-weight: bold;
-  color: #333;
-  margin-bottom: 1rem;
-}
-
-.intro-description {
-  font-size: 1.1em;
-  color: #444;
-  line-height: 1.6;
-  max-width: 600px;
-  margin-bottom: 2em;
-}
-
-.intro-buttons {
-  margin-top: 2em;
-  display: flex;
-  gap: 1.2em;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-/* ボタン共通 */
-.intro-buttons button {
-  font-size: 1.1em;
-  padding: 0.6em 1.4em;
+.intro-header .header-right button {
   border: none;
-  border-radius: 8px;
-  color: white;
+  border-radius: 6px;
+  padding: 0.4em 1em;
+  font-size: 0.9rem;
+  color: #fff;
   cursor: pointer;
-  transition: background-color 0.3s ease;
-  opacity: 1; /* 念のため可視 */
 }
 
-/* ログインボタン用 */
-#login-btn {
+.intro-header #login-btn {
   background-color: #66bbff;
 }
 
-#login-btn:hover {
+.intro-header #login-btn:hover {
   background-color: #42a5f5;
 }
 
-/* 無料会員登録ボタン用 */
-#signup-btn {
+.intro-header #signup-btn {
   background-color: #ff9900;
 }
 
-#signup-btn:hover {
+.intro-header #signup-btn:hover {
   background-color: #e57c00;
+}
+
+.intro-wrapper {
+  padding: 4em 1em;
+  text-align: center;
+  box-sizing: border-box;
+  background-color: #fff8f2;
+}
+
+.hero-title {
+  font-size: 2.2em;
+  margin-bottom: 0.5em;
+}
+
+.hero-sub {
+  font-size: 1.1em;
+  margin-bottom: 1.5em;
+}
+
+.hero-visual img {
+  width: 100%;
+  max-width: 800px;
+}
+
+.cta-button {
+  margin-top: 1.5em;
+  background-color: #ff9900;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6em 1.4em;
+  font-size: 1.1em;
+  cursor: pointer;
+}
+
+.problems,
+.features,
+.result-example,
+.faq {
+  padding: 3em 0;
+}
+
+.problem-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6em;
+}
+
+.step {
+  margin-bottom: 1.5em;
+}
+
+.result-block {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1em;
+  display: inline-block;
+  text-align: left;
+}
+
+.lp-footer {
+  padding: 2em 0;
+  text-align: center;
+}
+
+.lp-footer .cta-button {
+  margin-bottom: 1em;
 }


### PR DESCRIPTION
## Summary
- convert intro.js to a landing page with hero sections and FAQ
- add CTA buttons and header with login and signup links
- style the new landing page layout in intro.css

## Testing
- `npm run` *(fails: unknown env config warning)*

------
https://chatgpt.com/codex/tasks/task_b_684d1be64a7083238e6a808ac4a0dc0b