### PR TITLE
Fix gradient gap on growth screen

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,12 @@
   overflow-y: auto; /* ← モバイルでスクロールできるように */
 }
 
+body,
+#app {
+  margin: 0;
+  padding: 0;
+}
+
 .app-root.morning {
   background: #fff8f0;
 }
@@ -2523,6 +2529,13 @@ a/* Landing page styles */
 
 .growth-screen {
   background: linear-gradient(135deg, #fff1e6, #ffe6f2);
+  min-height: 100vh;
+}
+
+/* Ensure the gradient covers the very top behind the fixed header */
+.screen.active.growth-screen {
+  margin-top: -56px; /* pull background up under the header */
+  padding-top: calc(56px + 16px); /* retain default .screen padding below header */
   min-height: 100vh;
 }
 


### PR DESCRIPTION
## Summary
- ensure body and root container have no default margin/padding
- extend growth screen background under the fixed header so the gradient reaches the page top

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68552896f5188323bc2a20dad8a78714