### PR TITLE
Adjust intro bubble layout

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -164,7 +164,7 @@
   padding: 0.8em 1em;
   line-height: 1.6;
   border-radius: 8px;
-  flex: 1 1 200px;
+  flex: 0 0 calc(30% - 1em);
   box-sizing: border-box;
 }
 
@@ -184,7 +184,9 @@
     align-items: center;
   }
   .bubble {
-    max-width: 100%;
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 90%;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak `.bubble` flex size for better desktop layout (3 over 2)
- shrink bubble width on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684d371726108323aaa1ad987fa824ee