### PR TITLE
Fix analysis scroll and mobile table

### DIFF
--- a/css/result.css
+++ b/css/result.css
@@ -34,7 +34,7 @@
 .result-table {
   margin: 2em auto;
   border-collapse: collapse;
-  width: auto;
+  width: 100%;
   font-size: 0.85em;
   table-layout: fixed;
 }

--- a/css/summary.css
+++ b/css/summary.css
@@ -112,6 +112,6 @@ button#dummy-button {
 }
 
 .result-wrap.open {
-  max-height: 1000px;
+  max-height: none;
   opacity: 1;
 }

--- a/style.css
+++ b/style.css
@@ -1827,7 +1827,7 @@ a/* Landing page styles */
 .result-table {
   margin: 2em auto;
   border-collapse: collapse;
-  width: auto;
+  width: 100%;
   font-size: 0.85em;
   table-layout: fixed;
 }
@@ -2501,7 +2501,7 @@ button#dummy-button {
 }
 
 .result-wrap.open {
-  max-height: 1000px;
+  max-height: none;
   opacity: 1;
 }
 /* =============================== */


### PR DESCRIPTION
## Summary
- improve analysis table width so it's not cut off on mobile
- expand results sections without internal scrollbars

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852b74e5e748323ba09b3b16b7b655c