### PR TITLE
Update home screen layout

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -98,8 +98,8 @@ export async function renderHomeScreen(user, options = {}) {
   startButton.className = "main-start-button"; // CSSでデザイン指定
   startButton.onclick = () => switchScreen("training");
 
-  logoContainer.appendChild(startButton);
   logoContainer.appendChild(faceImg);
+  logoContainer.appendChild(startButton);
 
   container.appendChild(logoContainer);
 

--- a/style.css
+++ b/style.css
@@ -727,7 +727,7 @@ button:hover {
 
 .home-screen .logo-container {
   text-align: center;
-  margin-top: 6em; /* Adjust position further down */
+  margin-top: 8em; /* Place slightly below center */
 }
 
 .home-screen .otolon-face {
@@ -767,7 +767,7 @@ button:hover {
   box-shadow: 0 4px #c8a837;
   cursor: pointer;
   display: block;
-  margin: 2.5em auto 0.5em;
+  margin: 1em auto 0.5em;
   animation: start-button-pulse 1.8s ease-in-out infinite;
   transform-origin: center;
 }
@@ -823,12 +823,13 @@ button:hover {
   }
 
   .home-screen .logo-container {
-    margin-top: 3em;
+    margin-top: 5em;
   }
 
   .home-screen .main-start-button {
     font-size: 1.4rem;
     padding: 1em 2em;
+    margin: 1em auto 0.5em;
   }
 }
 .info-page {


### PR DESCRIPTION
## Summary
- position Otoron image slightly lower and put the training button below it
- tweak margins for logo container and training button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852b40826388323a9f459a7f4e8e6bf