### PR TITLE
Fix hero title spacing on mobile

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -39,13 +39,14 @@
 }
 
 .hero-title {
-  font-size: 1.8em;
+  font-size: 1.6em;
   font-weight: bold;
   text-align: center;
-  line-height: 1.4;
+  line-height: 1.6;
   max-width: 90%;
   margin: 0 auto 0.6em;
-  word-break: keep-all; /* 日本語の語中改行を避ける */
+  word-break: keep-all;
+  white-space: normal;
 }
 
 .hero-sub {
@@ -76,7 +77,9 @@
 
 @media (min-width: 768px) {
   .hero-title {
-    font-size: 2.2em;
+    font-size: 2.4em;
+    max-width: 700px;
+    line-height: 1.4;
   }
 
   .hero-sub {


### PR DESCRIPTION
## Summary
- tweak intro hero title styles for better mobile readability

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_684d3be8d9608323a1151dd962336b3c