### PR TITLE
Adjust info page layout

### DIFF
--- a/components/info/external.js
+++ b/components/info/external.js
@@ -6,7 +6,7 @@ export function renderExternalScreen(user) {
   renderHeader(app, user);
 
   const main = document.createElement("main");
-  main.className = "info-page center-page";
+  main.className = "info-page full-page";
   main.innerHTML = `
     <h1>外部送信ポリシー</h1>
     <p>この外部送信ポリシー（以下、「本ポリシー」といいます）は、オトロン（以下、「本サービス」といいます）をご利用いただく際に、ユーザーの端末から第三者に送信される情報とその目的・送信先等についてご案内するものです。</p>

--- a/components/info/law.js
+++ b/components/info/law.js
@@ -6,7 +6,7 @@ export function renderLawScreen(user) {
   renderHeader(app, user);
 
   const main = document.createElement("main");
-  main.className = "info-page center-page";
+  main.className = "info-page full-page";
   main.innerHTML = `
     <h1>特定商取引法に基づく表示</h1>
     <h2>事業者</h2>

--- a/components/info/privacy.js
+++ b/components/info/privacy.js
@@ -6,7 +6,7 @@ export function renderPrivacyScreen(user) {
   renderHeader(app, user);
 
   const main = document.createElement("main");
-  main.className = "info-page center-page";
+  main.className = "info-page full-page";
   main.innerHTML = `
     <h1>プライバシーポリシー</h1>
     <p>本プライバシーポリシー（以下、「本ポリシー」といいます。）は、オトロン（以下、「本サービス」といいます。）の提供にあたり、ユーザーの個人情報を適切に取り扱う方針を定めたものです。個人運営者である当方は、関連する法令（個人情報保護法など）を遵守し、本サービスを利用するすべてのユーザー（以下、「ユーザー」といいます。）のプライバシーを尊重します。</p>

--- a/components/info/terms.js
+++ b/components/info/terms.js
@@ -6,7 +6,7 @@ export function renderTermsScreen(user) {
   renderHeader(app, user);
 
   const main = document.createElement("main");
-  main.className = "info-page center-page";
+  main.className = "info-page full-page";
   main.innerHTML = `
     <h1>利用規約</h1>
     <p>この利用規約（以下、「本規約」といいます。）は、オトロン（以下、「本サービス」といいます。）の利用条件を定めるものであり、本サービスを利用するすべてのユーザー（以下、「ユーザー」といいます。）に適用されます。本サービスは、個人により運営されており、関連する法令およびガイドライン（消費者契約法、電気通信事業法など）を遵守しています。</p>

--- a/css/info.css
+++ b/css/info.css
@@ -17,6 +17,16 @@
   border-radius: 8px;
 }
 
+/* Full width pages with centered text */
+.info-page.full-page {
+  max-width: none;
+  margin: 0;
+  padding-left: 0;
+  padding-right: 0;
+  border-radius: 0;
+  text-align: center;
+}
+
 @media (min-width: 768px) {
   .info-page {
     max-width: none;

--- a/style.css
+++ b/style.css
@@ -861,6 +861,16 @@ button:hover {
   border-radius: 8px;
 }
 
+/* Full width pages with centered text */
+.info-page.full-page {
+  max-width: none;
+  margin: 0;
+  padding-left: 0;
+  padding-right: 0;
+  border-radius: 0;
+  text-align: center;
+}
+
 @media (min-width: 768px) {
   .info-page {
     max-width: none;


### PR DESCRIPTION
## Summary
- extend terms, privacy, law and external policy pages full width
- add shared style for full width info pages with centered text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852c0ecdc948323949c5a324149dae2