### PR TITLE
Move all-chords-unlocked message

### DIFF
--- a/logic/growth.js
+++ b/logic/growth.js
@@ -257,15 +257,6 @@ export async function renderGrowthScreen(user) {
 
   container.appendChild(chordStatus);
 
-  // ✅ 全和音が解放済みだった場合の表示（解放ボタンなし）
-  if (!target) {
-    const done = document.createElement("p");
-    done.textContent = "🎉 すべての和音が解放されています！";
-    done.style.margin = "1.5em auto";
-    done.style.textAlign = "center";
-    done.style.color = "#666";
-    container.appendChild(done);
-  }
 
 
 

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -130,11 +130,15 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
     btn.onpointerup = cancelProgress;
     btn.onpointerleave = cancelProgress;
   } else {
-    const label = target ? target.label : "";
-    const colorClass = target ? target.colorClass : "";
-    msg.innerHTML = `いま <span class="chord ${colorClass}">${label}</span> の和音に挑戦中`;
     msg.classList.remove("can-unlock");
     msg.classList.add("current-target");
+    if (target) {
+      const label = target.label;
+      const colorClass = target.colorClass;
+      msg.innerHTML = `いま <span class="chord ${colorClass}">${label}</span> の和音に挑戦中`;
+    } else {
+      msg.textContent = "🎉 すべての和音が解放されています！";
+    }
     card.classList.remove("highlight");
     btn.style.display = "none";
     btn.onpointerdown = null;


### PR DESCRIPTION
## Summary
- remove extra message from bottom of growth screen
- display "🎉 すべての和音が解放されています！" within the status bar when no target chord remains

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68580daf25dc83238baae6f3fd4b03a6