### PR TITLE
Add OGP image

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
   <link rel="icon" href="public/favicon.ico" />
+  <meta property="og:image" content="/ogp.jpg" />
+  <meta name="twitter:image" content="/ogp.jpg" />
 </head>
 
 <body class="app-root">

--- a/sw.js
+++ b/sw.js
@@ -5,6 +5,7 @@ const STATIC_ASSETS = [
   '/main.js',
   '/style.css',
   '/generated-icon.png',
+  '/ogp.jpg',
   //'/favicon.ico',
   // CSS files
   '/css/common.css',


### PR DESCRIPTION
## Summary
- reference `ogp.jpg` in meta tags
- precache `ogp.jpg` in the service worker
- remove checked-in `ogp.jpg` file (the image will be provided separately)

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685624b1494c8323b14f4369e0d946a4