### PR TITLE
Add 1 yen plan to pricing screens

### DIFF
--- a/components/mypage.js
+++ b/components/mypage.js
@@ -356,6 +356,15 @@ export function renderMyPageScreen(user) {
         benefit: "",
         recommended: false,
       },
+      {
+        key: "plan1yen",
+        title: "テスト用1円プラン",
+        months: 0,
+        monthly: 1,
+        total: 1,
+        benefit: "",
+        recommended: false,
+      },
     ];
 
     const wrap = document.createElement("div");
@@ -374,7 +383,7 @@ export function renderMyPageScreen(user) {
 
       const title = document.createElement("div");
       title.className = "plan-title";
-      title.textContent = `${p.months}ヶ月プラン`;
+      title.textContent = p.title || `${p.months}ヶ月プラン`;
       card.appendChild(title);
 
       const price = document.createElement("div");

--- a/components/pricing.js
+++ b/components/pricing.js
@@ -33,6 +33,15 @@ export function renderPricingScreen(user) {
       benefit: '',
       recommended: false,
     },
+    {
+      key: 'plan1yen',
+      title: 'テスト用1円プラン',
+      months: 0,
+      monthly: 1,
+      total: 1,
+      benefit: '',
+      recommended: false,
+    },
   ];
 
   plans.forEach((p) => {
@@ -48,7 +57,7 @@ export function renderPricingScreen(user) {
 
     const title = document.createElement('div');
     title.className = 'plan-title';
-    title.textContent = `${p.months}ヶ月プラン`;
+    title.textContent = p.title || `${p.months}ヶ月プラン`;
     card.appendChild(title);
 
     const price = document.createElement('div');


### PR DESCRIPTION
## Summary
- add test 1 yen plan to plan list
- show custom title when provided

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6857a8e3a6b48323ac651c34a5ee6929