### PR TITLE
Expand info pages on desktop

### DIFF
--- a/css/info.css
+++ b/css/info.css
@@ -9,6 +9,15 @@
   border-radius: 8px;
 }
 
+@media (min-width: 768px) {
+  .info-page {
+    max-width: none;
+    margin-left: 0;
+    margin-right: 0;
+    border-radius: 0;
+  }
+}
+
 /* Ensure readability even when the body has a dark background */
 .app-root.night .info-page {
   background: #fff;

--- a/style.css
+++ b/style.css
@@ -843,6 +843,15 @@ button:hover {
   border-radius: 8px;
 }
 
+@media (min-width: 768px) {
+  .info-page {
+    max-width: none;
+    margin-left: 0;
+    margin-right: 0;
+    border-radius: 0;
+  }
+}
+
 /* Ensure readability even when the body has a dark background */
 .app-root.night .info-page {
   background: #fff;


### PR DESCRIPTION
## Summary
- allow info screens to span full width on desktop

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852bd7b36548323b36bf0729542d70c