### PR TITLE
Fix unlocked inversion display

### DIFF
--- a/css/growth.css
+++ b/css/growth.css
@@ -26,6 +26,11 @@
   background-color: white;
 }
 
+/* 解放された黒鍵転回形の枠線色 */
+.growth-unlocked-inv {
+  border-color: green;
+}
+
 /* ✅ 転回形で解放済みのチェックマーク（白背景＋✅） */
 
 /* ✅ 色つき和音（名前＝クラス名と一致） */

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -227,7 +227,7 @@ export async function renderGrowthScreen(user) {
     if (chord.type === "black-inv") {
       circle.classList.add("growth-locked");
       if (isUnlocked) {
-        circle.textContent = "✅";
+        circle.classList.add("growth-unlocked-inv");
       }
     } else {
       if (isUnlocked) {

--- a/style.css
+++ b/style.css
@@ -211,6 +211,11 @@ button:hover {
   background-color: white;
 }
 
+/* 解放された黒鍵転回形の枠線色 */
+.growth-unlocked-inv {
+  border-color: green;
+}
+
 /* ✅ 転回形で解放済みのチェックマーク（白背景＋✅） */
 
 /* ✅ 色つき和音（名前＝クラス名と一致） */


### PR DESCRIPTION
## Summary
- maintain chord labels for black key inversions after unlock
- highlight unlocked inversions with a green border

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6858150c0b848323bcb1126f70971c6d