### PR TITLE
Fix free trial message layout

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -48,6 +48,13 @@ export async function renderHomeScreen(user, options = {}) {
   info.innerHTML = `🎯 きょう の がんばり：<strong>${todayRecord.sets}</strong>かい`;
   container.appendChild(info);
 
+  // Create trial info element ahead of time to preserve layout
+  const trialInfo = document.createElement("p");
+  trialInfo.className = "trial-info";
+  trialInfo.style.visibility = "hidden";
+  trialInfo.style.minHeight = "1.2em"; // reserve space even when hidden
+  container.appendChild(trialInfo);
+
   if (
     user &&
     user.trial_active &&
@@ -57,13 +64,11 @@ export async function renderHomeScreen(user, options = {}) {
     const end = new Date(user.trial_end_date);
     const now = new Date();
     const days = Math.ceil((end - now) / (1000 * 60 * 60 * 24));
-    const trialInfo = document.createElement("p");
-    trialInfo.className = "trial-info";
     if (days <= 3) {
       trialInfo.classList.add("warning");
     }
     trialInfo.textContent = `無料体験期間は残り${days}日`;
-    container.appendChild(trialInfo);
+    trialInfo.style.visibility = "visible";
   }
 
   // ✅ オトロン画像とスタートボタン

--- a/css/home.css
+++ b/css/home.css
@@ -114,6 +114,7 @@
   color: #543014;
   text-align: center;
   margin-top: 0.3em;
+  min-height: 1.2em; /* keep layout even when text is hidden */
 }
 
 .home-screen .trial-info.warning {


### PR DESCRIPTION
## Summary
- prevent layout shift when trial info is shown/hidden
- reserve space for the message via CSS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685036002ad88323b8b1d28e76223dc2