### PR TITLE
Set up Vite bundling

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
   </script>
   <script src="https://js.stripe.com/v3/" defer></script>
 
-  <!-- ✅ 最後に main.js をモジュールとして読み込む -->
-  <script type="module" src="main.js"></script>
+  <!-- ✅ 最後にビルド済みバンドルを読み込む -->
+  <script type="module" src="dist/assets/index.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -8,8 +8,13 @@
     "@supabase/supabase-js": "^2.39.7",
     "micro": "^9.3.4"
   },
+  "devDependencies": {
+    "vite": "^5.2.0"
+  },
   "scripts": {
-    "reset-expired-premiums": "node scripts/resetExpiredPremiums.js"
+    "reset-expired-premiums": "node scripts/resetExpiredPremiums.js",
+    "dev": "vite",
+    "build": "vite build"
   }
 }
 

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@ const CACHE_NAME = 'otoron-cache-v1';
 const STATIC_ASSETS = [
   '/',
   '/index.html',
-  '/main.js',
+  '/dist/assets/index.js',
   '/style.css',
   '/generated-icon.png',
   //'/favicon.ico',

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    cssCodeSplit: false,
+    rollupOptions: {
+      input: 'index.html',
+      output: {
+        manualChunks: undefined,
+        entryFileNames: 'assets/index.js',
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a basic Vite build configuration
- update scripts in `package.json` for Vite dev/build
- reference bundled script from `index.html`
- adjust service worker cache list

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68556f513eb0832380211ed81285ef7e