### PR TITLE
Fix vertical wrapping on intro page

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -158,6 +158,14 @@
   line-height: 1.6;
 }
 
+/* テキストが1文字ずつ縦に折り返されないようにする */
+.step > div:not(.step-icon),
+.result-card > div {
+  flex: 1 1 auto;
+  min-width: 0;
+  word-break: break-word;
+}
+
 .result-block {
   background: #fff;
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- prevent step and result texts from wrapping one character per line on small screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684d3159ced08323b6a2bcf512e5fb12