### PR TITLE
Fix width and scrollbar on analysis page

### DIFF
--- a/css/summary.css
+++ b/css/summary.css
@@ -8,6 +8,15 @@
   background: #fffaf5;
 }
 
+@media (min-width: 768px) {
+  .summary-screen {
+    max-width: none;
+    margin: 0;
+    height: auto;
+    overflow-y: visible;
+  }
+}
+
 #calendar,
 #from-date,
 #to-date {

--- a/style.css
+++ b/style.css
@@ -2852,4 +2852,10 @@ button.disabled {
     max-width: none;
     margin: 0;
   }
+
+  /* Allow the analysis page to use the full page height */
+  .summary-screen {
+    height: auto;
+    overflow-y: visible;
+  }
 }


### PR DESCRIPTION
## Summary
- keep analysis page full-width on desktop
- let summary screen use body scrolling instead of inner scrollbar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852c2c81c80832385d53054513bf38b