### PR TITLE
Arrange growth chords rows on desktop

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -295,6 +295,18 @@
   margin: 4px;
 }
 
+.chord-row-break {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .chord-row-break {
+    display: block;
+    flex-basis: 100%;
+    height: 0;
+  }
+}
+
 /* === confetti effect for unlock === */
 .confetti-container {
   position: fixed;

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -214,7 +214,7 @@ export async function renderGrowthScreen(user) {
   const chordStatus = document.createElement("div");
   chordStatus.className = "chord-status-grid";
 
-  for (const chord of chords) {
+  chords.forEach((chord, index) => {
     const item = document.createElement("div");
     item.style.textAlign = "center";
 
@@ -246,9 +246,14 @@ export async function renderGrowthScreen(user) {
 
     item.appendChild(circle);
 
-
     chordStatus.appendChild(item);
-  }
+
+    if (index === 8 || index === 13) {
+      const br = document.createElement("div");
+      br.className = "chord-row-break";
+      chordStatus.appendChild(br);
+    }
+  });
 
   container.appendChild(chordStatus);
 

--- a/style.css
+++ b/style.css
@@ -434,6 +434,19 @@ button:hover {
 .chord-status-grid > div {
   margin: 4px;
 }
+
+/* line break elements for desktop layout */
+.chord-row-break {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .chord-row-break {
+    display: block;
+    flex-basis: 100%;
+    height: 0;
+  }
+}
 .app-header {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- add row break support for growth mode chord grid
- show line breaks after the ninth and fourteenth chords
- style chord row breaks only for desktop view
- fix CSS so break elements are displayed on desktop

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685565f48bf0832399c3a95c6cdc26d3