### PR TITLE
Improve Help accordion

### DIFF
--- a/components/info/help.js
+++ b/components/info/help.js
@@ -28,7 +28,7 @@ export function renderHelpScreen() {
 
       <details>
         <summary>回答方法と進行の流れ</summary>
-        <p>和音を聴いたら、その和音に対応する色を声に出してボタンを押してください。最初は赤の和音1つから始め、順に和音を増やしていきます。2週間安定して回答できると、次の和音に進みます。</p>
+        <p>和音を聴いたら、その和音に対応する色を声に出してボタンを押してください。最初は赤の和音1つから始め、順に和音を増やしていきます。2週間安定して回答できると、次の和音に進みます。オトロンでは一週間で次の和音に進める設計にしていますが、聞き分けが完璧でないと思えば日数を伸ばして下さい。</p>
       </details>
 
       <details>
@@ -84,5 +84,16 @@ export function renderHelpScreen() {
     </section>
   `;
   app.appendChild(main);
+
+  const detailsList = main.querySelectorAll("#help-section details");
+  detailsList.forEach((detail) => {
+    detail.addEventListener("toggle", () => {
+      if (detail.open) {
+        detailsList.forEach((d) => {
+          if (d !== detail) d.removeAttribute("open");
+        });
+      }
+    });
+  });
 }
 

--- a/css/info.css
+++ b/css/info.css
@@ -34,16 +34,33 @@
   margin: 1em 0;
 }
 
+
 .info-page summary {
   cursor: pointer;
   font-weight: bold;
-  padding: 0.4em 0.6em;
+  padding: 0.4em 0.6em 0.4em 1.6em;
   background: #f3f3f3;
   border-radius: 4px;
+  list-style: none;
+  position: relative;
+}
+
+.info-page summary::-webkit-details-marker {
+  display: none;
+}
+
+.info-page summary::before {
+  content: "+";
+  position: absolute;
+  left: 0.6em;
 }
 
 .info-page details[open] summary {
   background: #e0e0e0;
+}
+
+.info-page details[open] summary::before {
+  content: "-";
 }
 
 .info-page details p,


### PR DESCRIPTION
## Summary
- add accordion logic for Help screen
- show plus/minus toggle icons for help topics
- update Help instructions on progressing with chords

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684ed502d5688323b632fe83b9c1945b