### PR TITLE
Limit training record fetch by date

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -40,7 +40,10 @@ export async function renderHomeScreen(user, options = {}) {
 
   // ✅ 今日のトレーニング回数
   const today = getToday();
-  const records = await loadTrainingRecords(user?.id);
+  const sinceDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const records = await loadTrainingRecords(user?.id, sinceDate);
   const todayRecord = records[today] || { sets: 0 };
 
   const info = document.createElement("p");

--- a/components/summary.js
+++ b/components/summary.js
@@ -90,7 +90,10 @@ export async function renderSummaryScreen(user) {
 export async function renderSummarySection(container, date, user, options = {}) {
   const { standalone = true } = options;
 
-  const records = await loadTrainingRecords(user.id);
+  const sinceDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const records = await loadTrainingRecords(user.id, sinceDate);
   const sessions = await loadTrainingSessionsForDate(user.id, date);
 
   container.innerHTML = "";

--- a/utils/growthUtils.js
+++ b/utils/growthUtils.js
@@ -144,7 +144,10 @@ export async function getSortedRecordArray(userId) {
     console.warn("getSortedRecordArray called without valid user ID");
     return [];
   }
-  const data = await loadTrainingRecords(userId);
+  const sinceDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const data = await loadTrainingRecords(userId, sinceDate);
   const sortedKeys = Object.keys(data).sort();
   return sortedKeys.map(date => ({
     date,

--- a/utils/recordStore_supabase.js
+++ b/utils/recordStore_supabase.js
@@ -96,15 +96,21 @@ export async function incrementSetCount(userId) {
  * 全トレーニング記録を取得（進捗判定・表示用）
  * @returns {Promise<Object>} 日付をキーにした記録オブジェクト
  */
-export async function loadTrainingRecords(userId) {
+export async function loadTrainingRecords(userId, sinceDate) {
   if (!userId) {
     console.warn("loadTrainingRecords called without valid user ID");
     return {};
   }
-  const { data, error } = await supabase
+  let query = supabase
     .from("training_records")
-    .select("*")
+    .select("date,count,correct,sets")
     .eq("user_id", userId);
+
+  if (sinceDate) {
+    query = query.gte("date", sinceDate);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     console.error("❌ 記録読み込み失敗:", error);


### PR DESCRIPTION
## Summary
- add `sinceDate` param to `loadTrainingRecords`
- fetch last 30 days of records on Home screen
- fetch last 30 days of records on Summary screen
- fetch last 30 days of records in growth utilities

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68556f4b00d08323be8ef79c4636c239