### PR TITLE
Update intro features card style

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -199,25 +199,32 @@
 .features .step {
   display: flex;
   align-items: center;
-  gap: 0.8em;
-  padding: 1em;
+  gap: 1em;
   background: #fff;
-  border-radius: 8px;
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  padding: 1em;
   max-width: 600px;
   margin: 1em auto;
   text-align: left;
-  flex-wrap: nowrap;
+}
+
+@media (max-width: 600px) {
+  .features .step {
+    width: 90%;
+  }
 }
 .features .step-icon {
-  background-color: #ff9900;
-  color: #fff;
-  font-weight: bold;
-  border-radius: 50%;
-  width: 2em;
-  height: 2em;
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 1.4em;
+  height: 1.4em;
+  margin-right: 0.6em;
+  background-color: #ff9900;
+  color: #fff;
+  border-radius: 50%;
+  font-weight: bold;
   flex-shrink: 0;
 }
 /* 🛠️ 重要：step-text に幅と折り返しを指定する */
@@ -228,15 +235,15 @@
   white-space: normal;
 }
 .features .step-text h3 {
-  font-size: 1.2em;
   margin: 0 0 0.3em;
+  font-size: 1.1em;
   color: #333;
 }
 .features .step-text p {
-  font-size: 1em;
+  margin: 0;
+  font-size: 0.95em;
   color: #555;
   line-height: 1.6;
-  margin: 0;
 }
 
 


### PR DESCRIPTION
## Summary
- apply card-style layout to `.features .step`
- style step icon and text similar to FAQ section
- add mobile width adjustment

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684d77ce0e2c8323b6f9ac2452cd58b7