### PR TITLE
Fix growth screen button layout

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -281,6 +281,20 @@
   border-radius: 6px;
 }
 
+/* 和音進捗表示のグリッド */
+.chord-status-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  padding: 0 16px;
+  box-sizing: border-box;
+}
+
+.chord-status-grid > div {
+  margin: 4px;
+}
+
 /* === confetti effect for unlock === */
 .confetti-container {
   position: fixed;

--- a/style.css
+++ b/style.css
@@ -423,12 +423,16 @@ button:hover {
 .chord-status-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 10px;
   margin: 1.5em auto;
   justify-content: center;
   padding: 0 16px;
   box-sizing: border-box;
   max-width: 100%;
+}
+
+.chord-status-grid > div {
+  margin: 4px;
 }
 .app-header {
   position: fixed;


### PR DESCRIPTION
## Summary
- wrap growth mode chord buttons to multiple lines
- add spacing between buttons so they aren't cramped

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6855515375088323852855ee5c74285d