### PR TITLE
Adjust trouble bubble layout

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -159,51 +159,40 @@
 .trouble-bubbles {
   display: flex;
   flex-wrap: wrap;
-  gap: 1em;
   justify-content: center;
+  gap: 1em;
+  max-width: 900px;
+  margin: 0 auto;
 }
 
 .speech-bubble {
-  position: relative;
+  width: 280px;
+  padding: 16px 20px;
   background: #e6e6e6;
-  padding: 16px 30px;
-  border-radius: 30px;
-  max-width: 340px;
-  margin: 1em auto;
+  border-radius: 24px;
+  position: relative;
   font-size: 15px;
   line-height: 1.6;
   color: #333;
-  text-align: center;
-  word-break: break-word;
+  text-align: left;
+  box-sizing: border-box;
 }
 
 .speech-bubble::after {
   content: "";
   position: absolute;
-  bottom: -15px;
-  left: 50%;
-  transform: translateX(-50%);
-  border: 15px solid transparent;
+  bottom: -12px;
+  left: 40px;
+  border: 12px solid transparent;
   border-top-color: #e6e6e6;
 }
 
 @media (max-width: 600px) {
-  .trouble-bubbles {
-    flex-direction: column;
-    align-items: center;
-  }
-
   .speech-bubble {
-    max-width: 90%;
+    width: 90%;
+    margin: 0.5em auto;
     font-size: 14px;
-    padding: 12px 20px;
-  }
-}
-
-@media (min-width: 768px) {
-  .speech-bubble {
-    flex: 0 0 calc(16.666% - 1em);
-    max-width: 130px;
+    padding: 12px 16px;
   }
 }
 


### PR DESCRIPTION
## Summary
- style `trouble-bubbles` container for centered wrapping layout
- unify `speech-bubble` styles and mobile rules per design spec

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684d73b053248323b8a1ce91e035ad5d