### PR TITLE
Implement free trial gating

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ import { renderSignUpScreen } from "./components/signup.js";
 import { renderInitialSetupScreen } from "./components/initialSetup.js";
 import { supabase } from "./utils/supabaseClient.js";
 import { ensureSupabaseAuth } from "./utils/supabaseAuthHelper.js";
+import { isAccessAllowed } from "./utils/accessControl.js";
 import { createInitialChordProgress } from "./utils/progressUtils.js";
 import { renderMyPageScreen } from "./components/mypage.js";
 import { clearTimeOfDayStyling } from "./utils/timeOfDay.js";
@@ -126,6 +127,11 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
     return;
   }
   const { user, isNew } = authResult;
+
+  if (!isAccessAllowed(user)) {
+    switchScreen("pricing", user);
+    return;
+  }
 
   if (isNew) {
     await createInitialChordProgress(user.id);

--- a/utils/accessControl.js
+++ b/utils/accessControl.js
@@ -1,0 +1,11 @@
+export function isAccessAllowed(user) {
+  if (!user) return false;
+  if (user.is_premium) return true;
+  if (user.trial_active && user.trial_end_date) {
+    const end = new Date(user.trial_end_date);
+    if (end > new Date()) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/utils/supabaseAuthHelper.js
+++ b/utils/supabaseAuthHelper.js
@@ -41,6 +41,7 @@ export async function ensureSupabaseAuth(firebaseUser) {
       throw signInError;
     }
 
+    const trialEnd = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
     const { data: inserted, error: insertError } = await supabase
       .from('users')
       .insert([
@@ -48,6 +49,8 @@ export async function ensureSupabaseAuth(firebaseUser) {
           firebase_uid: firebaseUser.uid,
           name: firebaseUser.displayName || '名前未設定',
           email,
+          trial_active: true,
+          trial_end_date: trialEnd,
         },
       ])
       .select()


### PR DESCRIPTION
## Summary
- add access control utility for free trial logic
- initialize trial period when creating new users
- gate app access based on premium or trial status

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684e72d99e6083239618af3ea66aae53