### PR TITLE
Revamp intro FAQ accordion

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -86,30 +86,72 @@ export function renderIntroScreen() {
 
       <section class="faq">
         <h2>よくある質問</h2>
-        <details>
-          <summary>Q1. 2歳半でも使えますか？</summary>
-          <p>はい、ご使用いただけます。オトロンは2歳半〜6歳の「絶対音感の適齢期」に合わせて設計されています。色や音で楽しく反応できるので、文字が読めなくても安心して使えます。</p>
-        </details>
-        <details>
-          <summary>Q2. 音楽の知識がなくても使えますか？</summary>
-          <p>はい、大丈夫です！ 特別な知識がなくても、アプリの指示通りに進めるだけでOK。保護者用の成績表示も「色」や「正答率」で視覚的にわかるようになっています。</p>
-        </details>
-        <details>
-          <summary>Q3. ピアノ教室の教材としても使えますか？</summary>
-          <p>はい、補助教材としてご活用いただける設計にしております。短時間でできるため、レッスンの冒頭や宿題にも最適です。進捗を保護者と共有できるので、ご家庭での練習もスムーズになります。</p>
-        </details>
-        <details>
-          <summary>Q4. どんな端末で使えますか？</summary>
-          <p>スマートフォン（iPhone／Android）、タブレット、パソコンでもご利用いただけます。特にタブレットでの操作が、子どもには見やすくておすすめです。</p>
-        </details>
-        <details>
-          <summary>Q5. 間違えても大丈夫ですか？子どもが自信をなくしませんか？</summary>
-          <p>大丈夫です。オトロンでは、間違えたときも優しくガイドされる設計になっており、子どもが嫌な気持ちにならないよう工夫されています。「できた！」を積み重ねて、自信を育てることを大切にしています。</p>
-        </details>
-        <details>
-          <summary>Q6. 有料版では何ができますか？価格は？</summary>
-          <p>無料体験では一部の和音や機能をご利用いただけます。有料版では、すべての和音や育成モード、進捗管理、共有機能などが解放され、より本格的なトレーニングが可能になります。料金の詳細はアプリ内または登録ページにてご確認ください。</p>
-        </details>
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            <span class="q-icon">Q</span>
+            <span class="q-text">2歳半でも使えますか？</span>
+            <span class="toggle-icon" aria-hidden="true"></span>
+          </button>
+          <div class="faq-answer" hidden>
+            <span class="a-label">A</span>
+            <p>はい、ご使用いただけます。オトロンは2歳半〜6歳の「絶対音感の適齢期」に合わせて設計されています。色や音で楽しく反応できるので、文字が読めなくても安心して使えます。</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            <span class="q-icon">Q</span>
+            <span class="q-text">音楽の知識がなくても使えますか？</span>
+            <span class="toggle-icon" aria-hidden="true"></span>
+          </button>
+          <div class="faq-answer" hidden>
+            <span class="a-label">A</span>
+            <p>はい、大丈夫です！ 特別な知識がなくても、アプリの指示通りに進めるだけでOK。保護者用の成績表示も「色」や「正答率」で視覚的にわかるようになっています。</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            <span class="q-icon">Q</span>
+            <span class="q-text">ピアノ教室の教材としても使えますか？</span>
+            <span class="toggle-icon" aria-hidden="true"></span>
+          </button>
+          <div class="faq-answer" hidden>
+            <span class="a-label">A</span>
+            <p>はい、補助教材としてご活用いただける設計にしております。短時間でできるため、レッスンの冒頭や宿題にも最適です。進捗を保護者と共有できるので、ご家庭での練習もスムーズになります。</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            <span class="q-icon">Q</span>
+            <span class="q-text">どんな端末で使えますか？</span>
+            <span class="toggle-icon" aria-hidden="true"></span>
+          </button>
+          <div class="faq-answer" hidden>
+            <span class="a-label">A</span>
+            <p>スマートフォン（iPhone／Android）、タブレット、パソコンでもご利用いただけます。特にタブレットでの操作が、子どもには見やすくておすすめです。</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            <span class="q-icon">Q</span>
+            <span class="q-text">間違えても大丈夫ですか？子どもが自信をなくしませんか？</span>
+            <span class="toggle-icon" aria-hidden="true"></span>
+          </button>
+          <div class="faq-answer" hidden>
+            <span class="a-label">A</span>
+            <p>大丈夫です。オトロンでは、間違えたときも優しくガイドされる設計になっており、子どもが嫌な気持ちにならないよう工夫されています。「できた！」を積み重ねて、自信を育てることを大切にしています。</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            <span class="q-icon">Q</span>
+            <span class="q-text">有料版では何ができますか？価格は？</span>
+            <span class="toggle-icon" aria-hidden="true"></span>
+          </button>
+          <div class="faq-answer" hidden>
+            <span class="a-label">A</span>
+            <p>無料体験では一部の和音や機能をご利用いただけます。有料版では、すべての和音や育成モード、進捗管理、共有機能などが解放され、より本格的なトレーニングが可能になります。料金の詳細はアプリ内または登録ページにてご確認ください。</p>
+          </div>
+        </div>
       </section>
 
       <footer class="lp-footer">
@@ -146,4 +188,19 @@ export function renderIntroScreen() {
       top?.scrollIntoView({ behavior: 'smooth' });
     });
   }
+
+  document.querySelectorAll('.faq-question').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      btn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      const answer = btn.nextElementSibling;
+      if (answer) {
+        if (expanded) {
+          answer.setAttribute('hidden', '');
+        } else {
+          answer.removeAttribute('hidden');
+        }
+      }
+    });
+  });
 }

--- a/css/intro.css
+++ b/css/intro.css
@@ -139,3 +139,65 @@
 .lp-footer .cta-button {
   margin-bottom: 1em;
 }
+
+/* FAQ accordion */
+.faq-item {
+  max-width: 600px;
+  margin: 0 auto 1em auto;
+  text-align: left;
+}
+
+.faq-question {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.8em;
+  background: #ffffff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 1em;
+}
+
+.faq-question .q-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4em;
+  height: 1.4em;
+  margin-right: 0.6em;
+  background: #ff9900;
+  color: #fff;
+  border-radius: 50%;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
+.faq-question .toggle-icon {
+  margin-left: auto;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
+.faq-question[aria-expanded="true"] .toggle-icon::before {
+  content: "-";
+}
+
+.faq-question[aria-expanded="false"] .toggle-icon::before {
+  content: "+";
+}
+
+.faq-answer {
+  padding: 0.8em 1em 1em 2.4em;
+  font-size: 0.95em;
+  background: #fff8f2;
+}
+
+.faq-answer .a-label {
+  font-weight: bold;
+  margin-right: 0.5em;
+}
+
+.faq-answer[hidden] {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- convert FAQ section to accordion with explicit Q/A blocks
- toggle answers with aria-expanded
- style FAQ accordion

## Testing
- `npm run` (list available scripts)

------
https://chatgpt.com/codex/tasks/task_b_684d26cf10388323879a1ff82f0f1b65