### PR TITLE
Fix pricing layout on desktop

### DIFF
--- a/css/pricing.css
+++ b/css/pricing.css
@@ -13,13 +13,14 @@
   .pricing-page {
     flex-direction: row;
     justify-content: center;
-    flex-wrap: wrap;
-    max-width: 800px;
+    flex-wrap: nowrap;
+    gap: 1em;
+    max-width: none;
   }
 
   .pricing-page .plan-card {
-    flex: 1;
-    max-width: 240px;
+    flex: none;
+    width: 240px;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1779,12 +1779,13 @@ a/* Landing page styles */
   .pricing-page {
     flex-direction: row;
     justify-content: center;
-    flex-wrap: wrap;
-    max-width: 800px;
+    flex-wrap: nowrap;
+    gap: 1em;
+    max-width: none;
   }
   .pricing-page .plan-card {
-    flex: 1;
-    max-width: 240px;
+    flex: none;
+    width: 240px;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep 3 pricing cards in a single row when screen is wide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6855270c429883238fc6194dea5e4150