### PR TITLE
Adjust training progress bar thickness and alignment

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -275,14 +275,14 @@ function drawQuizScreen() {
   progressWrapper.className = "progress-wrapper";
   progressWrapper.style.flexGrow = "1";
   progressWrapper.style.position = "relative";
-  progressWrapper.style.marginLeft = "1em";
+  progressWrapper.style.marginLeft = "0";
 
   const progress = document.createElement("progress");
   progress.id = "progress-bar";
   progress.value = questionCount;
   progress.max = total;
   progress.style.width = "100%";
-  progress.style.height = "1.5em";
+  progress.style.height = "2em";
   progressWrapper.appendChild(progress);
 
   const counter = document.createElement("span");

--- a/css/training.css
+++ b/css/training.css
@@ -200,7 +200,7 @@
 
 #progress-bar {
   width: 100%;
-  height: 1.5em;
+  height: 2em;
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- enlarge progress bar height in training screen
- align progress bar with chord grid

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68502160ca3c8323a32c3185247be34e