### PR TITLE
Fix growth mode chord layout on desktop

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -212,10 +212,7 @@ export async function renderGrowthScreen(user) {
 
   // 和音進捗表示
   const chordStatus = document.createElement("div");
-  chordStatus.style.display = "grid";
-  chordStatus.style.gridTemplateColumns = "repeat(auto-fit, minmax(90px, 1fr))";
-  chordStatus.style.gap = "10px";
-  chordStatus.style.marginTop = "1.5em";
+  chordStatus.className = "chord-status-grid";
 
   for (const chord of chords) {
     const item = document.createElement("div");

--- a/style.css
+++ b/style.css
@@ -409,6 +409,22 @@ button:hover {
   padding: 2px 6px;
   border-radius: 6px;
 }
+
+/* 和音進捗表示のグリッド */
+.chord-status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: 10px;
+  margin: 1.5em auto 0;
+  justify-items: center;
+}
+
+@media (min-width: 768px) {
+  .chord-status-grid {
+    grid-template-columns: repeat(2, 1fr);
+    max-width: 200px;
+  }
+}
 .app-header {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- show chord progress grid via class instead of inline styles
- style chord progress grid as two columns on desktop to prevent extra spacing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68552acaf2a48323acd5239579bdb62e