### PR TITLE
Remove Stripe subscription cancellation

### DIFF
--- a/api/cancel-subscription.js
+++ b/api/cancel-subscription.js
@@ -1,7 +1,4 @@
-import Stripe from 'stripe';
 import { createClient } from '@supabase/supabase-js';
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 const supabase = createClient(
   process.env.SUPABASE_URL,
   process.env.SUPABASE_SERVICE_ROLE_KEY,
@@ -17,77 +14,33 @@ const supabase = createClient(
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).end('Method Not Allowed');
 
-// ① リクエストから userId と email を受け取る
-const { userId, email } = req.body;
-
-let user = null;
-let error = null;
-
-// ② userId がある場合、それで検索
-if (userId) {
-  const result = await supabase
-    .from('users')
-    .select('id, stripe_customer_id')
-    .eq('id', userId)
-    .maybeSingle();
-  user = result.data;
-  error = result.error;
-}
-
-// ③ userId が無かった、もしくは見つからなかった場合、email で検索
-if ((!user || error) && email) {
-  const result = await supabase
-    .from('users')
-    .select('id, stripe_customer_id')
-    .eq('email', email)
-    .maybeSingle();
-  user = result.data;
-  error = result.error;
-}
-
-// ④ 最終チェック
-if (error || !user?.stripe_customer_id) {
-  return res.status(400).json({ error: 'User or customer ID not found' });
-}
-
-  // Stripeからサブスクリプション取得
-  const subscriptions = await stripe.subscriptions.list({
-    customer: user.stripe_customer_id,
-    status: 'active',
-    limit: 1,
-  });
-
-  if (subscriptions.data.length === 0) {
-    return res.status(400).json({ error: 'No active subscription found' });
+  let body = req.body;
+  if (typeof body === 'string') {
+    try {
+      body = JSON.parse(body);
+    } catch (err) {
+      console.error('Invalid JSON body');
+      return res.status(400).json({ error: 'Invalid request' });
+    }
   }
 
-  const subscription = subscriptions.data[0];
+  const { userId } = body || {};
+  if (!userId) {
+    return res.status(400).json({ error: 'Missing userId' });
+  }
 
-  // 次回更新を停止 (cancel_at_period_end)
-  const updated = await stripe.subscriptions.update(subscription.id, {
-    cancel_at_period_end: true,
-  });
-
-  // Supabase更新：user_subscriptions.statusを'cancelled'に
-  const { data: updatedRows, error: updateError } = await supabase
+  const { data: updatedRows, error } = await supabase
     .from('user_subscriptions')
     .update({ status: 'cancelled' })
-    .eq('user_id', user.id)
+    .eq('user_id', userId)
     .eq('status', 'active')
     .select();
 
-  console.log('[DEBUG] user_id:', user.id);
-  console.log('[DEBUG] updated result:', updatedRows);
-  console.log('[DEBUG] error:', updateError);
-
-  if (updateError || updatedRows.length === 0) {
+  if (error || updatedRows.length === 0) {
     return res
       .status(400)
       .json({ error: 'No active subscription found or update failed' });
   }
 
-  return res.status(200).json({
-    message: 'Cancellation scheduled',
-    current_period_end: new Date(updated.current_period_end * 1000).toISOString(),
-  });
+  return res.status(200).json({ message: 'Subscription cancelled' });
 }

--- a/components/planInfo.js
+++ b/components/planInfo.js
@@ -91,8 +91,7 @@ async function createPlanInfoContent(user) {
             body: JSON.stringify({ userId: user.id }),
           });
           if (res.ok) {
-            const data = await res.json();
-            alert(`ご契約は${formatDate(new Date(data.current_period_end))}まで有効です。それ以降、自動的に無料プランに戻ります。`);
+            alert('解約処理が完了しました');
             switchScreen('home');
           } else {
             alert('解約に失敗しました');


### PR DESCRIPTION
## Summary
- simplify `/api/cancel-subscription` to only update `user_subscriptions`
- adjust front-end alert after cancelling

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_b_684e56cb1b188323890fff2075c1a616