### PR TITLE
Fix hero layout on intro page

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -25,7 +25,7 @@ export function renderIntroScreen() {
       <section class="hero">
         <h1 class="hero-title">もうドレミは、「ドレミ」から教えない。</h1>
         <p class="hero-sub">2歳からはじめる、色と和音で育てる 絶対音感トレーニングアプリ</p>
-        <p class="highlight">＼遊びながら“聴く力”が伸びる！／</p>
+        <p class="hero-highlight">＼遊びながら“聴く力”が伸びる！／</p>
         <div class="hero-visual">
           <img src="images/otolon.webp" alt="アプリ画面イメージ" />
         </div>

--- a/css/intro.css
+++ b/css/intro.css
@@ -39,20 +39,45 @@
 }
 
 .hero-title {
-  font-size: 2.2em;
-  margin-bottom: 0.5em;
+  font-size: 1.8em;
+  font-weight: bold;
+  text-align: center;
+  line-height: 1.4;
+  max-width: 90%;
+  margin: 0 auto 0.6em;
+  word-break: keep-all; /* 日本語の語中改行を避ける */
 }
 
 .hero-sub {
-  font-size: 1.1em;
-  margin-bottom: 1.5em;
+  font-size: 1em;
+  text-align: center;
+  line-height: 1.6;
+  max-width: 90%;
+  margin: 0 auto 1em;
+  color: #333;
 }
 
-.hero .highlight {
-  font-weight: bold;
+.hero-highlight {
   font-size: 1.1em;
   color: #ff9900;
-  margin-top: 0.5em;
+  font-weight: bold;
+  margin-bottom: 1em;
+  max-width: 90%;
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .hero-title {
+    font-size: 2.2em;
+  }
+
+  .hero-sub {
+    font-size: 1.1em;
+  }
+
+  .hero-highlight {
+    font-size: 1.2em;
+  }
 }
 
 .hero-visual img {


### PR DESCRIPTION
## Summary
- center hero text and restrict width
- add responsive font sizes
- rename highlight element to `hero-highlight`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684d2e81643483239f2e752b82847c72