### PR TITLE
Fix analysis screen scrollbar style

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -38,13 +38,15 @@
 #app.with-header,
 body.with-header {
   padding-top: 56px;
+  overflow-x: hidden;
 }
 
 /* .screen の基本レイアウト */
 .screen {
-  max-width: 900px;
+  max-width: 960px;
   margin: 0 auto; /* 上部余白は #app.with-header に委任 */
-  padding: 1em;
+  padding: 16px;
+  width: 100%;
   box-sizing: border-box;
 }
 

--- a/css/summary.css
+++ b/css/summary.css
@@ -6,6 +6,7 @@
   margin: 0 auto;
   font-family: inherit;
   background: #fffaf5;
+  width: 100%;
 }
 
 @media (min-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -38,13 +38,15 @@
 #app.with-header,
 body.with-header {
   padding-top: 56px;
+  overflow-x: hidden;
 }
 
 /* .screen の基本レイアウト */
 .screen {
-  max-width: 900px;
+  max-width: 960px;
   margin: 0 auto; /* 上部余白は #app.with-header に委任 */
-  padding: 1em;
+  padding: 16px;
+  width: 100%;
   box-sizing: border-box;
 }
 
@@ -2581,6 +2583,7 @@ a/* Landing page styles */
   margin: 0 auto;
   font-family: inherit;
   background: #fffaf5;
+  width: 100%;
 }
 
 #calendar,


### PR DESCRIPTION
## Summary
- update base CSS to keep pages centered without extra horizontal scroll
- ensure analysis page scrolls with body rather than within the centered screen

## Testing
- `npm run reset-expired-premiums` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6852cf80c9a483238a40e47bcc67123d