### PR TITLE
Fix bullet indent on info pages

### DIFF
--- a/css/info.css
+++ b/css/info.css
@@ -27,6 +27,12 @@
   text-align: center;
 }
 
+/* Ensure bullet lists aren't flush against the edge on wide screens */
+.info-page.full-page ul {
+  text-align: left;
+  padding-left: 1.4em;
+}
+
 @media (min-width: 768px) {
   .info-page {
     max-width: none;

--- a/style.css
+++ b/style.css
@@ -875,6 +875,12 @@ button:hover {
   text-align: center;
 }
 
+/* Ensure bullet lists aren't flush against the edge on wide screens */
+.info-page.full-page ul {
+  text-align: left;
+  padding-left: 1.4em;
+}
+
 @media (min-width: 768px) {
   .info-page {
     max-width: none;


### PR DESCRIPTION
## Summary
- style full-width info pages so bullet lists have proper indentation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6852cd13c6a88323ab789047a45f13a1