### PR TITLE
Add trial welcome modal and remaining day display

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -20,6 +20,7 @@ export function renderHeader(container, user) {
     </button>
 
     <div class="header-right">
+      <div id="trial-status" class="trial-status" style="display:none"></div>
       <div class="info-menu">
         <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
         <div id="info-dropdown" class="info-dropdown">
@@ -58,6 +59,24 @@ export function renderHeader(container, user) {
   const helpBtn = header.querySelector("#help-btn");
   const lawBtn = header.querySelector("#law-btn");
   const externalBtn = header.querySelector("#external-btn");
+  const trialStatus = header.querySelector("#trial-status");
+
+  if (
+    trialStatus &&
+    user &&
+    user.trial_active &&
+    !user.is_premium &&
+    user.trial_end_date
+  ) {
+    const end = new Date(user.trial_end_date);
+    const now = new Date();
+    const days = Math.ceil((end - now) / (1000 * 60 * 60 * 24));
+    trialStatus.textContent = `無料体験：あと${days}日`;
+    trialStatus.style.display = "block";
+    if (days <= 3) {
+      trialStatus.classList.add("warning");
+    }
+  }
 
   parentMenuBtn.onclick = (e) => {
     e.stopPropagation();

--- a/components/home.js
+++ b/components/home.js
@@ -9,7 +9,8 @@ import {
 } from "../utils/timeOfDay.js";
 import { getAudio } from "../utils/audioCache.js";
 
-export function renderHomeScreen(user) {
+export function renderHomeScreen(user, options = {}) {
+  const { showWelcome = false } = options;
   const app = document.getElementById("app");
   app.innerHTML = "";
 
@@ -77,6 +78,12 @@ export function renderHomeScreen(user) {
   logoContainer.appendChild(startButton);
 
   container.appendChild(logoContainer);
+
+  if (showWelcome) {
+    showCustomAlert(
+      "\u2728 ようこそオトロンへ!\n\nあなたは現在\u300c7日間の無料体験\u300dをご利用中です。\n毎日のトレーニングや記録機能を、全て自由にお試しいただけます。\n\n残り日数はホーム画面に表示されます。"
+    );
+  }
 
   // ▼ 時間帯の変化に合わせて背景などを更新
   if (window.homeTimeInterval) {

--- a/css/header.css
+++ b/css/header.css
@@ -30,6 +30,15 @@
   gap: 0.1em; /* tighter spacing */
 }
 
+.trial-status {
+  font-size: 0.9rem;
+  margin-right: 0.4em;
+}
+
+.trial-status.warning {
+  color: #ff6600;
+}
+
 /* ▼ 親メニュー全体 */
 .parent-menu {
   position: relative;

--- a/main.js
+++ b/main.js
@@ -81,7 +81,7 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
     renderIntroScreen();
   }
   else if (screen === "login") renderLoginScreen(app, () => {});
-  else if (screen === "home") renderHomeScreen(user);
+  else if (screen === "home") renderHomeScreen(user, options);
   else if (screen === "training") renderTrainingScreen(user);
   else if (screen === "training_easy") renderTrainingEasy(user);
   else if (screen === "training_full") renderTrainingFull(user);
@@ -90,7 +90,7 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   else if (screen === "summary") renderSummaryScreen(user);
   else if (screen === "growth") renderGrowthScreen(user);
   else if (screen === "signup") renderSignUpScreen(user);
-  else if (screen === "setup") renderInitialSetupScreen(user, (u) => switchScreen("home", u));
+  else if (screen === "setup") renderInitialSetupScreen(user, (u) => switchScreen("home", u, options));
   else if (screen === "mypage") renderMyPageScreen(user);
   else if (screen === "result") renderResultScreen(user);
   else if (screen === "result_easy") renderTrainingEasyResultScreen(user);
@@ -142,9 +142,9 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 
   currentUser = user;
   if (!user.name || user.name === "名前未設定") {
-    switchScreen("setup", user);
+    switchScreen("setup", user, { showWelcome: isNew });
   } else {
-    switchScreen("home", user);
+    switchScreen("home", user, { showWelcome: isNew });
   }
 });
 


### PR DESCRIPTION
## Summary
- show trial remaining days in header with warning color
- add welcome modal on first login after registration
- pass options through screen switcher

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684e78a0bf708323a224519fc9fb466a