### PR TITLE
Fix mobile layout for result table

### DIFF
--- a/css/result.css
+++ b/css/result.css
@@ -3,6 +3,7 @@
   text-align: center;
   padding: 2em;
   background-color: #fffaf5;
+  box-sizing: border-box;
 }
 
 /* テーブル横スクロール用ラッパー */
@@ -234,4 +235,10 @@
 
 .summary-table th {
   background-color: #f4f4f4;
+}
+
+@media (max-width: 600px) {
+  .result-container {
+    padding: 1em;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -1869,6 +1869,7 @@ a/* Landing page styles */
   text-align: center;
   padding: 2em;
   background-color: #fffaf5;
+  box-sizing: border-box;
 }
 
 /* テーブル横スクロール用ラッパー */
@@ -2104,6 +2105,12 @@ a/* Landing page styles */
 
 .summary-table th {
   background-color: #f4f4f4;
+}
+
+@media (max-width: 600px) {
+  .result-container {
+    padding: 1em;
+  }
 }
 /* ===== settings.css ===== */
 


### PR DESCRIPTION
## Summary
- prevent `.result-container` from overflowing
- reduce padding on small screens for better mobile view

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6852fefeab0c8323a417f228ae4f6c49