### PR TITLE
Fix inversion section visibility on mobile

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -355,8 +355,3 @@
   }
 }
 
-@media (max-width: 600px) {
-  .inversion-section {
-    display: none;
-  }
-}

--- a/style.css
+++ b/style.css
@@ -2478,11 +2478,6 @@ a/* Landing page styles */
   }
 }
 
-@media (max-width: 600px) {
-  .inversion-section {
-    display: none;
-  }
-}
 
 .setup-wrapper input,
 .setup-wrapper select {


### PR DESCRIPTION
## Summary
- show inversion chord settings on small screens by removing hidden CSS rule

## Testing
- `npm test` *(fails: missing script)*
- `npm run reset-expired-premiums` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_b_685411dba0008323af7b1924a83947ca