### PR TITLE
Refactor intro steps layout

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -45,35 +45,35 @@ export function renderIntroScreen() {
         </div>
       </section>
 
-      <section class="features">
-        <h2>4ステップで身につく絶対音感</h2>
-        <div class="step">
-          <div class="step-icon">1</div>
-          <div class="step-body">
-            <h3>色と和音で楽しくトレーニング</h3>
-            <p>色旗×コードの組み合わせで、小さな子どもでも直感的に音を覚えていける</p>
+        <section class="features">
+          <h2>4ステップで身につく絶対音感</h2>
+          <div class="step">
+            <span class="step-icon">1</span>
+            <div class="step-text">
+              <h3>色と和音で楽しくトレーニング</h3>
+              <p>色旗×コードの組み合わせで、小さな子どもでも直感的に音を覚えていける</p>
+            </div>
           </div>
-        </div>
-        <div class="step">
-          <div class="step-icon">2</div>
-          <div class="step-body">
-            <h3>進捗に応じて和音が増える「育成モード」</h3>
-            <p>毎日のがんばりで和音がアンロックされる、ゲーム感覚の育成モード搭載</p>
+          <div class="step">
+            <span class="step-icon">2</span>
+            <div class="step-text">
+              <h3>進捗に応じて和音が増える「育成モード」</h3>
+              <p>毎日のがんばりで和音がアンロックされる、ゲーム感覚の育成モード搭載</p>
+            </div>
           </div>
-        </div>
-        <div class="step">
-          <div class="step-icon">3</div>
-          <div class="step-body">
-            <h3>結果は保護者と共有して見守れる</h3>
-            <p>分析グラフは未搭載。代わりに、保護者と成績を「共有」できる機能を提供</p>
+          <div class="step">
+            <span class="step-icon">3</span>
+            <div class="step-text">
+              <h3>結果は保護者と共有して見守れる</h3>
+              <p>分析グラフは未搭載。代わりに、保護者と成績を「共有」できる機能を提供</p>
+            </div>
           </div>
-        </div>
-        <div class="step">
-          <div class="step-icon">4</div>
-          <div class="step-body">
-            <h3>単音分化モードあり</h3>
-            <p>和音から単音への移行トレーニングも搭載。柔軟な設定も多数（出題比率、構成音限定など）</p>
-          </div>
+          <div class="step">
+            <span class="step-icon">4</span>
+            <div class="step-text">
+              <h3>単音分化モードあり</h3>
+              <p>和音から単音への移行トレーニングも搭載。柔軟な設定も多数（出題比率、構成音限定など）</p>
+            </div>
         </div>
         <button id="step-cta" class="cta-button">アプリの進化を体験してみる</button>
       </section>

--- a/css/intro.css
+++ b/css/intro.css
@@ -204,56 +204,52 @@
 }
 
 .features .step {
-  display: flex;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: auto 1fr;
   gap: 1em;
+  align-items: flex-start;
   padding: 1em;
   margin-bottom: 1em;
   background: #fff;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.08);
-  text-align: left;
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
-  flex-wrap: nowrap;
+  text-align: left;
 }
 .features .step-icon {
-  flex-shrink: 0;
-  width: 2em;
-  height: 2em;
   background-color: #ff9900;
-  border-radius: 50%;
-  text-align: center;
   color: #fff;
   font-weight: bold;
-  line-height: 2em;
+  border-radius: 50%;
+  width: 2em;
+  height: 2em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.features .step h3 {
+.features .step-text h3 {
   font-size: 1.2em;
-  color: #333;
   margin: 0 0 0.3em;
-  word-break: normal;
-  white-space: normal;
-  max-width: 100%;
+  color: #333;
 }
-.features .step p {
+.features .step-text p {
   font-size: 1em;
   color: #555;
   line-height: 1.6;
+  margin: 0;
 }
 
-/* テキストが1文字ずつ縦に折り返されないようにする */
-.features .step-body {
-  flex: 1 1 auto;
-  min-width: 0;
-  word-break: break-word;
-  white-space: normal;
-}
+@media (max-width: 600px) {
+  .features .step {
+    grid-template-columns: 1fr;
+  }
 
-/* Ensure flexible containers shrink properly */
-.step-body {
-  min-width: 0;
+  .features .step-icon {
+    margin-bottom: 0.5em;
+    justify-self: start;
+  }
 }
 
 .result-card > div {


### PR DESCRIPTION
## Summary
- switch intro feature steps from flexbox to grid layout
- update HTML structure with `step-text` container and `span` icons
- adjust CSS styles for grid-based steps

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684d4d5b2488832393a1dc541b048e9d