### PR TITLE
Update growth info display

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -46,11 +46,12 @@ export async function renderGrowthScreen(user) {
 
   const info = document.createElement("p");
   info.className = "today-info";
-  const targetLabel = target ? `${target.label}の和音に挑戦中` : "";
+  const targetLabel = target ? `いま ${target.label}の和音に挑戦中` : "";
   info.innerHTML = `
     今日の日付: <strong>${today}</strong><br/>
-    ${targetLabel}<br/>
-    連続合格日数: ${qualifiedDays}/7日
+    連続合格日数: ${qualifiedDays}/7日<br/>
+    <br/>
+    ${targetLabel}
   `;
   container.appendChild(info);
 

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -128,7 +128,7 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
     btn.onpointerleave = cancelProgress;
   } else {
     const label = target ? target.label : "";
-    msg.textContent = `いま ${label} の解放条件を満たしていません\n連続合格日数: ${consecutive} 日`;
+    msg.textContent = `いま ${label}の和音に挑戦中`;
     msg.classList.remove("can-unlock");
     card.classList.remove("highlight");
     btn.style.display = "none";


### PR DESCRIPTION
## Summary
- reorder info lines in growth screen
- simplify growth status message when unlock conditions not met

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68541bad7d8083239d739f6a371915ac