### PR TITLE
Fix vertical plan buttons on desktop

### DIFF
--- a/css/mypage.css
+++ b/css/mypage.css
@@ -62,6 +62,15 @@
 .plan-buttons button {
   padding: 0.8em;
 }
+
+@media (min-width: 768px) {
+  .plan-buttons {
+    flex-direction: row;
+  }
+  .plan-buttons button {
+    flex: 1;
+  }
+}
 .profile-form,
 .password-form {
   max-width: 360px;

--- a/style.css
+++ b/style.css
@@ -1689,6 +1689,15 @@ a/* Landing page styles */
 .plan-buttons button {
   padding: 0.8em;
 }
+
+@media (min-width: 768px) {
+  .plan-buttons {
+    flex-direction: row;
+  }
+  .plan-buttons button {
+    flex: 1;
+  }
+}
 .profile-form,
 .password-form {
   max-width: 360px;


### PR DESCRIPTION
## Summary
- ensure plan buttons lay out horizontally on wider screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6855248405708323997bf03e6efd520c