### PR TITLE
Fix .step layout

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -230,7 +230,12 @@
 }
 
 /* テキストが1文字ずつ縦に折り返されないようにする */
-.step > div:not(.step-icon),
+.step > div:not(.step-icon) {
+  flex: 1 1 0;
+  min-width: 0;
+  word-break: break-word;
+}
+
 .result-card > div {
   flex: 1 1 auto;
   min-width: 0;


### PR DESCRIPTION
## Summary
- ensure `.step` sections use flexbox layout with fixed basis
- split `.result-card` rule for clarity

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_684d3844e8d48323ba60dcef8d8e9d37