### PR TITLE
Fix OGP meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,23 +5,29 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta name="theme-color" content="#ffdede" />
   <title>絶対音感トレーニング</title>
+  <!-- ✅ OGP設定（LINE・Twitter・Facebook用） -->
   <meta property="og:title" content="子どもがゲーム感覚で絶対音感を育てるアプリ「オトロン」🎵" />
   <meta property="og:description" content="音の高さを旗の色で感じるユニークなトレーニング。音感の土台をゲーム感覚で楽しく育てよう。今すぐお試し！" />
-  <meta property="og:image" content="/ogp.jpg" />
+  <meta property="og:image" content="https://playotoron.com/ogp.jpg" />
   <meta property="og:url" content="https://playotoron.com" />
   <meta property="og:type" content="website" />
-
+  
+  <!-- ✅ Twitter用 -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://playotoron.com/ogp.jpg" />
+  
+  <!-- ✅ Favicon -->
+  <link rel="icon" href="/favicon.ico" />
+  
+  <!-- ✅ Google Fonts & Material Icons -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-
+  
   <!-- CSS -->
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
-  <link rel="icon" href="public/favicon.ico" />
-  <meta property="og:image" content="/ogp.jpg" />
-  <meta name="twitter:image" content="/ogp.jpg" />
 </head>
 
 <body class="app-root">

--- a/success/index.html
+++ b/success/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <title>決済完了</title>
-  <link rel="icon" href="../public/favicon.ico" />
+  <link rel="icon" href="/favicon.ico" />
 </head>
 <body style="margin:0;">
   <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;background-color:#fff;text-align:center;">


### PR DESCRIPTION
## Summary
- adjust OGP meta tags in `index.html`
- reference favicon from root in `success/index.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68566e8942648323a1a20d997224d795