### PR TITLE
Update growth mode layout and styling

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -269,11 +269,14 @@
   font-weight: bold;
 }
 
+#growth-message.current-target {
+  font-size: 1.1em;
+  font-weight: bold;
+}
+
 /* 現在挑戦中の和音表示を強調 */
 .current-target .chord {
   font-weight: bold;
-  background: #333;
-  color: white;
   padding: 2px 6px;
   border-radius: 6px;
 }

--- a/style.css
+++ b/style.css
@@ -401,11 +401,14 @@ button:hover {
   font-weight: bold;
 }
 
+#growth-message.current-target {
+  font-size: 1.1em;
+  font-weight: bold;
+}
+
 /* 現在挑戦中の和音表示を強調 */
 .current-target .chord {
   font-weight: bold;
-  background: #333;
-  color: white;
   padding: 2px 6px;
   border-radius: 6px;
 }
@@ -413,17 +416,12 @@ button:hover {
 /* 和音進捗表示のグリッド */
 .chord-status-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
-  gap: 10px;
-  margin: 1.5em auto 0;
-  justify-items: center;
-}
-
-@media (min-width: 768px) {
-  .chord-status-grid {
-    grid-template-columns: repeat(2, 1fr);
-    max-width: 200px;
-  }
+  grid-template-columns: repeat(12, 72px);
+  gap: 8px;
+  margin: 1.5em auto;
+  justify-content: center;
+  width: max-content;
+  overflow-x: auto;
 }
 .app-header {
   position: fixed;

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -131,7 +131,8 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
     btn.onpointerleave = cancelProgress;
   } else {
     const label = target ? target.label : "";
-    msg.innerHTML = `いま <span class="chord">${label}</span> の和音に挑戦中`;
+    const colorClass = target ? target.colorClass : "";
+    msg.innerHTML = `いま <span class="chord ${colorClass}">${label}</span> の和音に挑戦中`;
     msg.classList.remove("can-unlock");
     msg.classList.add("current-target");
     card.classList.remove("highlight");


### PR DESCRIPTION
## Summary
- show growth chord buttons in a 12-column grid
- color-code the current target chord in the status message
- enlarge the current target message to stand out

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68552e960b14832385d5c92c25cc196d