### PR TITLE
Remove unused dummy password from login.js

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -13,8 +13,6 @@ import { ensureSupabaseAuth } from "../utils/supabaseAuthHelper.js";
 import { chords } from "../data/chords.js";
 import { showCustomAlert } from "./home.js";
 
-const DUMMY_PASSWORD = "secure_dummy_password";
-
 export function renderLoginScreen(container, onLoginSuccess) {
   container.innerHTML = `
     <div class="login-wrapper">


### PR DESCRIPTION
## Summary
- delete the `DUMMY_PASSWORD` constant from `components/login.js`

## Testing
- `grep -n "DUMMY_PASSWORD" components/login.js`

------
https://chatgpt.com/codex/tasks/task_b_68556ca1b7d88323861af4eb4f18fbec