### PR TITLE
Remove header trial days display

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -20,7 +20,6 @@ export function renderHeader(container, user) {
     </button>
 
     <div class="header-right">
-      <div id="trial-status" class="trial-status" style="display:none"></div>
       <div class="info-menu">
         <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
         <div id="info-dropdown" class="info-dropdown">
@@ -59,24 +58,6 @@ export function renderHeader(container, user) {
   const helpBtn = header.querySelector("#help-btn");
   const lawBtn = header.querySelector("#law-btn");
   const externalBtn = header.querySelector("#external-btn");
-  const trialStatus = header.querySelector("#trial-status");
-
-  if (
-    trialStatus &&
-    user &&
-    user.trial_active &&
-    !user.is_premium &&
-    user.trial_end_date
-  ) {
-    const end = new Date(user.trial_end_date);
-    const now = new Date();
-    const days = Math.ceil((end - now) / (1000 * 60 * 60 * 24));
-    trialStatus.textContent = `無料体験：あと${days}日`;
-    trialStatus.style.display = "block";
-    if (days <= 3) {
-      trialStatus.classList.add("warning");
-    }
-  }
 
   parentMenuBtn.onclick = (e) => {
     e.stopPropagation();

--- a/css/header.css
+++ b/css/header.css
@@ -30,14 +30,6 @@
   gap: 0.1em; /* tighter spacing */
 }
 
-.trial-status {
-  font-size: 0.9rem;
-  margin-right: 0.4em;
-}
-
-.trial-status.warning {
-  color: #ff6600;
-}
 
 /* ▼ 親メニュー全体 */
 .parent-menu {


### PR DESCRIPTION
## Summary
- hide trial days display from the header area by removing the element
- drop unused CSS rules for the trial-status badge

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68502f915148832382a9db99aca93a38