### PR TITLE
Fix gradient coverage on summary and growth screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -3068,6 +3068,7 @@ button.disabled {
 /* PC表示では分析画面・マイページ・プランページを横幅いっぱいに */
 @media (min-width: 768px) {
   .summary-screen,
+  .growth-screen,
   .mypage-screen,
   .pricing-page,
   .plan-info-screen {
@@ -3075,8 +3076,11 @@ button.disabled {
     margin: 0;
   }
 
-  /* Allow the analysis page to use the full page height */
-  .summary-screen {
+  /* Allow analysis/growth pages to use the full page height */
+  .summary-screen,
+  .growth-screen {
+    padding: 0;
+    min-height: calc(100vh - 56px);
     height: auto;
     overflow-y: visible;
   }


### PR DESCRIPTION
## Summary
- adjust media query to include `growth-screen` with zero padding
- ensure analysis and growth screens use full viewport height on desktop

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68552446e98883239bf983a4ce30a227