### PR TITLE
Fix intro step-text wrapping

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -235,6 +235,7 @@
 .features .step-text {
   flex: 1 1 auto;
   min-width: 0;
+  width: 100%;
   word-break: break-word;
   white-space: normal;
 }


### PR DESCRIPTION
## Summary
- ensure features step text spans the available width

## Testing
- `npm run reset-expired-premiums` *(fails: Cannot find package '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_b_684d7ad689e48323b5344034be32e1fa