### PR TITLE
Revamp settings board layout

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -169,11 +169,15 @@ buttonGroup.appendChild(resetBtn);
   singleSelectWrap.appendChild(singleSelect);
   container.appendChild(singleSelectWrap);
 
+  const board = document.createElement("div");
+  board.className = "board";
+  const boardTitle = document.createElement("h2");
+  boardTitle.textContent = "出題設定ボード";
+  board.appendChild(boardTitle);
+
   const mainSection = document.createElement("div");
   mainSection.className = "main-section";
-  mainSection.style.display = "flex";
-  mainSection.style.gap = "24px";
-  mainSection.style.alignItems = "flex-start";
+  board.appendChild(mainSection);
 
   const trainingMode = sessionStorage.getItem("trainingMode");
   const stored = (trainingMode === "custom")
@@ -332,7 +336,7 @@ buttonGroup.appendChild(resetBtn);
   `;
 
   mainSection.appendChild(section);
-  container.appendChild(mainSection);
+  container.appendChild(board);
   app.appendChild(container);
 
   document.getElementById("btn-easy").onclick = () => switchScreen("training_easy");

--- a/css/settings.css
+++ b/css/settings.css
@@ -1,16 +1,31 @@
 /* ===== settings.css ===== */
 
-/* 出題数設定エリア */
-#chord-settings {
-  max-width: 860px;
+/* 出題設定ボード全体 */
+.board {
   margin: 1em auto;
+  padding: 1em;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.6);
+  max-width: 960px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+
+.board h2 {
+  text-align: center;
+  margin-bottom: 1em;
+  font-size: 1.4em;
+}
+
+/* PCで横並びにするメインセクション */
+.main-section {
   display: flex;
-  gap: 1em;
   flex-wrap: wrap;
+  justify-content: center;
+  gap: 24px;
 }
 
 @media (min-width: 768px) {
-  #chord-settings {
+  .main-section {
     flex-wrap: nowrap;
   }
 }
@@ -18,10 +33,10 @@
 .chord-group {
   margin-bottom: 1.5em;
   flex: 1 1 260px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
+  border-radius: 12px;
   background: #fff;
   padding: 0.5em;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
 .chord-group h2 {
@@ -293,6 +308,17 @@
   margin-bottom: 8px;
 }
 
+/* カード型の各セクション */
+.white-key-section,
+.black-key-section,
+.inversion-section,
+.other-training {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  padding: 16px;
+}
+
 .shadow-button {
   border-radius: 6px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
@@ -303,4 +329,9 @@
 
 .toggle-label {
   font-weight: bold;
+}
+
+/* 温かみのある背景 */
+.settings-screen {
+  background: linear-gradient(135deg, #fff5e3, #ffe8ec);
 }

--- a/style.css
+++ b/style.css
@@ -2093,17 +2093,32 @@ a/* Landing page styles */
 }
 /* ===== settings.css ===== */
 
-/* 出題数設定エリア */
-#chord-settings {
-  max-width: 860px;
+/* 出題設定ボード全体 */
+.board {
   margin: 1em auto;
+  padding: 1em;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.6);
+  max-width: 960px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+
+.board h2 {
+  text-align: center;
+  margin-bottom: 1em;
+  font-size: 1.4em;
+}
+
+/* PCで横並びにするメインセクション */
+.main-section {
   display: flex;
-  gap: 1em;
   flex-wrap: wrap;
+  justify-content: center;
+  gap: 24px;
 }
 
 @media (min-width: 768px) {
-  #chord-settings {
+  .main-section {
     flex-wrap: nowrap;
   }
 }
@@ -2111,10 +2126,10 @@ a/* Landing page styles */
 .chord-group {
   margin-bottom: 1.5em;
   flex: 1 1 260px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
+  border-radius: 12px;
   background: #fff;
   padding: 0.5em;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
 .chord-group h2 {
@@ -2390,6 +2405,17 @@ a/* Landing page styles */
   font-size: 16px;
   margin-bottom: 8px;
 }
+
+/* カード型の各セクション */
+.white-key-section,
+.black-key-section,
+.inversion-section,
+.other-training {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  padding: 16px;
+}
 .setup-wrapper {
   max-width: 400px;
   margin: 100px auto;
@@ -2406,6 +2432,11 @@ a/* Landing page styles */
   font-size: 1.6rem;
   margin-bottom: 1rem;
   color: #333;
+}
+
+/* 温かみのある背景 */
+.settings-screen {
+  background: linear-gradient(135deg, #fff5e3, #ffe8ec);
 }
 
 .setup-wrapper input,


### PR DESCRIPTION
## Summary
- use board wrapper for settings screen and add heading
- show main sections as cards lined up in the center
- apply friendly warm gradient background
- consolidate styles in aggregated CSS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852cc1a6ae4832393cf7852dd33528c