### PR TITLE
Fix result table overflow on mobile

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -148,7 +148,9 @@ export async function renderResultScreen(user) {
     <div class="tab-contents">
       <div id="result" class="tab-content active">
         <div class="result-container">
-          ${tableHtml}
+          <div class="result-scroll-wrap">
+            ${tableHtml}
+          </div>
           <div class="result-footer"></div>
         </div>
       </div>

--- a/css/result.css
+++ b/css/result.css
@@ -5,6 +5,12 @@
   background-color: #fffaf5;
 }
 
+/* テーブル横スクロール用ラッパー */
+.result-scroll-wrap {
+  overflow-x: auto;
+  width: 100%;
+}
+
 /* メッセージ強調 */
 .praise {
   font-size: 1.8em;
@@ -35,6 +41,7 @@
   margin: 2em auto;
   border-collapse: collapse;
   width: 100%;
+  min-width: 600px;
   font-size: 0.85em;
   table-layout: fixed;
 }

--- a/style.css
+++ b/style.css
@@ -1871,6 +1871,12 @@ a/* Landing page styles */
   background-color: #fffaf5;
 }
 
+/* テーブル横スクロール用ラッパー */
+.result-scroll-wrap {
+  overflow-x: auto;
+  width: 100%;
+}
+
 /* メッセージ強調 */
 .praise {
   font-size: 1.8em;
@@ -1901,6 +1907,7 @@ a/* Landing page styles */
   margin: 2em auto;
   border-collapse: collapse;
   width: 100%;
+  min-width: 600px;
   font-size: 0.85em;
   table-layout: fixed;
 }


### PR DESCRIPTION
## Summary
- wrap result tables in a scroll container for small screens
- set minimum width on result tables

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852dccfedc083238ae763ee85bc6b1e