### PR TITLE
Fix pricing layout and style

### DIFF
--- a/css/pricing.css
+++ b/css/pricing.css
@@ -7,6 +7,19 @@
   gap: 1em;
 }
 
+@media (min-width: 768px) {
+  .pricing-page {
+    flex-direction: row;
+    justify-content: center;
+    max-width: 800px;
+  }
+
+  .pricing-page .plan-card {
+    flex: 1;
+    max-width: 240px;
+  }
+}
+
 .plan-card {
   background: #fff;
   border-radius: 12px;
@@ -57,7 +70,7 @@
 }
 
 .plan-card button {
-  margin-top: 0.6em;
+  margin-top: auto;
   padding: 0.8em;
   font-size: 1rem;
   background: #ffa500;
@@ -69,6 +82,15 @@
 
 .plan-card button:hover {
   background: #e38c00;
+}
+
+.plan-card:not(.recommended) button {
+  background: #ccc;
+  color: #666;
+}
+
+.plan-card:not(.recommended) button:hover {
+  background: #bbb;
 }
 
 .plan-note {

--- a/style.css
+++ b/style.css
@@ -1728,6 +1728,7 @@ a/* Landing page styles */
   .pricing-page {
     flex-direction: row;
     justify-content: center;
+    max-width: 800px;
   }
   .pricing-page .plan-card {
     flex: 1;
@@ -1785,7 +1786,7 @@ a/* Landing page styles */
 }
 
 .plan-card button {
-  margin-top: 0.6em;
+  margin-top: auto;
   padding: 0.8em;
   font-size: 1rem;
   background: #ffa500;
@@ -1797,6 +1798,15 @@ a/* Landing page styles */
 
 .plan-card button:hover {
   background: #e38c00;
+}
+
+.plan-card:not(.recommended) button {
+  background: #ccc;
+  color: #666;
+}
+
+.plan-card:not(.recommended) button:hover {
+  background: #bbb;
 }
 
 .plan-note {


### PR DESCRIPTION
## Summary
- adjust pricing card layout for desktop view
- align plan buttons at bottom
- grey out non-12-month plan buttons

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852c362108c8323a4d8ceac24153314