### PR TITLE
Hide inversion card on mobile screens

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -354,3 +354,9 @@
     box-sizing: border-box;
   }
 }
+
+@media (max-width: 600px) {
+  .inversion-section {
+    display: none;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -2471,6 +2471,12 @@ a/* Landing page styles */
   }
 }
 
+@media (max-width: 600px) {
+  .inversion-section {
+    display: none;
+  }
+}
+
 .setup-wrapper input,
 .setup-wrapper select {
   width: 100%;


### PR DESCRIPTION
## Summary
- hide the inversion section when the screen width is small

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852fe8ac4fc8323997b3fe6b93b786b