### PR TITLE
Switch contact info to web form

### DIFF
--- a/components/info/law.js
+++ b/components/info/law.js
@@ -1,4 +1,5 @@
 import { renderHeader } from "../header.js";
+import { switchScreen } from "../../main.js";
 
 export function renderLawScreen(user) {
   const app = document.getElementById("app");
@@ -13,9 +14,11 @@ export function renderLawScreen(user) {
     <p>個人運営（氏名・住所は取引時に請求があれば開示いたします）</p>
     <h2>運営責任者</h2>
     <p>オトロン運営者</p>
-    <h2>連絡先</h2>
-    <p>メールアドレス：<strong>otoron.app@example.com</strong><br>
-    お問い合わせはメールにてお願いいたします。</p>
+    <h2>お問い合わせ</h2>
+    <p>ご質問やご要望は、以下のフォームからご連絡ください。<br>
+    通常、2〜3営業日以内にご返信いたします。</p>
+    <p><a href="#" id="contact-link">お問い合わせフォームはこちら</a></p>
+    <p>※セキュリティ保護とスムーズな対応のため、メールアドレスでの直接対応は行っておりません。</p>
     <h2>販売価格</h2>
     <p>有料プランを導入した場合、価格はアプリ内またはWebサイト上の各サービス紹介ページに表示されます。</p>
     <h2>商品以外の必要料金</h2>
@@ -38,5 +41,13 @@ export function renderLawScreen(user) {
     <hr />
     <p>2025年6月 作成</p>
   `;
+
+  const contactLink = main.querySelector("#contact-link");
+  if (contactLink) {
+    contactLink.addEventListener("click", (e) => {
+      e.preventDefault();
+      switchScreen("contact");
+    });
+  }
   app.appendChild(main);
 }

--- a/components/info/privacy.js
+++ b/components/info/privacy.js
@@ -1,4 +1,5 @@
 import { renderHeader } from "../header.js";
+import { switchScreen } from "../../main.js";
 
 export function renderPrivacyScreen(user) {
   const app = document.getElementById("app");
@@ -43,15 +44,31 @@ export function renderPrivacyScreen(user) {
     <h2>第6条（安全管理措置）</h2>
     <p>ユーザーの個人情報は、適切なセキュリティ対策を講じて管理します。万一、漏えい、滅失、毀損が発生した場合には、速やかに通知し、再発防止策を講じます。</p>
     <h2>第7条（利用者の権利）</h2>
-    <p>ユーザーは、自己の個人情報について、開示、訂正、利用停止、削除を求めることができます。お問い合わせは下記連絡先までご連絡ください。</p>
+    <p>ユーザーは、自己の個人情報について、開示、訂正、利用停止、削除を求めることができます。お問い合わせは<a href="#" id="contact-link">お問い合わせフォーム</a>からご連絡ください。</p>
     <h2>第8条（未成年の利用）</h2>
     <p>20歳未満のユーザーは、保護者の同意を得た上で本サービスを利用してください。</p>
     <h2>第9条（問い合わせ窓口）</h2>
-    <p>個人情報に関する問い合わせは、<strong>otoron.app@example.com</strong> までお願いいたします。</p>
+    <p>個人情報に関する問い合わせは、<a href="#" id="contact-link2">お問い合わせフォームはこちら</a>からお願いいたします。<br>
+    ※セキュリティ保護とスムーズな対応のため、メールアドレスでの直接対応は行っておりません。</p>
     <h2>第10条（プライバシーポリシーの変更）</h2>
     <p>本ポリシーは、法令の改正などに応じて必要に応じて改定されます。重要な変更がある場合には、本サービス内またはWebサイト上でお知らせいたします。</p>
     <hr />
     <p>2025年6月 作成</p>
   `;
+
+  const link1 = main.querySelector("#contact-link");
+  if (link1) {
+    link1.addEventListener("click", (e) => {
+      e.preventDefault();
+      switchScreen("contact");
+    });
+  }
+  const link2 = main.querySelector("#contact-link2");
+  if (link2) {
+    link2.addEventListener("click", (e) => {
+      e.preventDefault();
+      switchScreen("contact");
+    });
+  }
   app.appendChild(main);
 }


### PR DESCRIPTION
## Summary
- update special commercial law and privacy pages to use a contact form
- remove email address and add links that open the form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68551fdc77988323aa3145c970e96804