### PR TITLE
Fix intro bubble layout

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -156,11 +156,14 @@
   margin-bottom: 1.2em;
 }
 
+
+/* お悩み吹き出しエリア */
 .trouble-bubbles {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(200px, 1fr));
   gap: 1em;
   justify-content: center;
+  justify-items: center;
 }
 
 .speech-bubble {
@@ -170,10 +173,11 @@
   line-height: 1.6;
   border-radius: 8px;
   color: #333;
+  width: 100%;
   max-width: 260px;
-  flex: 1 1 200px;
   box-sizing: border-box;
   text-align: left;
+  margin-bottom: 1.5em;
 }
 
 .speech-bubble::after {
@@ -188,11 +192,11 @@
 
 @media (max-width: 600px) {
   .trouble-bubbles {
-    flex-direction: column;
-    align-items: center;
+    grid-template-columns: 1fr;
   }
   .speech-bubble {
     max-width: 100%;
+    margin-bottom: 1em;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak `trouble-bubbles` to use a grid layout
- ensure each speech bubble keeps the same width
- adjust mobile styling so bubbles line up consistently

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684d778cd66883239e11ce46e0fb52e3