### PR TITLE
Fix note placement & badge centering on pricing page

### DIFF
--- a/css/pricing.css
+++ b/css/pricing.css
@@ -11,6 +11,7 @@
   .pricing-page {
     flex-direction: row;
     justify-content: center;
+    flex-wrap: wrap;
     max-width: 800px;
   }
 
@@ -61,7 +62,7 @@
 }
 
 .recommend-badge {
-  align-self: flex-start;
+  align-self: center;
   background: #ff9900;
   color: #fff;
   border-radius: 999px;
@@ -98,6 +99,7 @@
   text-align: center;
   color: #666;
   margin-top: 0.5em;
+  width: 100%;
 }
 
 .plan-info-screen {

--- a/style.css
+++ b/style.css
@@ -1732,6 +1732,7 @@ a/* Landing page styles */
   .pricing-page {
     flex-direction: row;
     justify-content: center;
+    flex-wrap: wrap;
     max-width: 800px;
   }
   .pricing-page .plan-card {
@@ -1781,7 +1782,7 @@ a/* Landing page styles */
 }
 
 .recommend-badge {
-  align-self: flex-start;
+  align-self: center;
   background: #ff9900;
   color: #fff;
   border-radius: 999px;
@@ -1818,6 +1819,7 @@ a/* Landing page styles */
   text-align: center;
   color: #666;
   margin-top: 0.5em;
+  width: 100%;
 }
 
 .plan-info-screen {


### PR DESCRIPTION
## Summary
- keep pricing note under the cards on desktop by allowing wrapping
- center the "おすすめ" badge on plan cards

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852c6f4e3808323805cf016842d23c6