### PR TITLE
Fix growth day count after unlock

### DIFF
--- a/utils/growthStore_supabase.js
+++ b/utils/growthStore_supabase.js
@@ -87,14 +87,6 @@ export async function generateMockGrowthData(userId, days = 7) {
     .eq("user_id", userId)
     .not("status", "eq", "locked");
 
-  const sampleMistakes = [
-    { question: "C-E-G", answer: "E-G-C" },
-    { question: "A-C#-E", answer: "C#-E-A" },
-    { question: "D-F#-A", answer: "F#-A-D" },
-    { question: "E-G#-B", answer: "G#-B-E" },
-    { question: "F-A-C", answer: "A-C-F" }
-  ];
-
   const flags = await loadGrowthFlags(userId);
   let queue = generateRecommendedQueue(flags);
   if (queue.length === 0) queue = ["C-E-G"];
@@ -131,10 +123,10 @@ export async function generateMockGrowthData(userId, days = 7) {
       let correctFlag = true;
 
       if (q < mistakeNum) {
-        const m = sampleMistakes[(i + q) % sampleMistakes.length];
-        answerName = m.answer;
+        const wrongIdx = (q + 1) % queue.length;
+        answerName = queue[wrongIdx];
         correctFlag = false;
-        inversionMistakes.push({ ...m, count: 1 });
+        inversionMistakes.push({ question: chordName, answer: answerName, count: 1 });
       }
 
       results.push({ chordName, answerName, correct: correctFlag });

--- a/utils/qualifiedStore_supabase.js
+++ b/utils/qualifiedStore_supabase.js
@@ -153,6 +153,11 @@ export async function getConsecutiveQualifiedDays(userId, days = REQUIRED_DAYS) 
   const qualifiedSet = new Set(qualified.map(d => d.qualified_date));
 
   function isValidPassingDay(dateStr) {
+    // if any chord was unlocked on this exact day, treat it as not qualified
+    if (progress.some(p => p.status !== "locked" && p.unlocked_date === dateStr)) {
+      return false;
+    }
+
     const unlockedOnDate = progress
       .filter(
         p =>
@@ -160,6 +165,7 @@ export async function getConsecutiveQualifiedDays(userId, days = REQUIRED_DAYS) 
           (!p.unlocked_date || p.unlocked_date <= dateStr)
       )
       .map(p => p.chord_key);
+
     if (unlockedOnDate.length !== currentUnlocked.length) return false;
     return unlockedOnDate.every(ch => currentSet.has(ch));
   }


### PR DESCRIPTION
## Summary
- ensure days with chord unlocks don't count toward consecutive passes
- generate mock data using recommended chords with one wrong answer

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852fccff53c83238a294c02b24f79a5