### PR TITLE
Apply gradient background to more screens

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -1,3 +1,9 @@
+/* 育成画面全体の背景 */
+.growth-screen {
+  background: linear-gradient(135deg, #fff1e6, #ffe6f2);
+  min-height: 100vh;
+}
+
 /* ✅ 和音サークル共通 */
 .growth-chord-circle {
   width: 36px;

--- a/css/mypage.css
+++ b/css/mypage.css
@@ -1,6 +1,8 @@
 .mypage-screen {
   max-width: 480px;
   margin: 0 auto; /* 上部余白は #app.with-header に委任 */
+  background: linear-gradient(135deg, #fff1e6, #ffe6f2);
+  min-height: 100vh;
 }
 
 .mypage-tabs {

--- a/css/pricing.css
+++ b/css/pricing.css
@@ -5,6 +5,8 @@
   display: flex;
   flex-direction: column;
   gap: 1em;
+  background: linear-gradient(135deg, #fff1e6, #ffe6f2);
+  min-height: 100vh;
 }
 
 @media (min-width: 768px) {

--- a/css/summary.css
+++ b/css/summary.css
@@ -5,7 +5,8 @@
   max-width: 960px;
   margin: 0 auto;
   font-family: inherit;
-  background: #fffaf5;
+  background: linear-gradient(135deg, #fff1e6, #ffe6f2);
+  min-height: 100vh;
   width: 100%;
 }
 

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -31,7 +31,7 @@ export async function renderGrowthScreen(user) {
   renderHeader(app, user);
 
   const container = document.createElement("div");
-  container.className = "screen active";
+  container.className = "screen active growth-screen";
 
   const today = getToday();
   const passed = await getPassedDays(user.id);

--- a/style.css
+++ b/style.css
@@ -1616,6 +1616,8 @@ a/* Landing page styles */
 .mypage-screen {
   max-width: 480px;
   margin: 0 auto; /* 上部余白は #app.with-header に委任 */
+  background: linear-gradient(135deg, #fff1e6, #ffe6f2);
+  min-height: 100vh;
 }
 
 .mypage-tabs {
@@ -1748,6 +1750,8 @@ a/* Landing page styles */
   display: flex;
   flex-direction: column;
   gap: 1em;
+  background: linear-gradient(135deg, #fff1e6, #ffe6f2);
+  min-height: 100vh;
 }
 
 @media (min-width: 768px) {
@@ -2495,6 +2499,11 @@ a/* Landing page styles */
   min-height: 100vh;
 }
 
+.growth-screen {
+  background: linear-gradient(135deg, #fff1e6, #ffe6f2);
+  min-height: 100vh;
+}
+
 @media (max-width: 768px) {
   .main-section {
     flex-direction: column;
@@ -2646,14 +2655,15 @@ a/* Landing page styles */
 
 /* summary.css */
 
-.summary-screen {
-  padding: 1em;
-  max-width: 960px;
-  margin: 0 auto;
-  font-family: inherit;
-  background: #fffaf5;
-  width: 100%;
-}
+  .summary-screen {
+    padding: 1em;
+    max-width: 960px;
+    margin: 0 auto;
+    font-family: inherit;
+    background: linear-gradient(135deg, #fff1e6, #ffe6f2);
+    min-height: 100vh;
+    width: 100%;
+  }
 
 #calendar,
 #from-date,


### PR DESCRIPTION
## Summary
- use `growth-screen` class in growth mode
- apply same gradient to growth, summary, pricing and mypage screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6854b03a4d7c83238e97211abc4a3bb5