### PR TITLE
Improve settings layout

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -311,8 +311,6 @@ buttonGroup.appendChild(resetBtn);
     chordSettings.appendChild(sec);
   });
 
-  container.appendChild(chordSettings);
-
   // ✅ その他のトレーニングセクション
   const section = document.createElement("div");
   section.className = "other-training-section";
@@ -324,7 +322,9 @@ buttonGroup.appendChild(resetBtn);
       <li><button id="btn-full">単音テスト（全88鍵）</button></li>
     </ul>
   `;
-  container.appendChild(section);
+
+  chordSettings.appendChild(section);
+  container.appendChild(chordSettings);
   app.appendChild(container);
 
   document.getElementById("btn-easy").onclick = () => switchScreen("training_easy");

--- a/css/settings.css
+++ b/css/settings.css
@@ -57,11 +57,12 @@
   border: 1px solid #ccc;
   border-radius: 8px;
   background: #fff;
-  padding: 4px;
+  padding: 8px;
   text-align: center;
   font-size: 0.9em;
   position: relative;
   transition: filter 0.2s, opacity 0.2s;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .chord-block:not(.selected) {
@@ -103,7 +104,7 @@
 
 .checkbox-row {
   text-align: center;
-  margin-bottom: 2px;
+  margin-bottom: 6px;
 }
 
 /* 以前は選択中のブロックに擬似要素でチェックマークを表示していたが、
@@ -118,7 +119,7 @@
 
 .chord-name {
   font-weight: bold;
-  margin-bottom: 2px;
+  margin-bottom: 4px;
   border-radius: 4px;
   white-space: nowrap; /* Prevent chord names from wrapping */
 }
@@ -128,7 +129,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 2px;
+  gap: 6px;
 }
 
 .count-control button {
@@ -268,6 +269,17 @@
 /* その他のトレーニングの見出し */
 .other-training-section h3 {
   text-align: left; /* 左寄せに変更 */
+}
+.other-training-section {
+  flex: 1 1 260px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fff;
+  padding: 1em;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75em;
 }
 
 .shadow-button {

--- a/style.css
+++ b/style.css
@@ -2134,11 +2134,12 @@ a/* Landing page styles */
   border: 1px solid #ccc;
   border-radius: 12px;
   background: #fff;
-  padding: 4px;
+  padding: 8px;
   text-align: center;
   font-size: 0.9em;
   position: relative;
   transition: filter 0.2s, opacity 0.2s;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .chord-block:not(.selected) {
@@ -2189,7 +2190,7 @@ a/* Landing page styles */
 
 .checkbox-row {
   text-align: center;
-  margin-bottom: 2px;
+  margin-bottom: 6px;
 }
 
 /* 以前は選択中のブロックに擬似要素でチェックマークを表示していたが、
@@ -2204,7 +2205,7 @@ a/* Landing page styles */
 
 .chord-name {
   font-weight: bold;
-  margin-bottom: 2px;
+  margin-bottom: 4px;
   border-radius: 4px;
   white-space: nowrap; /* Prevent chord names from wrapping */
 }
@@ -2213,7 +2214,7 @@ a/* Landing page styles */
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
 }
 
 .count-control button {
@@ -2350,6 +2351,17 @@ a/* Landing page styles */
 /* その他のトレーニングの見出し */
 .other-training-section h3 {
   text-align: left; /* 左寄せに変更 */
+}
+.other-training-section {
+  flex: 1 1 260px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fff;
+  padding: 1em;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75em;
 }
 .setup-wrapper {
   max-width: 400px;


### PR DESCRIPTION
## Summary
- tweak PC settings layout to show other training next to inversion section
- add spacing and card styles for training blocks

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_6852c5bd9a8c83239012693b2ed48347