### PR TITLE
Refactor note label utilities

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -6,29 +6,9 @@ import { chords } from "../data/chords.js";
 import { drawStaffFromNotes } from "./resultStaff.js";  // 楽譜描画（必要なら）
 import { renderHeader } from "./header.js";
 import { renderSummarySection } from "./summary.js";
+import { kanaToHiragana, noteLabels } from "../utils/noteUtils.js";
 
 let resultShownInThisSession = false;
-
-const noteLabels = {
-  "C": "ど",
-  "D": "れ",
-  "E": "み",
-  "F": "ふぁ",
-  "G": "そ",
-  "A": "ら",
-  "B": "し",
-  "C#": "ちす", "Db": "ちす",
-  "D#": "えす", "Eb": "えす",
-  "F#": "ふぃす", "Gb": "ふぃす",
-  "G#": "じす", "Ab": "じす",
-  "A#": "べー", "Bb": "べー"
-};
-
-function kanaToHiragana(str) {
-  return str.replace(/[ァ-ン]/g, ch =>
-    String.fromCharCode(ch.charCodeAt(0) - 0x60)
-  );
-}
 
 function labelNote(n) {
   const pitch = n ? n.replace(/\d/g, '') : '';

--- a/components/training.js
+++ b/components/training.js
@@ -11,6 +11,7 @@ import { saveTrainingSession } from "../utils/trainingStore_supabase.js";
 import { generateRecommendedQueue } from "../utils/growthUtils.js";
 import { loadGrowthFlags } from "../utils/growthStore_supabase.js";
 import { getAudio } from "../utils/audioCache.js";
+import { kanaToHiragana, noteLabels } from "../utils/noteUtils.js";
 
 let questionCount = 0;
 let currentAnswer = null;
@@ -24,27 +25,6 @@ let singleNoteMode = false;
 let singleNoteStrategy = 'top';
 let chordProgressCount = 0;
 let chordSoundOn = true;
-
-const noteLabels = {
-  "C": "ど",
-  "D": "れ",
-  "E": "み",
-  "F": "ふぁ",
-  "G": "そ",
-  "A": "ら",
-  "B": "し",
-  "C#": "ちす", "Db": "ちす",
-  "D#": "えす", "Eb": "えす",
-  "F#": "ふぃす", "Gb": "ふぃす",
-  "G#": "じす", "Ab": "じす",
-  "A#": "べー", "Bb": "べー"
-};
-
-function kanaToHiragana(str) {
-  return str.replace(/[ァ-ン]/g, ch =>
-    String.fromCharCode(ch.charCodeAt(0) - 0x60)
-  );
-}
 
 export const stats = {};
 export const mistakes = {};

--- a/components/training_easy_note.js
+++ b/components/training_easy_note.js
@@ -4,6 +4,7 @@ import { getRandomNoteSequence } from "./question_easy.js";
 import { playNote } from "./soundPlayer.js";
 import { switchScreen } from "../main.js";
 import { saveTrainingSession } from "../utils/trainingStore_supabase.js";
+import { kanaToHiragana, noteLabels } from "../utils/noteUtils.js";
 
 let currentNote = null;
 let noteSequence = [];
@@ -14,31 +15,6 @@ let questionCount = 0;
 const FEEDBACK_DELAY = 1000;
 const maxQuestions = 24;
 
-const noteLabels = {
-  "C": "ど",
-  "D": "れ",
-  "E": "み",
-  "F": "ふぁ",
-  "G": "そ",
-  "A": "ら",
-  "B": "し",
-  "C#": "ちす",
-  "D#": "えす",
-  "F#": "ふぃす",
-  "G#": "じす",
-  "A#": "べー",
-  "Db": "ちす",
-  "Eb": "えす",
-  "Gb": "ふぃす",
-  "Ab": "じす",
-  "Bb": "べー",
-};
-
-function kanaToHiragana(str) {
-  return str.replace(/[ァ-ン]/g, ch =>
-    String.fromCharCode(ch.charCodeAt(0) - 0x60)
-  );
-}
 
 export async function renderTrainingScreen(user) {
   const app = document.getElementById("app");

--- a/components/training_full.js
+++ b/components/training_full.js
@@ -4,6 +4,7 @@ import { getRandomNote } from "./question_full.js";
 import { playNote } from "./soundPlayer.js";
 import { switchScreen } from "../main.js";
 import { saveTrainingSession } from "../utils/trainingStore_supabase.js";
+import { kanaToHiragana, noteLabels } from "../utils/noteUtils.js";
 
 let currentNote = null;
 let noteHistory = [];
@@ -13,31 +14,6 @@ let questionCount = 0;
 const FEEDBACK_DELAY = 1000;
 const maxQuestions = 5; // ← テスト用（本番時は30に）
 
-const noteLabels = {
-  "C": "ど",
-  "D": "れ",
-  "E": "み",
-  "F": "ふぁ",
-  "G": "そ",
-  "A": "ら",
-  "B": "し",
-  "C#": "ちす",
-  "D#": "えす",
-  "F#": "ふぃす",
-  "G#": "じす",
-  "A#": "べー",
-  "Db": "ちす",
-  "Eb": "えす",
-  "Gb": "ふぃす",
-  "Ab": "じす",
-  "Bb": "べー",
-};
-
-function kanaToHiragana(str) {
-  return str.replace(/[ァ-ン]/g, ch =>
-    String.fromCharCode(ch.charCodeAt(0) - 0x60)
-  );
-}
 
 export async function renderTrainingScreen(user) {
   const app = document.getElementById("app");

--- a/components/training_white_keys.js
+++ b/components/training_white_keys.js
@@ -4,6 +4,7 @@ import { getRandomWhiteNoteSequence } from "./question_white.js";
 import { playNote } from "./soundPlayer.js";
 import { switchScreen } from "../main.js";
 import { saveTrainingSession } from "../utils/trainingStore_supabase.js";
+import { kanaToHiragana, noteLabels } from "../utils/noteUtils.js";
 
 let currentNote = null;
 let noteSequence = [];
@@ -14,21 +15,6 @@ let questionCount = 0;
 const FEEDBACK_DELAY = 1000;
 const maxQuestions = 24;
 
-const noteLabels = {
-  "C": "ど",
-  "D": "れ",
-  "E": "み",
-  "F": "ふぁ",
-  "G": "そ",
-  "A": "ら",
-  "B": "し"
-};
-
-function kanaToHiragana(str) {
-  return str.replace(/[ァ-ン]/g, ch =>
-    String.fromCharCode(ch.charCodeAt(0) - 0x60)
-  );
-}
 
 export async function renderTrainingScreen(user) {
   const app = document.getElementById("app");

--- a/utils/noteUtils.js
+++ b/utils/noteUtils.js
@@ -1,0 +1,20 @@
+export const noteLabels = {
+  "C": "ど",
+  "D": "れ",
+  "E": "み",
+  "F": "ふぁ",
+  "G": "そ",
+  "A": "ら",
+  "B": "し",
+  "C#": "ちす", "Db": "ちす",
+  "D#": "えす", "Eb": "えす",
+  "F#": "ふぃす", "Gb": "ふぃす",
+  "G#": "じす", "Ab": "じす",
+  "A#": "べー", "Bb": "べー"
+};
+
+export function kanaToHiragana(str) {
+  return str.replace(/[ァ-ン]/g, ch =>
+    String.fromCharCode(ch.charCodeAt(0) - 0x60)
+  );
+}


### PR DESCRIPTION
## Summary
- add `noteUtils` with `kanaToHiragana` and `noteLabels`
- reuse these utilities in result and training components

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68556c9ce48c832389c141aacf44f551