### PR TITLE
Fix favicon link

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <!-- CSS -->
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
+  <link rel="icon" href="public/favicon.ico" />
 </head>
 
 <body class="app-root">

--- a/success/index.html
+++ b/success/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>決済完了</title>
+  <link rel="icon" href="../public/favicon.ico" />
 </head>
 <body style="margin:0;">
   <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;background-color:#fff;text-align:center;">


### PR DESCRIPTION
## Summary
- ensure favicon is loaded on main and success pages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_6855a149b1948323bff9813125c2902a