### PR TITLE
Add GA4 tracking code

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,16 @@
   <!-- CSS -->
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-QCRGGLGDER"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-QCRGGLGDER');
+  </script>
 </head>
 
 <body class="app-root">


### PR DESCRIPTION
## Summary
- add Google Analytics 4 tracking code to index.html

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6856a6fa07908323bc6a90162d06794a