### PR TITLE
Improve growth mode info display

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -210,9 +210,18 @@
 
 /* 今日の情報 */
 .today-info {
+  margin: 0 auto 1em;
+  padding: 0.75em;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   text-align: center;
-  font-size: 1.1em;
-  margin-bottom: 1em;
+  font-size: 1.05em;
+  max-width: 320px;
+}
+
+.today-info div {
+  margin: 0.25em 0;
 }
 
 /* ステータスバーとメッセージ */

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -44,14 +44,11 @@ export async function renderGrowthScreen(user) {
   title.textContent = "🎯 育成モード";
   container.appendChild(title);
 
-  const info = document.createElement("p");
+  const info = document.createElement("div");
   info.className = "today-info";
-  const targetLabel = target ? `いま ${target.label}の和音に挑戦中` : "";
   info.innerHTML = `
-    今日の日付: <strong>${today}</strong><br/>
-    連続合格日数: ${qualifiedDays}/7日<br/>
-    <br/>
-    ${targetLabel}
+    <div>今日の日付: <strong>${today}</strong></div>
+    <div>連続合格日数: ${qualifiedDays}/7日</div>
   `;
   container.appendChild(info);
 

--- a/style.css
+++ b/style.css
@@ -342,9 +342,18 @@ button:hover {
 
 /* 今日の情報 */
 .today-info {
+  margin: 0 auto 1em;
+  padding: 0.75em;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   text-align: center;
-  font-size: 1.1em;
-  margin-bottom: 1em;
+  font-size: 1.05em;
+  max-width: 320px;
+}
+
+.today-info div {
+  margin: 0.25em 0;
 }
 
 /* ステータスバーとメッセージ */


### PR DESCRIPTION
## Summary
- show today's info in a card
- remove duplicate line from growth status

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685424be21c08323bdf44975916fc626