### PR TITLE
Replace inline styles with CSS classes

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -32,10 +32,7 @@ export async function renderHomeScreen(user, options = {}) {
   const titleText = document.createElement("h1");
   const userName = user?.name || "";
 　titleText.innerHTML = `${userName}ちゃん<br>${getGreeting()}`;
-  titleText.style.fontSize = "1.8rem"; // make greeting text slightly smaller
-  titleText.style.margin = "0";
-  titleText.style.color = "#543014";
-  titleText.style.textAlign = "center";
+  titleText.className = "greeting";
   container.appendChild(titleText);
 
   // ✅ 今日のトレーニング回数
@@ -55,7 +52,6 @@ export async function renderHomeScreen(user, options = {}) {
   const trialInfo = document.createElement("p");
   trialInfo.className = "trial-info";
   trialInfo.style.visibility = "hidden";
-  trialInfo.style.minHeight = "1.2em"; // reserve space even when hidden
   container.appendChild(trialInfo);
 
   if (
@@ -83,7 +79,6 @@ export async function renderHomeScreen(user, options = {}) {
     timeClass === "night" ? "images/night_otolon.webp" : "images/otolon.webp";
   faceImg.alt = "おとろん";
   faceImg.className = "otolon-face";
-  faceImg.style.marginBottom = "0.5em";
   faceImg.addEventListener("pointerdown", () => {
     const audio = getAudio("audio/touch.mp3");
     audio.play().catch((e) => console.warn("touch sound error", e));
@@ -155,41 +150,28 @@ export function showCustomConfirm(message, onConfirm, options = {}) {
   if (!modal) {
     modal = document.createElement("div");
     modal.id = "custom-confirm";
-    modal.style.position = "fixed";
-    modal.style.top = "0";
-    modal.style.left = "0";
-    // Prevent potential overflow caused by viewport units
-    modal.style.width = "100%";
-    modal.style.height = "100%";
-    modal.style.background = "rgba(0,0,0,0.6)";
-    modal.style.display = "flex";
-    modal.style.justifyContent = "center";
-    modal.style.alignItems = "center";
-    modal.style.zIndex = "1000";
+    modal.className = "modal";
 
     const box = document.createElement("div");
-    box.style.background = "#fff";
-    box.style.padding = "1.5em";
-    box.style.borderRadius = "10px";
-    box.style.textAlign = "center";
+    box.className = "modal-box";
 
     const titleNode = document.createElement("h3");
     titleNode.id = "custom-confirm-title";
     titleNode.textContent = title;
-    titleNode.style.margin = "0 0 0.5em";
+    titleNode.className = "modal-title";
     box.appendChild(titleNode);
 
     const messageEl = document.createElement("p");
     messageEl.id = "custom-confirm-message";
     messageEl.textContent = message;
+    messageEl.className = "modal-message";
     box.appendChild(messageEl);
 
     const buttons = document.createElement("div");
-    buttons.style.marginTop = "1em";
+    buttons.className = "modal-buttons";
 
     const okBtn = document.createElement("button");
     okBtn.className = "ok-btn";
-    okBtn.style.margin = "0 0.5em";
     okBtn.onclick = () => {
       modal.style.display = "none";
       if (typeof modal.callback === "function") {
@@ -199,7 +181,6 @@ export function showCustomConfirm(message, onConfirm, options = {}) {
 
     const cancelBtn = document.createElement("button");
     cancelBtn.className = "cancel-btn";
-    cancelBtn.style.margin = "0 0.5em";
     cancelBtn.onclick = () => {
       modal.style.display = "none";
     };

--- a/components/planInfo.js
+++ b/components/planInfo.js
@@ -78,7 +78,7 @@ async function createPlanInfoContent(user) {
     if (sub.status === 'cancelled') {
       const msg = document.createElement('div');
       msg.textContent = `ご契約は${formatDate(expireDate)}まで有効です。それ以降、自動的に無料プランに戻ります。`;
-      msg.style.marginTop = '1em';
+      msg.className = 'plan-info-msg';
       btnWrap.appendChild(msg);
     } else {
       const cancelBtn = document.createElement('button');

--- a/css/common.css
+++ b/css/common.css
@@ -122,5 +122,42 @@ button:hover {
   cursor: pointer;
 }
 
+/* Modal styles */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-box {
+  background: #fff;
+  padding: 1.5em;
+  border-radius: 10px;
+  text-align: center;
+}
+
+.modal-title {
+  margin: 0 0 0.5em;
+}
+
+.modal-buttons {
+  margin-top: 1em;
+}
+
+.modal-buttons button {
+  margin: 0 0.5em;
+}
+
 
 

--- a/css/home.css
+++ b/css/home.css
@@ -76,6 +76,13 @@
   text-align: center;
 }
 
+.home-screen .greeting {
+  font-size: 1.8rem;
+  margin: 0;
+  color: #543014;
+  text-align: center;
+}
+
 .home-screen .sub-title {
   font-size: 1.2rem;
   text-align: center;

--- a/css/pricing.css
+++ b/css/pricing.css
@@ -134,3 +134,7 @@
   flex: 1;
   padding: 0.8em;
 }
+
+.plan-info-msg {
+  margin-top: 1em;
+}

--- a/style.css
+++ b/style.css
@@ -144,6 +144,43 @@ button:hover {
   cursor: pointer;
 }
 
+/* Modal styles */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-box {
+  background: #fff;
+  padding: 1.5em;
+  border-radius: 10px;
+  text-align: center;
+}
+
+.modal-title {
+  margin: 0 0 0.5em;
+}
+
+.modal-buttons {
+  margin-top: 1em;
+}
+
+.modal-buttons button {
+  margin: 0 0.5em;
+}
+
 
 
 /* ✅ 和音サークル共通 */
@@ -824,6 +861,13 @@ button:hover {
   font-size: 2.4rem;
   color: var(--color-accent);
   margin: 0.5em 0 0.2em 0;
+  text-align: center;
+}
+
+.home-screen .greeting {
+  font-size: 1.8rem;
+  margin: 0;
+  color: #543014;
   text-align: center;
 }
 
@@ -1950,6 +1994,10 @@ a/* Landing page styles */
 .plan-info-buttons button {
   flex: 1;
   padding: 0.8em;
+}
+
+.plan-info-msg {
+  margin-top: 1em;
 }
 /* 結果画面全体のレイアウト */
 .result-container {


### PR DESCRIPTION
## Summary
- add new `.greeting` and modal styles in `common.css`, `home.css` and `style.css`
- style plan info messages with new `.plan-info-msg` class
- update `home.js` and `planInfo.js` to use CSS classes instead of inline styles

## Testing
- `npm run` *(shows available npm scripts)*

------
https://chatgpt.com/codex/tasks/task_b_68557136f2488323baa3dbb5c1a7d2d1