### PR TITLE
Fix table columns on result screen

### DIFF
--- a/style.css
+++ b/style.css
@@ -1905,14 +1905,18 @@ a/* Landing page styles */
 /* 列幅調整：1列目だけ小さく */
 .result-table th:nth-child(1),
 .result-table td:nth-child(1) {
-  width: 40px;
+  width: 70px;
 }
 
 .result-table th:nth-child(2),
 .result-table td:nth-child(2),
 .result-table th:nth-child(3),
-.result-table td:nth-child(3) {
-  width: 60px;
+.result-table td:nth-child(3),
+.result-table th:nth-child(4),
+.result-table td:nth-child(4),
+.result-table th:nth-child(5),
+.result-table td:nth-child(5) {
+  width: 80px;
 }
 
 /* セルの余白を最小限に */


### PR DESCRIPTION
## Summary
- keep table columns wide enough to show Japanese text without ellipsis
- align widths for all columns

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852d4a853308323b3e3ebb4e8bfef3c