### PR TITLE
Adjust FAQ answer styling

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -349,17 +349,21 @@
   content: "+";
 }
 
+
 .faq-answer {
+  display: flex;
+  align-items: center;
+  gap: 0.8em;
   background: #fff;
   padding: 1em;
   border-top: 1px solid #eee;
   font-size: 0.95em;
   color: #333;
+  border-radius: 0 0 8px 8px;
+  line-height: 1.6;
 }
 
 .faq-answer .a-label {
-  font-weight: bold;
-  margin-bottom: 0.4em;
   background: #66bbff;
   color: #fff;
   width: 1.4em;
@@ -367,8 +371,13 @@
   line-height: 1.4em;
   text-align: center;
   border-radius: 50%;
-  margin-right: 0.6em;
-  display: inline-block;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
+.faq-answer p {
+  margin: 0;
+  flex: 1;
 }
 
 .faq-answer[hidden] {


### PR DESCRIPTION
## Summary
- update FAQ answer layout so the `A` icon sits inline left of the text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684d470b1b708323b37755b42b0afa4f