### PR TITLE
Adjust summary table sizing on mobile

### DIFF
--- a/css/summary.css
+++ b/css/summary.css
@@ -125,3 +125,12 @@ button#dummy-button {
   max-height: none;
   opacity: 1;
 }
+
+@media (max-width: 600px) {
+  /* shrink answer tables on small screens */
+  .summary-screen .result-table {
+    transform: scale(0.8);
+    transform-origin: left top;
+    width: 125%;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -2129,6 +2129,12 @@ a/* Landing page styles */
   .result-table td:nth-child(5) {
     width: 60px;
   }
+  /* shrink answer tables on small screens */
+  .summary-screen .result-table {
+    transform: scale(0.8);
+    transform-origin: left top;
+    width: 125%;
+  }
 }
 /* ===== settings.css ===== */
 


### PR DESCRIPTION
## Summary
- tweak CSS for analysis summary table to scale down on small screens
- apply same rule in `css/summary.css`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68541ab8d594832390835202e304bbdb