### PR TITLE
Include black inversion chords in reselect

### DIFF
--- a/components/info/chordReset.js
+++ b/components/info/chordReset.js
@@ -20,13 +20,12 @@ export function renderChordResetScreen(user) {
   app.appendChild(main);
 
   const select = main.querySelector("#start-chord");
+  // include every chord option, including black key inversions
   chords.forEach((ch, idx) => {
-    if (idx <= 13) { // up to mizuiro (basic 14 colors)
-      const opt = document.createElement("option");
-      opt.value = idx;
-      opt.textContent = ch.label;
-      select.appendChild(opt);
-    }
+    const opt = document.createElement("option");
+    opt.value = idx;
+    opt.textContent = ch.label;
+    select.appendChild(opt);
   });
 
   main.querySelector("#apply-btn").onclick = () => {

--- a/components/info/faq.js
+++ b/components/info/faq.js
@@ -21,7 +21,8 @@ export function renderFaqScreen(user) {
     {
       id: "q2",
       question: "和音の選択を間違えてしまいました。最初からやり直せますか？",
-      answer: "はい、できます。以下のボタンから和音を選び直すことができます。",
+      answer:
+        "はい、できます。以下のボタンから開始和音を選び直せます。白鍵はもちろん、黒鍵の転回形もすべて選択できます。",
       button: {
         id: "reselect-btn",
         label: "和音の選び直しボタン",


### PR DESCRIPTION
## Summary
- allow all chords to be selectable when resetting start chord
- mention that black key inversions can also be chosen in FAQ answer

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6857fa2172d083239bc4ff14a8fd04f8