### PR TITLE
Fix FAQ text overlap

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -339,7 +339,7 @@ a/* Landing page styles */
 .faq-question {
   display: block;
   width: 100%;
-  padding: 1em;
+  padding: 1em 2.5em 1em 1em; /* ensure space for the toggle icon */
   border: none;
   background: #f6f6f6;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- add extra right padding to FAQ question text so the plus icon doesn't overlap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68502aaec6388323bb9cb43edd6dda89