### PR TITLE
Fix settings layout issues

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -169,16 +169,9 @@ buttonGroup.appendChild(resetBtn);
   singleSelectWrap.appendChild(singleSelect);
   container.appendChild(singleSelectWrap);
 
-  const board = document.createElement("div");
-  board.className = "board";
-  const boardTitle = document.createElement("h2");
-  boardTitle.textContent = "出題設定ボード";
-  board.appendChild(boardTitle);
-
   const mainSection = document.createElement("div");
   mainSection.className = "main-section";
-  board.appendChild(mainSection);
-
+  
   const trainingMode = sessionStorage.getItem("trainingMode");
   const stored = (trainingMode === "custom")
     ? sessionStorage.getItem("selectedChords")
@@ -336,7 +329,7 @@ buttonGroup.appendChild(resetBtn);
   `;
 
   mainSection.appendChild(section);
-  container.appendChild(board);
+  container.appendChild(mainSection);
   app.appendChild(container);
 
   document.getElementById("btn-easy").onclick = () => switchScreen("training_easy");

--- a/style.css
+++ b/style.css
@@ -2131,7 +2131,7 @@ a/* Landing page styles */
 
 .chord-group {
   margin-bottom: 1.5em;
-  flex: 1 1 260px;
+  flex: 1 1 200px;
   border-radius: 12px;
   background: #fff;
   padding: 0.5em;
@@ -2410,6 +2410,7 @@ a/* Landing page styles */
   font-weight: bold;
   font-size: 16px;
   margin-bottom: 8px;
+  white-space: nowrap;
 }
 
 /* カード型の各セクション */


### PR DESCRIPTION
## Summary
- drop unused board container from settings screen
- tweak flex basis for chord group sections
- keep "その他のトレーニング" heading on one line

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852cf4e4efc8323b9435b8aaf2bf31a