### PR TITLE
Add quit buttons to single note test footers

### DIFF
--- a/components/training_easy_note.js
+++ b/components/training_easy_note.js
@@ -54,8 +54,14 @@ export function renderTrainingScreen(user) {
     <div class="piano-container">
       <div class="white-keys"></div>
     </div>
-    <button id="finish-btn">やめる</button>
   `;
+
+  const finishBtn = document.createElement("button");
+  finishBtn.id = "finish-btn";
+  finishBtn.textContent = "やめる";
+  const bottomWrap = document.createElement("footer");
+  bottomWrap.id = "training-footer";
+  bottomWrap.appendChild(finishBtn);
 
   const debugAnswer = document.createElement("div");
   debugAnswer.style.position = "absolute";
@@ -64,6 +70,7 @@ export function renderTrainingScreen(user) {
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
   app.appendChild(debugAnswer);
+  app.appendChild(bottomWrap);
 
   const whiteOrder = ["C", "D", "E", "F", "G", "A", "B"];
   const blackOrder = [
@@ -84,7 +91,6 @@ export function renderTrainingScreen(user) {
   });
 
   const piano = app.querySelector(".piano-container");
-  const finishBtn = document.getElementById("finish-btn");
 
   function setInteraction(enabled) {
     if (enabled) {

--- a/components/training_full.js
+++ b/components/training_full.js
@@ -52,8 +52,14 @@ export function renderTrainingScreen(user) {
     <div class="piano-container">
       <div class="white-keys"></div>
     </div>
-    <button id="finish-btn">やめる</button>
   `;
+
+  const finishBtn = document.createElement("button");
+  finishBtn.id = "finish-btn";
+  finishBtn.textContent = "やめる";
+  const bottomWrap = document.createElement("footer");
+  bottomWrap.id = "training-footer";
+  bottomWrap.appendChild(finishBtn);
 
   const debugAnswer = document.createElement("div");
   debugAnswer.style.position = "absolute";
@@ -62,6 +68,7 @@ export function renderTrainingScreen(user) {
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
   app.appendChild(debugAnswer);
+  app.appendChild(bottomWrap);
 
   const whiteOrder = ["C", "D", "E", "F", "G", "A", "B"];
   const blackOrder = [
@@ -82,7 +89,6 @@ export function renderTrainingScreen(user) {
   });
 
   const piano = app.querySelector(".piano-container");
-  const finishBtn = document.getElementById("finish-btn");
 
   function setInteraction(enabled) {
     if (enabled) {

--- a/components/training_white_keys.js
+++ b/components/training_white_keys.js
@@ -44,8 +44,14 @@ export function renderTrainingScreen(user) {
     <div class="piano-container">
       <div class="white-keys"></div>
     </div>
-    <button id="finish-btn">やめる</button>
   `;
+
+  const finishBtn = document.createElement("button");
+  finishBtn.id = "finish-btn";
+  finishBtn.textContent = "やめる";
+  const bottomWrap = document.createElement("footer");
+  bottomWrap.id = "training-footer";
+  bottomWrap.appendChild(finishBtn);
 
   const debugAnswer = document.createElement("div");
   debugAnswer.style.position = "absolute";
@@ -54,6 +60,7 @@ export function renderTrainingScreen(user) {
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
   app.appendChild(debugAnswer);
+  app.appendChild(bottomWrap);
 
   const whiteOrder = ["C", "D", "E", "F", "G", "A", "B"];
 
@@ -67,7 +74,6 @@ export function renderTrainingScreen(user) {
   });
 
   const piano = app.querySelector(".piano-container");
-  const finishBtn = document.getElementById("finish-btn");
 
   function setInteraction(enabled) {
     if (enabled) {


### PR DESCRIPTION
## Summary
- show Quit button in footer for white-key single note test
- show Quit button in footer for 3-octave single note test
- show Quit button in footer for full-range single note test

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685012f2d1dc8323afdd09bbf315143b