### PR TITLE
Restore intro bubble style

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -159,40 +159,40 @@
 .trouble-bubbles {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
   gap: 1em;
-  max-width: 900px;
-  margin: 0 auto;
+  justify-content: center;
 }
 
 .speech-bubble {
-  width: 280px;
-  padding: 16px 20px;
-  background: #e6e6e6;
-  border-radius: 24px;
   position: relative;
-  font-size: 15px;
+  background: #e6e6e6;
+  padding: 0.8em 1em;
   line-height: 1.6;
+  border-radius: 8px;
   color: #333;
-  text-align: left;
+  max-width: 260px;
+  flex: 1 1 200px;
   box-sizing: border-box;
+  text-align: left;
 }
 
 .speech-bubble::after {
   content: "";
   position: absolute;
   bottom: -12px;
-  left: 40px;
-  border: 12px solid transparent;
-  border-top-color: #e6e6e6;
+  left: 1.5em;
+  border-width: 12px 12px 0 12px;
+  border-style: solid;
+  border-color: #e6e6e6 transparent transparent transparent;
 }
 
 @media (max-width: 600px) {
+  .trouble-bubbles {
+    flex-direction: column;
+    align-items: center;
+  }
   .speech-bubble {
-    width: 90%;
-    margin: 0.5em auto;
-    font-size: 14px;
-    padding: 12px 16px;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- revert to classic speech bubble layout on intro screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684d753558508323b8e23f21ebaa6aa3