### PR TITLE
Fix gradient on result screen

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -137,7 +137,7 @@ export async function renderResultScreen(user) {
   renderHeader(app, user);
 
   const container = document.createElement("div");
-  container.className = "screen active";
+  container.className = "screen active result-screen";
   const tableHtml = createResultTable(results);
 
   container.innerHTML = `

--- a/css/result.css
+++ b/css/result.css
@@ -1,3 +1,15 @@
+.result-screen {
+  background: linear-gradient(135deg, #fff1e6, #ffe6f2);
+  min-height: 100vh;
+}
+
+@media (min-width: 768px) {
+  .result-screen {
+    max-width: none;
+    margin: 0;
+  }
+}
+
 /* 結果画面全体のレイアウト */
 .result-container {
   text-align: center;

--- a/style.css
+++ b/style.css
@@ -60,6 +60,7 @@ body.with-header {
 @media (min-width: 768px) {
   .settings-screen,
   .summary-screen,
+  .result-screen,
   .mypage-screen {
     max-width: none;
     margin: 0;
@@ -2552,6 +2553,11 @@ a/* Landing page styles */
   min-height: 100vh;
 }
 
+.result-screen {
+  background: linear-gradient(135deg, #fff1e6, #ffe6f2);
+  min-height: 100vh;
+}
+
 /* Ensure the gradient covers the very top behind the fixed header */
 .screen.active.growth-screen {
   margin-top: -56px; /* pull background up under the header */
@@ -3112,6 +3118,7 @@ button.disabled {
 @media (min-width: 768px) {
   .summary-screen,
   .growth-screen,
+  .result-screen,
   .mypage-screen,
   .pricing-page,
   .plan-info-screen {


### PR DESCRIPTION
## Summary
- apply `result-screen` class to result page container
- add matching CSS so the result tab uses a full-width background gradient

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68552fd5c368832381f318184290974b