### PR TITLE
Add mailto link for support email

### DIFF
--- a/components/info/contact.js
+++ b/components/info/contact.js
@@ -31,6 +31,11 @@ export function renderContactScreen(user) {
     <p style="text-align:center;margin-top:1em;">
       お急ぎの方は、<a href="#" id="help-link">ヘルプ・操作マニュアル</a> もあわせてご覧ください。
     </p>
+    <p class="support-email" style="text-align:center;margin-top:0.5em;">
+      直接のご連絡は
+      <a href="mailto:support@playotoron.com">support@playotoron.com</a>
+      までお願いいたします。
+    </p>
   `;
 
   app.appendChild(main);


### PR DESCRIPTION
## Summary
- add support email mailto link on contact page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68594f9bd18c832394364fb1d9ff0742