### PR TITLE
Improve chord reset flow

### DIFF
--- a/components/info/chordReset.js
+++ b/components/info/chordReset.js
@@ -1,6 +1,8 @@
 import { renderHeader } from "../header.js";
 import { chords } from "../../data/chords.js";
 import { resetProgressAndUnlock } from "../../utils/progressUtils.js";
+import { showCustomConfirm, showCustomAlert } from "../home.js";
+import { switchScreen } from "../../main.js";
 
 export function renderChordResetScreen(user) {
   const app = document.getElementById("app");
@@ -13,6 +15,7 @@ export function renderChordResetScreen(user) {
     <h1>開始和音を選び直す</h1>
     <select id="start-chord"></select>
     <button id="apply-btn">選び直す</button>
+    <button id="back-btn" class="link-btn">戻る</button>
   `;
   app.appendChild(main);
 
@@ -26,14 +29,19 @@ export function renderChordResetScreen(user) {
     }
   });
 
-  main.querySelector("#apply-btn").onclick = async () => {
+  main.querySelector("#apply-btn").onclick = () => {
     const idx = parseInt(select.value, 10);
-    if (!window.confirm("本当に進捗をリセットして選び直しますか？")) return;
-    const ok = await resetProgressAndUnlock(user.id, idx);
-    if (ok) {
-      alert("進捗をリセットしました");
-    } else {
-      alert("リセットに失敗しました");
-    }
+    showCustomConfirm("本当に進捗をリセットして選び直しますか？", async () => {
+      const ok = await resetProgressAndUnlock(user.id, idx);
+      if (ok) {
+        showCustomAlert("進捗をリセットしました");
+      } else {
+        showCustomAlert("リセットに失敗しました");
+      }
+    });
+  };
+
+  main.querySelector("#back-btn").onclick = () => {
+    switchScreen("faq");
   };
 }


### PR DESCRIPTION
## Summary
- customize chord reset confirmation dialog
- add a Back button to return to FAQ screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852b27ea54083239ed997a712725940