### PR TITLE
Fix info page visibility and intro login actions

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -1,5 +1,8 @@
 // components/intro.js
 import { switchScreen } from "../main.js";
+import { signOut } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+import { firebaseAuth } from "../firebase/firebase-init.js";
+import { supabase } from "../utils/supabaseClient.js";
 
 export function renderIntroScreen() {
   const app = document.getElementById('app');
@@ -232,14 +235,26 @@ export function renderIntroScreen() {
 
   const loginBtn = document.getElementById('login-btn');
   if (loginBtn) {
-    loginBtn.addEventListener('click', () => {
+    loginBtn.addEventListener('click', async () => {
+      try {
+        await signOut(firebaseAuth);
+        await supabase.auth.signOut();
+      } catch (e) {
+        console.warn('intro logout error', e);
+      }
       switchScreen('login');
     });
   }
 
   const signupBtn = document.getElementById('signup-btn');
   if (signupBtn) {
-    signupBtn.addEventListener('click', () => {
+    signupBtn.addEventListener('click', async () => {
+      try {
+        await signOut(firebaseAuth);
+        await supabase.auth.signOut();
+      } catch (e) {
+        console.warn('intro logout error', e);
+      }
       switchScreen('signup');
     });
   }

--- a/css/info.css
+++ b/css/info.css
@@ -4,7 +4,7 @@
   padding: 0 1em 2em;
   box-sizing: border-box;
   background: #fff;
-  color: #543014;
+  color: #543014 !important;
   line-height: 1.7;
   border-radius: 8px;
 }
@@ -51,7 +51,7 @@
 /* Ensure readability even when the body has a dark background */
 .app-root.night .info-page {
   background: #fff;
-  color: #543014;
+  color: #543014 !important;
 }
 
 .info-page h1 {

--- a/style.css
+++ b/style.css
@@ -970,7 +970,7 @@ button:hover {
   padding: 0 1em 2em;
   box-sizing: border-box;
   background: #fff;
-  color: #543014;
+  color: #543014 !important;
   line-height: 1.7;
   border-radius: 8px;
 }
@@ -1020,7 +1020,7 @@ button:hover {
 /* Ensure readability even when the body has a dark background */
 .app-root.night .info-page {
   background: #fff;
-  color: #543014;
+  color: #543014 !important;
 }
 
 .info-page h1 {


### PR DESCRIPTION
## Summary
- ensure information pages use visible text color
- sign out before navigating to login or signup from the intro page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685c7f9461fc8323ae97868d98b31d34