### PR TITLE
Fix growth mode chord arrangement

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -301,6 +301,7 @@
 
 @media (min-width: 768px) {
   .chord-row-break {
+    display: block;
     flex-basis: 100%;
     height: 0;
   }

--- a/style.css
+++ b/style.css
@@ -442,6 +442,7 @@ button:hover {
 
 @media (min-width: 768px) {
   .chord-row-break {
+    display: block;
     flex-basis: 100%;
     height: 0;
   }


### PR DESCRIPTION
## Summary
- ensure `.chord-row-break` is visible at desktop sizes

## Testing
- `grep -n "display" css/growth.css | tail`

------
https://chatgpt.com/codex/tasks/task_b_68556a05bbc08323b0563f3874fcad53