### PR TITLE
Add FAQ and chord reset page

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -26,7 +26,8 @@ export function renderHeader(container, user) {
           <button id="terms-btn">利用規約</button>
           <button id="privacy-btn">プライバシーポリシー</button>
           <button id="contact-btn">お問い合わせ</button>
-          <button id="help-btn">ヘルプ</button>
+          <button id="help-btn">必ずお読みください</button>
+          <button id="faq-btn">よくある質問</button>
           <button id="law-btn">特定商取引法に基づく表示</button>
           <button id="external-btn">外部送信ポリシー</button>
         </div>
@@ -56,6 +57,7 @@ export function renderHeader(container, user) {
   const privacyBtn = header.querySelector("#privacy-btn");
   const contactBtn = header.querySelector("#contact-btn");
   const helpBtn = header.querySelector("#help-btn");
+  const faqBtn = header.querySelector("#faq-btn");
   const lawBtn = header.querySelector("#law-btn");
   const externalBtn = header.querySelector("#external-btn");
 
@@ -91,6 +93,7 @@ export function renderHeader(container, user) {
   privacyBtn.onclick = () => switchScreen("privacy");
   contactBtn.onclick = () => switchScreen("contact");
   helpBtn.onclick = () => switchScreen("help");
+  faqBtn.onclick = () => switchScreen("faq");
   lawBtn.onclick = () => switchScreen("law");
   externalBtn.onclick = () => switchScreen("external");
 

--- a/components/info/chordReset.js
+++ b/components/info/chordReset.js
@@ -1,0 +1,39 @@
+import { renderHeader } from "../header.js";
+import { chords } from "../../data/chords.js";
+import { resetProgressAndUnlock } from "../../utils/progressUtils.js";
+
+export function renderChordResetScreen(user) {
+  const app = document.getElementById("app");
+  app.innerHTML = "";
+  renderHeader(app, user);
+
+  const main = document.createElement("main");
+  main.className = "info-page";
+  main.innerHTML = `
+    <h1>開始和音を選び直す</h1>
+    <select id="start-chord"></select>
+    <button id="apply-btn">選び直す</button>
+  `;
+  app.appendChild(main);
+
+  const select = main.querySelector("#start-chord");
+  chords.forEach((ch, idx) => {
+    if (idx <= 13) { // up to mizuiro (basic 14 colors)
+      const opt = document.createElement("option");
+      opt.value = idx;
+      opt.textContent = ch.label;
+      select.appendChild(opt);
+    }
+  });
+
+  main.querySelector("#apply-btn").onclick = async () => {
+    const idx = parseInt(select.value, 10);
+    if (!window.confirm("本当に進捗をリセットして選び直しますか？")) return;
+    const ok = await resetProgressAndUnlock(user.id, idx);
+    if (ok) {
+      alert("進捗をリセットしました");
+    } else {
+      alert("リセットに失敗しました");
+    }
+  };
+}

--- a/components/info/faq.js
+++ b/components/info/faq.js
@@ -1,0 +1,24 @@
+import { renderHeader } from "../header.js";
+import { switchScreen } from "../../main.js";
+
+export function renderFaqScreen(user) {
+  const app = document.getElementById("app");
+  app.innerHTML = "";
+  renderHeader(app, user);
+
+  const main = document.createElement("main");
+  main.className = "info-page";
+  main.innerHTML = `
+    <h1>よくある質問</h1>
+    <h2>Q. 和音の選択を間違えてしまいました。最初からやり直せますか？</h2>
+    <p>はい、できます。以下のボタンから和音の選び直しが可能です。<br />ただし、トレーニングの記録は全てリセットされます。</p>
+    <p><button id="reselect-btn">和音を選び直す</button></p>
+    <h2>Q. 初めて使います。どうすればいいですか？</h2>
+    <p>「必ずお読みください」ページに使い方をまとめています。</p>
+    <p><button id="guide-link">▶️ 必ずお読みください</button></p>
+  `;
+  app.appendChild(main);
+
+  main.querySelector("#reselect-btn").onclick = () => switchScreen("chord_reset");
+  main.querySelector("#guide-link").onclick = () => switchScreen("help");
+}

--- a/components/info/help.js
+++ b/components/info/help.js
@@ -9,7 +9,7 @@ export function renderHelpScreen(user) {
   main.className = "info-page";
   main.innerHTML = `
     <section id="help-section" class="help-container">
-      <h1>絶対音感トレーニング ガイド</h1>
+      <h1>必ずお読みください</h1>
 
       <details>
         <summary>対象年齢と基礎的な考え方</summary>

--- a/main.js
+++ b/main.js
@@ -28,6 +28,8 @@ import { renderContactScreen } from "./components/info/contact.js";
 import { renderLawScreen } from "./components/info/law.js";
 import { renderExternalScreen } from "./components/info/external.js";
 import { renderHelpScreen } from "./components/info/help.js";
+import { renderFaqScreen } from "./components/info/faq.js";
+import { renderChordResetScreen } from "./components/info/chordReset.js";
 import { renderPricingScreen } from "./components/pricing.js";
 import { renderLockScreen } from "./components/lock.js";
 
@@ -100,6 +102,8 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   else if (screen === "privacy") renderPrivacyScreen(user);
   else if (screen === "contact") renderContactScreen(user);
   else if (screen === "help") renderHelpScreen(user);
+  else if (screen === "faq") renderFaqScreen(user);
+  else if (screen === "chord_reset") renderChordResetScreen(user);
   else if (screen === "law") renderLawScreen(user);
   else if (screen === "external") renderExternalScreen(user);
   else if (screen === "pricing") renderPricingScreen(user);


### PR DESCRIPTION
## Summary
- rename help menu to "必ずお読みください" and add "よくある質問"
- add FAQ page with chord reset link
- add chord reset page to reselect starting chord and purge progress
- implement progress reset helper
- hook new pages into router

## Testing
- `npm run` *(fails: no internet)*

------
https://chatgpt.com/codex/tasks/task_b_685033acf7588323943f4972a0f98fe6