### PR TITLE
Ensure wide layout for analysis, mypage and plan pages on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -2835,3 +2835,14 @@ button#dummy-button {
 button.disabled {
   opacity: 0.5;
 }
+
+/* PC表示では分析画面・マイページ・プランページを横幅いっぱいに */
+@media (min-width: 768px) {
+  .summary-screen,
+  .mypage-screen,
+  .pricing-page,
+  .plan-info-screen {
+    max-width: none;
+    margin: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- adjust CSS so that analysis, mypage and plan pages use full width when viewed on desktop screens

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852c0842d988323bab58b44f2c34978