### PR TITLE
Simplify webhook logging

### DIFF
--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -41,13 +41,13 @@ export default async function handler(req, res) {
 
   const { type, data } = event;
   const customerId = data?.object?.customer;
-  console.log('Stripe event received:', type, 'customerId:', customerId);
+  console.log(`Stripe event: ${type} (${customerId})`);
 
   if (type === 'checkout.session.completed') {
     const session = data.object;
     const email =
       session.customer_email || session.customer_details?.email || null;
-    console.log('Processing checkout.session.completed', { email, customerId });
+    console.log(`Processing checkout.session.completed for ${email}`);
 
     let query = supabase
       .from('users')
@@ -76,14 +76,14 @@ export default async function handler(req, res) {
     }
 
     const { data: updated, error } = await query.select();
-    console.log('Supabase update result:', { updated, error });
+    console.log('Supabase update result');
 
     if (error) {
       console.error('Supabase update error:', error);
       return res.status(500).send('Supabase update failed');
     }
 
-    console.log(`✅ ${email} is now a premium user with customer ID ${customerId}`);
+    console.log(`${email} premium with customer ID ${customerId}`);
   }
 
   let isPremium;
@@ -102,7 +102,7 @@ export default async function handler(req, res) {
       .update({ is_premium: isPremium })
       .eq('stripe_customer_id', customerId)
       .select();
-    console.log('Supabase subscription update result:', { updatedRows, error });
+    console.log('Supabase subscription update result');
 
     if (error) {
       console.error('Supabase update error:', error);
@@ -110,7 +110,7 @@ export default async function handler(req, res) {
     }
 
     console.log(
-      `Updated user with customer ID ${customerId}: is_premium -> ${isPremium}`
+      `Updated premium status for ${customerId}: ${isPremium}`
     );
   }
 

--- a/pages/api/stripe-webhook.js
+++ b/pages/api/stripe-webhook.js
@@ -41,13 +41,13 @@ export default async function handler(req, res) {
 
   const { type, data } = event;
   const customerId = data?.object?.customer;
-  console.log('Stripe event received:', type, 'customerId:', customerId);
+  console.log(`Stripe event: ${type} (${customerId})`);
 
   if (type === 'checkout.session.completed') {
     const session = data.object;
     const email =
       session.customer_email || session.customer_details?.email || null;
-    console.log('Processing checkout.session.completed', { email, customerId });
+    console.log(`Processing checkout.session.completed for ${email}`);
     let query = supabase
       .from('users')
       .update({
@@ -75,14 +75,14 @@ export default async function handler(req, res) {
     }
 
     const { data: updated, error } = await query.select();
-    console.log('Supabase update result:', { updated, error });
+    console.log('Supabase update result');
     if (error) {
       console.error('Supabase update error:', error);
       return res.status(500).send('Supabase update failed');
     }
 
     console.log(
-      `\u2705 ${email} is now a premium user with customer ID ${customerId}`
+      `${email} premium with customer ID ${customerId}`
     );
   }
 
@@ -103,7 +103,7 @@ export default async function handler(req, res) {
         .update({ is_premium: isPremium })
         .eq('stripe_customer_id', customerId)
         .select();
-      console.log('Supabase subscription update result:', { updatedRows, error });
+      console.log('Supabase subscription update result');
 
     if (error) {
       console.error('Supabase update error:', error);
@@ -111,7 +111,7 @@ export default async function handler(req, res) {
     }
 
     console.log(
-      `Updated user with customer ID ${customerId}: is_premium -> ${isPremium}`
+      `Updated premium status for ${customerId}: ${isPremium}`
     );
   }
 


### PR DESCRIPTION
## Summary
- shorten console logs in webhook handlers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68556ccf78c08323b05ac1e643ec1f27