### PR TITLE
Remove meta tags from success page

### DIFF
--- a/success/index.html
+++ b/success/index.html
@@ -1,14 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>決済完了</title>
-  <meta property="og:title" content="子どもがゲーム感覚で絶対音感を育てるアプリ「オトロン」🎵" />
-  <meta property="og:description" content="音の高さを旗の色で感じるユニークなトレーニング。音感の土台をゲーム感覚で楽しく育てよう。今すぐお試し！" />
-  <meta property="og:image" content="/ogp.jpg" />
-  <meta property="og:url" content="https://playotoron.com" />
-  <meta property="og:type" content="website" />
   <link rel="icon" href="../public/favicon.ico" />
 </head>
 <body style="margin:0;">


### PR DESCRIPTION
## Summary
- remove all meta tags from `success/index.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68566bfe84108323bf4f2d6e11a31315