### PR TITLE
Fix vertical layout issue on intro steps

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -42,19 +42,19 @@ export function renderIntroScreen() {
 
       <section class="features">
         <h2>4ステップで身につく絶対音感</h2>
-        <div class="step">
+        <div class="intro-step">
           <h3>Step 01：色と和音で楽しくトレーニング</h3>
           <p>色旗×コードの組み合わせで、小さな子どもでも直感的に音を覚えていける</p>
         </div>
-        <div class="step">
+        <div class="intro-step">
           <h3>Step 02：進捗に応じて和音が増える「育成モード」</h3>
           <p>毎日のがんばりで和音がアンロックされる、ゲーム感覚の育成モード搭載</p>
         </div>
-        <div class="step">
+        <div class="intro-step">
           <h3>Step 03：結果は保護者と共有して見守れる</h3>
           <p>分析グラフは未搭載。代わりに、保護者と成績を「共有」できる機能を提供</p>
         </div>
-        <div class="step">
+        <div class="intro-step">
           <h3>Step 04：単音分化モードあり</h3>
           <p>和音から単音への移行トレーニングも搭載。柔軟な設定も多数（出題比率、構成音限定など）</p>
         </div>

--- a/css/intro.css
+++ b/css/intro.css
@@ -90,7 +90,7 @@
   gap: 0.6em;
 }
 
-.step {
+.intro-step {
   max-width: 600px;
   margin: 0 auto 2em auto;
   padding: 1em;
@@ -99,20 +99,17 @@
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
   text-align: left;
 }
-
-.step h3 {
+.intro-step h3 {
   font-size: 1.2em;
   color: #333;
   margin-bottom: 0.5em;
 }
-
-.step p {
+.intro-step p {
   font-size: 1em;
   color: #555;
   line-height: 1.6;
 }
-
-.step h3::before {
+.intro-step h3::before {
   content: '';
   display: inline-block;
   width: 1.2em;


### PR DESCRIPTION
## Summary
- avoid CSS class conflict on intro page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684d276a7ba88323bd6274a482914928