### PR TITLE
Fix responsive layout for inversion-section

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -337,3 +337,20 @@
   background: linear-gradient(135deg, #fff5e3, #ffe8ec);
   min-height: 100vh;
 }
+
+/* スマホ向けレイアウト調整 */
+@media (max-width: 768px) {
+  .main-section {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .white-key-section,
+  .black-key-section,
+  .inversion-section,
+  .other-training {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -2445,6 +2445,22 @@ a/* Landing page styles */
   min-height: 100vh;
 }
 
+@media (max-width: 768px) {
+  .main-section {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .white-key-section,
+  .black-key-section,
+  .inversion-section,
+  .other-training {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+}
+
 .setup-wrapper input,
 .setup-wrapper select {
   width: 100%;


### PR DESCRIPTION
## Summary
- ensure inversion-section aligns with other sections on mobile
- apply responsive styling for settings screen sections

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6852db5638ec8323aa8782ab02ad728a