### PR TITLE
Implement common lock screen

### DIFF
--- a/components/lock.js
+++ b/components/lock.js
@@ -1,0 +1,46 @@
+import { renderHeader } from './header.js';
+import { switchScreen } from '../main.js';
+
+const CONTENT = {
+  trial_expired: {
+    title: '無料体験が終了しました',
+    message: '引き続きご利用いただくには、有料プランへの登録が必要です。',
+    button: 'プランを確認する',
+  },
+  premium_expired: {
+    title: '有料期間が終了しました',
+    message: 'ご契約期間が終了しています。更新または再登録をお願いいたします。',
+    button: 'プランを更新する',
+  },
+};
+
+export function renderLockScreen(user, { lockType = 'trial_expired', url } = {}) {
+  const info = CONTENT[lockType] || CONTENT.trial_expired;
+  const app = document.getElementById('app');
+  app.innerHTML = '';
+  renderHeader(app, user);
+
+  const main = document.createElement('main');
+  main.className = 'lock-screen screen';
+
+  const titleEl = document.createElement('h1');
+  titleEl.textContent = info.title;
+  main.appendChild(titleEl);
+
+  const msgEl = document.createElement('p');
+  msgEl.textContent = info.message;
+  main.appendChild(msgEl);
+
+  const btn = document.createElement('button');
+  btn.textContent = info.button;
+  btn.onclick = () => {
+    if (url) {
+      location.href = url;
+    } else {
+      switchScreen('pricing', user);
+    }
+  };
+  main.appendChild(btn);
+
+  app.appendChild(main);
+}

--- a/css/lock.css
+++ b/css/lock.css
@@ -1,0 +1,11 @@
+.lock-screen {
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 1em;
+  text-align: center;
+}
+
+.lock-screen button {
+  margin-top: 1em;
+  padding: 0.8em;
+}

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
   <link rel="stylesheet" href="css/mypage.css" />
   <link rel="stylesheet" href="css/info.css" />
   <link rel="stylesheet" href="css/pricing.css" />
+  <link rel="stylesheet" href="css/lock.css" />
   <link rel="stylesheet" href="css/setup.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
 </head>

--- a/main.js
+++ b/main.js
@@ -18,7 +18,7 @@ import { renderSignUpScreen } from "./components/signup.js";
 import { renderInitialSetupScreen } from "./components/initialSetup.js";
 import { supabase } from "./utils/supabaseClient.js";
 import { ensureSupabaseAuth } from "./utils/supabaseAuthHelper.js";
-import { isAccessAllowed } from "./utils/accessControl.js";
+import { isAccessAllowed, getLockType } from "./utils/accessControl.js";
 import { createInitialChordProgress } from "./utils/progressUtils.js";
 import { renderMyPageScreen } from "./components/mypage.js";
 import { clearTimeOfDayStyling } from "./utils/timeOfDay.js";
@@ -29,6 +29,7 @@ import { renderLawScreen } from "./components/info/law.js";
 import { renderExternalScreen } from "./components/info/external.js";
 import { renderHelpScreen } from "./components/info/help.js";
 import { renderPricingScreen } from "./components/pricing.js";
+import { renderLockScreen } from "./components/lock.js";
 
 
 import { firebaseAuth } from "./firebase/firebase-init.js";
@@ -102,6 +103,7 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   else if (screen === "law") renderLawScreen();
   else if (screen === "external") renderExternalScreen();
   else if (screen === "pricing") renderPricingScreen(user);
+  else if (screen === "lock") renderLockScreen(user, options);
 };
 
 // ブラウザ戻る/進む操作に対応
@@ -128,8 +130,9 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
   }
   const { user, isNew } = authResult;
 
-  if (!isAccessAllowed(user)) {
-    switchScreen("pricing", user);
+  const lockType = getLockType(user);
+  if (lockType) {
+    switchScreen("lock", user, { lockType });
     return;
   }
 

--- a/utils/accessControl.js
+++ b/utils/accessControl.js
@@ -1,11 +1,21 @@
-export function isAccessAllowed(user) {
-  if (!user) return false;
-  if (user.is_premium) return true;
-  if (user.trial_active && user.trial_end_date) {
+export function getLockType(user) {
+  if (!user) return null;
+  const now = new Date();
+
+  if (!user.is_premium && user.trial_active && user.trial_end_date) {
     const end = new Date(user.trial_end_date);
-    if (end > new Date()) {
-      return true;
+    if (end <= now) {
+      return "trial_expired";
     }
   }
-  return false;
+
+  if (!user.is_premium && !user.trial_active) {
+    return "premium_expired";
+  }
+
+  return null;
+}
+
+export function isAccessAllowed(user) {
+  return !getLockType(user);
 }


### PR DESCRIPTION
## Summary
- add a reusable lock screen and CSS
- detect expired trial or subscription
- show lock screen when users no longer have access

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684e759456508323847154ef4c7d12ec