### PR TITLE
Store single note training results

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -55,6 +55,24 @@ export function createResultTable(results) {
     return `<p class="no-training">きょうは まだ トレーニングしてないよ</p>`;
   }
 
+  const onlySingle = results.every(r => r.isSingleNote);
+  if (onlySingle) {
+    const rows = results
+      .map((r, i) => `
+        <tr class="${r.correct ? 'correct-row' : 'wrong-row'}">
+          <td>${i + 1}</td>
+          <td>${labelNote(r.noteQuestion || '')}</td>
+          <td><span class="ans-mark ${r.correct ? 'correct' : 'wrong'}">${r.correct ? '◯' : ''}</span>${labelNote(r.noteAnswer || '')}</td>
+        </tr>`)
+      .join('');
+    return `<table class="result-table">
+        <thead>
+          <tr><th>じゅんばん</th><th>もんだい</th><th>こたえ</th></tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>`;
+  }
+
   const rows = (() => {
     let rhtml = '';
     let idx = 0;
@@ -108,7 +126,7 @@ export async function renderResultScreen(user) {
   let results = lastResults;
   if (!results.length && user && user.id) {
     const latest = await loadLatestTrainingSession(user.id);
-    if (latest && Array.isArray(latest.results_json)) {
+    if (latest && latest.results_json) {
       results = latest.results_json;
     }
   }

--- a/components/summary.js
+++ b/components/summary.js
@@ -205,7 +205,12 @@ export async function renderSummarySection(container, date, user) {
     const sessionTitle = document.createElement("h3");
     const t = session.timestamp ? new Date(session.timestamp).toTimeString().slice(0,5) : '';
     const jp = jpNums[sessionIndex] || (sessionIndex + 1);
-    sessionTitle.textContent = `${jp}回目のトレーニング${t ? ' ' + t : ''}`;
+    const type = session.results_json && session.results_json.type;
+    let typeLabel = '和音トレーニング';
+    if (type === 'note-white') typeLabel = '単音テスト（白鍵）';
+    else if (type === 'note-easy') typeLabel = '単音テスト（3オクターブ）';
+    else if (type === 'note-full') typeLabel = '単音テスト（全88鍵）';
+    sessionTitle.textContent = `${jp}回目: ${typeLabel}${t ? ' ' + t : ''}`;
     sessionTitle.style.fontSize = "1em";
     sessionTitle.style.margin = "0 0 0.5em 0";
     sessionSummary.appendChild(sessionTitle);

--- a/components/training.js
+++ b/components/training.js
@@ -170,7 +170,7 @@ async function nextQuestion() {
     playSoundThen(sound, async () => {
       await saveTrainingSession({
         userId: currentUser.id,
-        results: lastResults,
+        results: { type: 'chord', results: lastResults },
         stats,
         mistakes,
         correctCount,

--- a/components/training_white_keys.js
+++ b/components/training_white_keys.js
@@ -3,6 +3,7 @@
 import { getRandomWhiteNoteSequence } from "./question_white.js";
 import { playNote } from "./soundPlayer.js";
 import { switchScreen } from "../main.js";
+import { saveTrainingSession } from "../utils/trainingStore_supabase.js";
 
 let currentNote = null;
 let noteSequence = [];
@@ -29,7 +30,7 @@ function kanaToHiragana(str) {
   );
 }
 
-export function renderTrainingScreen(user) {
+export async function renderTrainingScreen(user) {
   const app = document.getElementById("app");
   // reset session state
   currentNote = null;
@@ -93,7 +94,12 @@ export function renderTrainingScreen(user) {
     setInteraction(false);
     const note = btn.dataset.note;
     const correct = note === currentNote.replace(/[0-9]/g, "");
-    noteHistory.push({ question: currentNote, answer: note, correct });
+    noteHistory.push({
+      noteQuestion: currentNote,
+      noteAnswer: note,
+      correct,
+      isSingleNote: true
+    });
 
     const feedback = document.getElementById("feedback");
     feedback.textContent = correct ? "🎉 正解!" : "❌ 不正解";
@@ -101,7 +107,7 @@ export function renderTrainingScreen(user) {
 
     isAnswering = true;
     const proceed = () => {
-      setTimeout(() => {
+      setTimeout(async () => {
         feedback.textContent = "";
         isAnswering = false;
         questionCount++;
@@ -109,6 +115,15 @@ export function renderTrainingScreen(user) {
           nextQuestion();
         } else {
           sessionStorage.setItem("noteHistory", JSON.stringify(noteHistory));
+          await saveTrainingSession({
+            userId: user.id,
+            results: { type: 'note-white', results: noteHistory },
+            stats: {},
+            mistakes: {},
+            correctCount: noteHistory.filter(n => n.correct).length,
+            totalCount: noteHistory.length,
+            date: new Date().toISOString()
+          });
           switchScreen("result_white", user);
         }
       }, FEEDBACK_DELAY);

--- a/utils/growthStore_supabase.js
+++ b/utils/growthStore_supabase.js
@@ -155,7 +155,7 @@ export async function generateMockGrowthData(userId, days = 7) {
         session_date: `${dateStr}${time}`,
         correct_count: count - mistakeNum,
         total_count: count,
-        results_json: results,
+        results_json: { type: 'chord', results },
         stats_json: stats,
         mistakes_json: { inversion_confusions: inversionMistakes },
         is_qualified: isQualified

--- a/utils/trainingStore_supabase.js
+++ b/utils/trainingStore_supabase.js
@@ -21,7 +21,10 @@ export async function saveTrainingSession({ userId, results, stats, mistakes, co
     return;
   }
   
-  const structuredMistakes = convertMistakesJsonToStructuredForm(mistakes, results);
+  const answerList = Array.isArray(results)
+    ? results
+    : (results && Array.isArray(results.results) ? results.results : []);
+  const structuredMistakes = convertMistakesJsonToStructuredForm(mistakes, answerList);
   const isQualified = sessionMeetsStats(stats, totalCount);
   const { data, error } = await supabase.from("training_sessions").insert([
     {


### PR DESCRIPTION
## Summary
- store arrays in results_json with a type flag so sessions distinguish chord vs note tests
- persist single note test sessions to Supabase
- show session type on the summary screen
- render single-note-only tables in the result screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68501393ce1083239332137b0d9a80ab