### PR TITLE
Add font variables for consistent headings

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -1,7 +1,9 @@
 /* ===== common.css (scoped) ===== */
 
 :root {
-  --font-main: 'Kosugi Maru', sans-serif;
+  --font-body: 'Kosugi Maru', 'Noto Sans JP', sans-serif;
+  --font-heading: var(--font-body);
+  --font-main: var(--font-body);
   /* Theming variables */
   --color-primary: #ff9900;
   --color-accent: #FFD44C;
@@ -10,7 +12,7 @@
 
 /* デフォルト：モバイルファースト（スクロール許可） */
 .app-root {
-  font-family: var(--font-main);
+  font-family: var(--font-body);
   margin: 0;
   padding: 0;
   background: var(--color-background);
@@ -57,6 +59,7 @@ body.with-header {
 /* 見出し統一（任意） */
 .screen h1,
 .screen h2 {
+  font-family: var(--font-heading);
   text-align: center;
   margin-bottom: 1em;
 }

--- a/css/info.css
+++ b/css/info.css
@@ -55,12 +55,14 @@
 }
 
 .info-page h1 {
+  font-family: var(--font-heading);
   text-align: center;
   font-size: 1.6rem;
   margin-bottom: 0.8em;
 }
 
 .info-page h2 {
+  font-family: var(--font-heading);
   margin-top: 1.4em;
   font-size: 1.3rem;
 }

--- a/css/settings.css
+++ b/css/settings.css
@@ -303,6 +303,7 @@
   cursor: pointer;
 }
 .other-training h3 {
+  font-family: var(--font-heading);
   font-weight: bold;
   font-size: 16px;
   margin-bottom: 8px;

--- a/style.css
+++ b/style.css
@@ -1,7 +1,9 @@
 /* ===== common.css (scoped) ===== */
 
 :root {
-  --font-main: 'Kosugi Maru', sans-serif;
+  --font-body: 'Kosugi Maru', 'Noto Sans JP', sans-serif;
+  --font-heading: var(--font-body);
+  --font-main: var(--font-body);
   /* Theming variables */
   --color-primary: #ff9900;
   --color-accent: #FFD44C;
@@ -10,7 +12,7 @@
 
 /* デフォルト：モバイルファースト（スクロール許可） */
 .app-root {
-  font-family: var(--font-main);
+  font-family: var(--font-body);
   margin: 0;
   padding: 0;
   background: var(--color-background);
@@ -79,6 +81,7 @@ body.with-header {
 /* 見出し統一（任意） */
 .screen h1,
 .screen h2 {
+  font-family: var(--font-heading);
   text-align: center;
   margin-bottom: 1em;
 }
@@ -1013,12 +1016,14 @@ button:hover {
 }
 
 .info-page h1 {
+  font-family: var(--font-heading);
   text-align: center;
   font-size: 1.6rem;
   margin-bottom: 0.8em;
 }
 
 .info-page h2 {
+  font-family: var(--font-heading);
   margin-top: 1.4em;
   font-size: 1.3rem;
 }
@@ -2581,6 +2586,7 @@ a/* Landing page styles */
   cursor: pointer;
 }
 .other-training h3 {
+  font-family: var(--font-heading);
   font-weight: bold;
   font-size: 16px;
   margin-bottom: 8px;


### PR DESCRIPTION
## Summary
- define `--font-body` and `--font-heading` variables with fallback fonts
- apply body font to `.app-root`
- use heading font for standard headings and info pages
- apply heading font on settings page

## Testing
- `npm test` *(fails: Missing script and no network access)*

------
https://chatgpt.com/codex/tasks/task_b_6855713818888323b4c84fb1e2a2e14c