### PR TITLE
Fix .step flexbox issue on mobile

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -230,7 +230,7 @@
 }
 
 /* テキストが1文字ずつ縦に折り返されないようにする */
-.step > div:not(.step-icon) {
+.step > :not(.step-icon) {
   flex: 1 1 0;
   min-width: 0;
   word-break: break-word;


### PR DESCRIPTION
## Summary
- ensure flexbox rules apply to `.step` text correctly on mobile

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run reset-expired-premiums` *(fails: Cannot find package '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_b_684d39ee7f0c8323b3c0177a7da90392