### PR TITLE
Fix double scrollbars on detail view

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -177,7 +177,7 @@ export async function renderResultScreen(user) {
   const dates = Object.keys(history).sort();
   const latestDate = dates[dates.length - 1] || new Date().toISOString().slice(0,10);
   const summaryContainer = container.querySelector("#summary .summary-container");
-  renderSummarySection(summaryContainer, latestDate, user);
+  renderSummarySection(summaryContainer, latestDate, user, { standalone: false });
 
   app.querySelectorAll('.tab').forEach(btn => {
     btn.addEventListener('click', () => {

--- a/components/summary.js
+++ b/components/summary.js
@@ -87,13 +87,19 @@ export async function renderSummaryScreen(user) {
   await renderSummaryScreenForDate(today, user);
 }
 
-export async function renderSummarySection(container, date, user) {
+export async function renderSummarySection(container, date, user, options = {}) {
+  const { standalone = true } = options;
+
   const records = await loadTrainingRecords(user.id);
   const sessions = await loadTrainingSessionsForDate(user.id, date);
 
   container.innerHTML = "";
   // Add a specific class so CSS rules don't affect other screens
-  container.className = "screen active summary-screen";
+  if (standalone) {
+    container.className = "screen active summary-screen";
+  } else {
+    container.className = "summary-screen";
+  }
 
   const calendarLabel = document.createElement("div");
   calendarLabel.textContent = "日付を絞って選択";


### PR DESCRIPTION
## Summary
- avoid nested `.screen` when rendering summary inside result view
- allow `renderSummarySection` to be used without fullscreen layout

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852bce540f48323a3c3f38734e2d67d