### PR TITLE
Fix layout for other training section

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -169,8 +169,11 @@ buttonGroup.appendChild(resetBtn);
   singleSelectWrap.appendChild(singleSelect);
   container.appendChild(singleSelectWrap);
 
-  const chordSettings = document.createElement("div");
-  chordSettings.id = "chord-settings";
+  const mainSection = document.createElement("div");
+  mainSection.className = "main-section";
+  mainSection.style.display = "flex";
+  mainSection.style.gap = "24px";
+  mainSection.style.alignItems = "flex-start";
 
   const trainingMode = sessionStorage.getItem("trainingMode");
   const stored = (trainingMode === "custom")
@@ -308,12 +311,17 @@ buttonGroup.appendChild(resetBtn);
     });
 
     sec.appendChild(grid);
-    chordSettings.appendChild(sec);
+    const wrapper = document.createElement("div");
+    if (g.type === "white") wrapper.className = "white-key-section";
+    else if (g.type === "black-root") wrapper.className = "black-key-section";
+    else wrapper.className = "inversion-section";
+    wrapper.appendChild(sec);
+    mainSection.appendChild(wrapper);
   });
 
   // ✅ その他のトレーニングセクション
   const section = document.createElement("div");
-  section.className = "other-training-section";
+  section.className = "other-training";
   section.innerHTML = `
     <h3>その他のトレーニング</h3>
     <ul>
@@ -323,8 +331,8 @@ buttonGroup.appendChild(resetBtn);
     </ul>
   `;
 
-  chordSettings.appendChild(section);
-  container.appendChild(chordSettings);
+  mainSection.appendChild(section);
+  container.appendChild(mainSection);
   app.appendChild(container);
 
   document.getElementById("btn-easy").onclick = () => switchScreen("training_easy");

--- a/css/settings.css
+++ b/css/settings.css
@@ -266,20 +266,31 @@
   padding: 6px 12px;
 }
 
-/* その他のトレーニングの見出し */
-.other-training-section h3 {
-  text-align: left; /* 左寄せに変更 */
-}
-.other-training-section {
-  flex: 1 1 260px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  background: #fff;
-  padding: 1em;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+/* その他のトレーニング */
+.other-training {
+  background: white;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  font-size: 14px;
+  width: 240px;
   display: flex;
   flex-direction: column;
-  gap: 0.75em;
+  gap: 12px;
+}
+.other-training button {
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  font-size: 14px;
+  cursor: pointer;
+}
+.other-training h3 {
+  font-weight: bold;
+  font-size: 16px;
+  margin-bottom: 8px;
 }
 
 .shadow-button {

--- a/style.css
+++ b/style.css
@@ -2364,20 +2364,31 @@ a/* Landing page styles */
   padding: 6px 12px;
 }
 
-/* その他のトレーニングの見出し */
-.other-training-section h3 {
-  text-align: left; /* 左寄せに変更 */
-}
-.other-training-section {
-  flex: 1 1 260px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  background: #fff;
-  padding: 1em;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+/* その他のトレーニング */
+.other-training {
+  background: white;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  font-size: 14px;
+  width: 240px;
   display: flex;
   flex-direction: column;
-  gap: 0.75em;
+  gap: 12px;
+}
+.other-training button {
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  font-size: 14px;
+  cursor: pointer;
+}
+.other-training h3 {
+  font-weight: bold;
+  font-size: 16px;
+  margin-bottom: 8px;
 }
 .setup-wrapper {
   max-width: 400px;


### PR DESCRIPTION
## Summary
- update settings layout to include a `main-section` flex box
- style `other-training` block and its children
- adjust settings.js to use new `other-training` markup

## Testing
- `npm test` *(fails: Missing script)*
- `npm run reset-expired-premiums` *(fails: Cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_b_6852c80f3a388323be0c5df62d50b5b6