### PR TITLE
Fix intro page features CSS block

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -216,6 +216,7 @@
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
+}
 .features .step-icon {
   flex-shrink: 0;
   width: 2em;


### PR DESCRIPTION
## Summary
- close missing `}` for `.features .step` in `css/intro.css`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684d43555ee08323aefbc5d48fb1f9ec