### PR TITLE
Display trial countdown on home screen

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -48,6 +48,24 @@ export async function renderHomeScreen(user, options = {}) {
   info.innerHTML = `🎯 きょう の がんばり：<strong>${todayRecord.sets}</strong>かい`;
   container.appendChild(info);
 
+  if (
+    user &&
+    user.trial_active &&
+    !user.is_premium &&
+    user.trial_end_date
+  ) {
+    const end = new Date(user.trial_end_date);
+    const now = new Date();
+    const days = Math.ceil((end - now) / (1000 * 60 * 60 * 24));
+    const trialInfo = document.createElement("p");
+    trialInfo.className = "trial-info";
+    if (days <= 3) {
+      trialInfo.classList.add("warning");
+    }
+    trialInfo.textContent = `無料体験期間は残り${days}日`;
+    container.appendChild(trialInfo);
+  }
+
   // ✅ オトロン画像とスタートボタン
   const logoContainer = document.createElement("div");
   logoContainer.className = "logo-container";

--- a/css/home.css
+++ b/css/home.css
@@ -109,6 +109,17 @@
   margin-top: 0.5em;
 }
 
+.home-screen .trial-info {
+  font-size: 1em;
+  color: #543014;
+  text-align: center;
+  margin-top: 0.3em;
+}
+
+.home-screen .trial-info.warning {
+  color: #ff6600;
+}
+
 @keyframes start-button-pulse {
   0%, 100% {
     transform: scale(1);


### PR DESCRIPTION
## Summary
- show trial days remaining underneath "きょう の がんばり" on home screen
- style the trial info text and apply warning color when few days remain

## Testing
- `npm test` *(fails: Missing script and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68502e18c400832389c13d8f0a882c4c