### PR TITLE
Improve trouble section design

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -34,15 +34,15 @@ export function renderIntroScreen() {
       </section>
 
       <section class="problems">
-        <p class="problem-intro">絶対音感に興味はあるけど...</p>
-        <h2>こんなお悩みありませんか？</h2>
-        <ul class="problem-list">
-          <li>ちょっと調べたけどレッスンがかなり高額になる...</li>
-          <li>教えてくれる先生や教室が近所にない...</li>
-          <li>独学でやってみたいけど、どう教えればいいかわからない</li>
-          <li>ちゃんと続けられるかが不安...</li>
-          <li>既に取り組んでいるけど、毎日のトレーニングの負担が大きい</li>
-        </ul>
+        <p class="trouble-lead">絶対音感に興味はあるけど...</p>
+        <h2 class="trouble-title">こんなお悩みありませんか？</h2>
+        <div class="trouble-bubbles">
+          <div class="bubble">ちょっと調べたけどレッスンがかなり高額になる...</div>
+          <div class="bubble">教えてくれる先生や教室が近所にない...</div>
+          <div class="bubble">独学でやってみたいけど、どう教えればいいかわからない</div>
+          <div class="bubble">ちゃんと続けられるかが不安...</div>
+          <div class="bubble">既に取り組んでいるけど、毎日のトレーニングの負担が大きい</div>
+        </div>
       </section>
 
       <section class="features">

--- a/css/intro.css
+++ b/css/intro.css
@@ -136,13 +136,56 @@
   margin-bottom: 2em;
 }
 
-.problem-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+
+/* お悩み吹き出し */
+.trouble-lead {
+  text-align: center;
+  margin-bottom: 0.6em;
+  font-size: 1em;
+}
+
+.trouble-title {
+  text-align: center;
+  font-size: 1.4em;
+  margin-bottom: 1.2em;
+}
+
+.trouble-bubbles {
   display: flex;
-  flex-direction: column;
-  gap: 0.6em;
+  flex-wrap: wrap;
+  gap: 1em;
+  justify-content: center;
+}
+
+.bubble {
+  position: relative;
+  background: #eeeeee;
+  max-width: 260px;
+  padding: 0.8em 1em;
+  line-height: 1.6;
+  border-radius: 8px;
+  flex: 1 1 200px;
+  box-sizing: border-box;
+}
+
+.bubble::after {
+  content: "";
+  position: absolute;
+  left: 1.5em;
+  bottom: -12px;
+  border-width: 12px 12px 0 12px;
+  border-style: solid;
+  border-color: #eeeeee transparent transparent transparent;
+}
+
+@media (max-width: 600px) {
+  .trouble-bubbles {
+    flex-direction: column;
+    align-items: center;
+  }
+  .bubble {
+    max-width: 100%;
+  }
 }
 
 .step {


### PR DESCRIPTION
## Summary
- redesign problems section in intro page
- switch problem list to speech-bubble layout
- adjust styles for bubbles with mobile support

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_684d354f1fc08323811806e21a6c3288