### PR TITLE
Fix settings screen layout

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -311,12 +311,13 @@
 /* カード型の各セクション */
 .white-key-section,
 .black-key-section,
-.inversion-section,
-.other-training {
+.inversion-section {
   background: #fff;
   border-radius: 12px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
   padding: 16px;
+  flex: 1 1 280px;
+  box-sizing: border-box;
 }
 
 .shadow-button {
@@ -334,4 +335,5 @@
 /* 温かみのある背景 */
 .settings-screen {
   background: linear-gradient(135deg, #fff5e3, #ffe8ec);
+  min-height: 100vh;
 }

--- a/style.css
+++ b/style.css
@@ -2438,6 +2438,7 @@ a/* Landing page styles */
 /* 温かみのある背景 */
 .settings-screen {
   background: linear-gradient(135deg, #fff5e3, #ffe8ec);
+  min-height: 100vh;
 }
 
 .setup-wrapper input,


### PR DESCRIPTION
## Summary
- allow settings cards to flex and fit smaller screens
- ensure gradient background covers full height

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_6852d40a35d48323beb00e99186b86b2