### PR TITLE
Fix plan button hidden on info pages

### DIFF
--- a/components/info/contact.js
+++ b/components/info/contact.js
@@ -3,10 +3,10 @@ import { switchScreen } from "../../main.js";
 
 const GAS_URL = "https://script.google.com/macros/s/AKfycbxuLk3wnuOENw8lqC0oZq-rLTvH8MJbzSPeMMwDLPYNpfDg10qQ2koVcvsIiPEepLSu/exec";
 
-export function renderContactScreen() {
+export function renderContactScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app);
+  renderHeader(app, user);
 
   const main = document.createElement("main");
   main.className = "info-page contact-page";

--- a/components/info/external.js
+++ b/components/info/external.js
@@ -1,9 +1,9 @@
 import { renderHeader } from "../header.js";
 
-export function renderExternalScreen() {
+export function renderExternalScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app);
+  renderHeader(app, user);
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/help.js
+++ b/components/info/help.js
@@ -1,9 +1,9 @@
 import { renderHeader } from "../header.js";
 
-export function renderHelpScreen() {
+export function renderHelpScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app);
+  renderHeader(app, user);
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/law.js
+++ b/components/info/law.js
@@ -1,9 +1,9 @@
 import { renderHeader } from "../header.js";
 
-export function renderLawScreen() {
+export function renderLawScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app);
+  renderHeader(app, user);
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/privacy.js
+++ b/components/info/privacy.js
@@ -1,9 +1,9 @@
 import { renderHeader } from "../header.js";
 
-export function renderPrivacyScreen() {
+export function renderPrivacyScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app);
+  renderHeader(app, user);
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/terms.js
+++ b/components/info/terms.js
@@ -1,9 +1,9 @@
 import { renderHeader } from "../header.js";
 
-export function renderTermsScreen() {
+export function renderTermsScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app);
+  renderHeader(app, user);
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/main.js
+++ b/main.js
@@ -96,12 +96,12 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   else if (screen === "result_easy") renderTrainingEasyResultScreen(user);
   else if (screen === "result_full") renderTrainingFullResultScreen(user);
   else if (screen === "result_white") renderTrainingWhiteResultScreen(user);
-  else if (screen === "terms") renderTermsScreen();
-  else if (screen === "privacy") renderPrivacyScreen();
-  else if (screen === "contact") renderContactScreen();
-  else if (screen === "help") renderHelpScreen();
-  else if (screen === "law") renderLawScreen();
-  else if (screen === "external") renderExternalScreen();
+  else if (screen === "terms") renderTermsScreen(user);
+  else if (screen === "privacy") renderPrivacyScreen(user);
+  else if (screen === "contact") renderContactScreen(user);
+  else if (screen === "help") renderHelpScreen(user);
+  else if (screen === "law") renderLawScreen(user);
+  else if (screen === "external") renderExternalScreen(user);
   else if (screen === "pricing") renderPricingScreen(user);
   else if (screen === "lock") renderLockScreen(user, options);
 };


### PR DESCRIPTION
## Summary
- ensure headers on info pages receive the user object
- pass `user` when switching to information screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68502fde6a2c83239912ceda5b4a5792