### PR TITLE
Fix info page bullet list alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -872,7 +872,10 @@ button:hover {
 /* Ensure bullet lists aren't flush against the edge on wide screens */
 .info-page.full-page ul {
   text-align: left;
-  padding-left: 1.4em;
+  max-width: 800px;
+  margin: 0 auto 1em;
+  padding-left: 1.6em;
+  font-size: 1rem;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- improve bullet list layout on info pages by centering the list container

## Testing
- `npm run reset-expired-premiums` *(fails: no such script)*

------
https://chatgpt.com/codex/tasks/task_b_6852d5f6ee08832386445f1282dd8088