### PR TITLE
Fix width and scrollbar on analysis page

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -93,6 +93,10 @@ button:hover {
     overflow-y: auto;
   }
 
+  .app-root.summary-scroll {
+    overflow-y: auto;
+  }
+
   .screen {
     height: calc(100dvh - 56px); /* ヘッダーを除く高さ */
     overflow-y: auto;

--- a/css/summary.css
+++ b/css/summary.css
@@ -8,6 +8,15 @@
   background: #fffaf5;
 }
 
+@media (min-width: 768px) {
+  .summary-screen {
+    max-width: none;
+    margin: 0;
+    height: auto;
+    overflow-y: visible;
+  }
+}
+
 #calendar,
 #from-date,
 #to-date {

--- a/main.js
+++ b/main.js
@@ -56,6 +56,7 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   const app = document.getElementById("app");
   app.innerHTML = "";
   document.body.classList.remove("intro-scroll");
+  document.body.classList.remove("summary-scroll");
 
   if (screen !== "home") {
     clearTimeOfDayStyling();
@@ -81,7 +82,10 @@ export const switchScreen = (screen, user = currentUser, options = {}) => {
   else if (screen === "training_full") renderTrainingFull(user);
   else if (screen === "training_white") renderTrainingWhite(user);
   else if (screen === "settings") renderSettingsScreen(user);
-  else if (screen === "summary") renderSummaryScreen(user);
+  else if (screen === "summary") {
+    document.body.classList.add("summary-scroll");
+    renderSummaryScreen(user);
+  }
   else if (screen === "growth") renderGrowthScreen(user);
   else if (screen === "signup") renderSignUpScreen(user);
   else if (screen === "setup") renderInitialSetupScreen(user, (u) => switchScreen("home", u, options));

--- a/style.css
+++ b/style.css
@@ -103,6 +103,10 @@ button:hover {
     overflow-y: auto;
   }
 
+  .app-root.summary-scroll {
+    overflow-y: auto;
+  }
+
   .screen {
     height: calc(100dvh - 56px); /* ヘッダーを除く高さ */
     overflow-y: auto;
@@ -2851,5 +2855,11 @@ button.disabled {
   .plan-info-screen {
     max-width: none;
     margin: 0;
+  }
+
+  /* Allow the analysis page to use the full page height */
+  .summary-screen {
+    height: auto;
+    overflow-y: visible;
   }
 }


### PR DESCRIPTION
## Summary
- keep analysis page full-width on desktop
- let summary screen use body scrolling instead of inner scrollbar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852c2c81c80832385d53054513bf38b