### PR TITLE
Fix intro feature step layout

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -206,6 +206,7 @@
   max-width: 600px;
   margin: 1em auto;
   text-align: left;
+  flex-wrap: nowrap;
 }
 .features .step-icon {
   background-color: #ff9900;
@@ -221,8 +222,10 @@
 }
 /* 🛠️ 重要：step-text に幅と折り返しを指定する */
 .features .step-text {
-  flex: 1;
+  flex: 1 1 auto;
+  min-width: 0;
   word-break: break-word;
+  white-space: normal;
 }
 .features .step-text h3 {
   font-size: 1.2em;


### PR DESCRIPTION
## Summary
- ensure `.features .step` doesn't wrap items
- allow `.step-text` to shrink properly in flexbox

## Testing
- `npm test` *(fails: Missing script)*
- `npm run reset-expired-premiums` *(fails: Cannot find package '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_b_684d75934cfc8323bf01675b77773410