### PR TITLE
Center otolon image on home screen

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -53,7 +53,7 @@
 
 .home-screen .logo-container {
   text-align: center;
-  margin-top: 6em; /* Adjust position further down */
+  margin-top: 4em; /* Move closer to the center */
 }
 
 .home-screen .otolon-face {
@@ -149,7 +149,7 @@
   }
 
   .home-screen .logo-container {
-    margin-top: 3em;
+    margin-top: 2em;
   }
 
   .home-screen .main-start-button {

--- a/style.css
+++ b/style.css
@@ -727,7 +727,7 @@ button:hover {
 
 .home-screen .logo-container {
   text-align: center;
-  margin-top: 8em; /* Place slightly below center */
+  margin-top: 5em; /* Move closer to the center */
 }
 
 .home-screen .otolon-face {
@@ -823,7 +823,7 @@ button:hover {
   }
 
   .home-screen .logo-container {
-    margin-top: 5em;
+    margin-top: 4em;
   }
 
   .home-screen .main-start-button {


### PR DESCRIPTION
## Summary
- adjust logo container margins to center Otoron image vertically

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852b53ef48083239d11122f884f46af