### PR TITLE
Update bubble styling on intro screen

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -37,11 +37,11 @@ export function renderIntroScreen() {
         <p class="trouble-lead">絶対音感に興味はあるけど...</p>
         <h2 class="trouble-title">こんなお悩みありませんか？</h2>
         <div class="trouble-bubbles">
-          <div class="bubble">ちょっと調べたけどレッスンがかなり高額になる...</div>
-          <div class="bubble">教えてくれる先生や教室が近所にない...</div>
-          <div class="bubble">独学でやってみたいけど、どう教えればいいかわからない</div>
-          <div class="bubble">ちゃんと続けられるかが不安...</div>
-          <div class="bubble">既に取り組んでいるけど、毎日のトレーニングの負担が大きい</div>
+          <div class="speech-bubble">ちょっと調べたけどレッスンがかなり高額になる...</div>
+          <div class="speech-bubble">教えてくれる先生や教室が近所にない...</div>
+          <div class="speech-bubble">独学でやってみたいけど、どう教えればいいかわからない</div>
+          <div class="speech-bubble">ちゃんと続けられるかが不安...</div>
+          <div class="speech-bubble">既に取り組んでいるけど、毎日のトレーニングの負担が大きい</div>
         </div>
       </section>
 

--- a/css/intro.css
+++ b/css/intro.css
@@ -163,25 +163,28 @@
   justify-content: center;
 }
 
-.bubble {
+.speech-bubble {
   position: relative;
-  background: #eeeeee;
-  padding: 0.8em 1em;
+  background: #e6e6e6;
+  padding: 16px 30px;
+  border-radius: 30px;
+  max-width: 340px;
+  margin: 1em auto;
+  font-size: 15px;
   line-height: 1.6;
-  border-radius: 8px;
-  max-width: 260px;
-  flex: 0 0 calc(30% - 1em);
-  box-sizing: border-box;
+  color: #333;
+  text-align: center;
+  word-break: break-word;
 }
 
-.bubble::after {
+.speech-bubble::after {
   content: "";
   position: absolute;
-  left: 1.5em;
-  bottom: -12px;
-  border-width: 12px 12px 0 12px;
-  border-style: solid;
-  border-color: #eeeeee transparent transparent transparent;
+  bottom: -15px;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 15px solid transparent;
+  border-top-color: #e6e6e6;
 }
 
 @media (max-width: 600px) {
@@ -190,16 +193,15 @@
     align-items: center;
   }
 
-  .bubble {
-    width: 100%;
+  .speech-bubble {
     max-width: 90%;
-    font-size: 0.95em;
-    text-align: left;
+    font-size: 14px;
+    padding: 12px 20px;
   }
 }
 
 @media (min-width: 768px) {
-  .bubble {
+  .speech-bubble {
     flex: 0 0 calc(16.666% - 1em);
     max-width: 130px;
   }


### PR DESCRIPTION
## Summary
- switch intro bubble style to `.speech-bubble` card design
- tweak CSS for new Jazz-Steps like speech bubble appearance

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684d706e0598832397ca2edac199ed91