### PR TITLE
Update info screens with intro header

### DIFF
--- a/components/info/chordReset.js
+++ b/components/info/chordReset.js
@@ -1,4 +1,4 @@
-import { renderHeader } from "../header.js";
+import { renderIntroHeader } from "../introHeader.js";
 import { chords } from "../../data/chords.js";
 import { resetProgressAndUnlock } from "../../utils/progressUtils.js";
 import { showCustomConfirm, showCustomAlert } from "../home.js";
@@ -7,7 +7,7 @@ import { switchScreen } from "../../main.js";
 export function renderChordResetScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app, user);
+  renderIntroHeader(app);
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/contact.js
+++ b/components/info/contact.js
@@ -1,4 +1,4 @@
-import { renderHeader } from "../header.js";
+import { renderIntroHeader } from "../introHeader.js";
 import { switchScreen } from "../../main.js";
 
 const GAS_URL = "https://script.google.com/macros/s/AKfycbxuLk3wnuOENw8lqC0oZq-rLTvH8MJbzSPeMMwDLPYNpfDg10qQ2koVcvsIiPEepLSu/exec";
@@ -6,7 +6,7 @@ const GAS_URL = "https://script.google.com/macros/s/AKfycbxuLk3wnuOENw8lqC0oZq-r
 export function renderContactScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app, user);
+  renderIntroHeader(app);
 
   const main = document.createElement("main");
   main.className = "info-page contact-page";

--- a/components/info/external.js
+++ b/components/info/external.js
@@ -1,9 +1,9 @@
-import { renderHeader } from "../header.js";
+import { renderIntroHeader } from "../introHeader.js";
 
 export function renderExternalScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app, user);
+  renderIntroHeader(app);
 
   const main = document.createElement("main");
   main.className = "info-page full-page";

--- a/components/info/faq.js
+++ b/components/info/faq.js
@@ -1,11 +1,11 @@
-import { renderHeader } from "../header.js";
+import { renderIntroHeader } from "../introHeader.js";
 import { switchScreen } from "../../main.js";
 
 export function renderFaqScreen(user, options = {}) {
   const { hideReselect = false } = options;
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app, user);
+  renderIntroHeader(app);
 
   const faqs = [
     {

--- a/components/info/help.js
+++ b/components/info/help.js
@@ -1,9 +1,9 @@
-import { renderHeader } from "../header.js";
+import { renderIntroHeader } from "../introHeader.js";
 
 export function renderHelpScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app, user);
+  renderIntroHeader(app);
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/law.js
+++ b/components/info/law.js
@@ -1,10 +1,10 @@
-import { renderHeader } from "../header.js";
+import { renderIntroHeader } from "../introHeader.js";
 import { switchScreen } from "../../main.js";
 
 export function renderLawScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app, user);
+  renderIntroHeader(app);
 
   const main = document.createElement("main");
   main.className = "info-page full-page";

--- a/components/info/privacy.js
+++ b/components/info/privacy.js
@@ -1,10 +1,10 @@
-import { renderHeader } from "../header.js";
+import { renderIntroHeader } from "../introHeader.js";
 import { switchScreen } from "../../main.js";
 
 export function renderPrivacyScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app, user);
+  renderIntroHeader(app);
 
   const main = document.createElement("main");
   main.className = "info-page full-page";

--- a/components/info/terms.js
+++ b/components/info/terms.js
@@ -1,9 +1,9 @@
-import { renderHeader } from "../header.js";
+import { renderIntroHeader } from "../introHeader.js";
 
 export function renderTermsScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderHeader(app, user);
+  renderIntroHeader(app);
 
   const main = document.createElement("main");
   main.className = "info-page full-page";

--- a/components/introHeader.js
+++ b/components/introHeader.js
@@ -1,0 +1,100 @@
+import { signOut } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+import { firebaseAuth } from "../firebase/firebase-init.js";
+import { supabase } from "../utils/supabaseClient.js";
+import { switchScreen } from "../main.js";
+
+export function renderIntroHeader(container) {
+  const header = document.createElement("header");
+  header.className = "app-header intro-header";
+  header.innerHTML = `
+    <button class="home-icon" id="intro-home-btn">
+      <img src="images/otolon_face.webp" alt="トップへ" />
+    </button>
+    <div class="header-right">
+      <div class="info-menu">
+        <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
+        <div id="info-dropdown" class="info-dropdown">
+          <button id="terms-btn">利用規約</button>
+          <button id="privacy-btn">プライバシーポリシー</button>
+          <button id="contact-btn">お問い合わせ</button>
+          <button id="help-btn">必ずお読みください</button>
+          <button id="faq-btn">よくある質問</button>
+          <button id="law-btn">特定商取引法に基づく表示</button>
+          <button id="external-btn">外部送信ポリシー</button>
+        </div>
+      </div>
+      <button id="login-btn" class="intro-login">ログイン</button>
+      <button id="signup-btn" class="intro-signup">無料会員登録</button>
+    </div>
+  `;
+  container.prepend(header);
+  container.classList.add("with-header");
+
+  const loginBtn = header.querySelector("#login-btn");
+  if (loginBtn) {
+    loginBtn.addEventListener("click", async () => {
+      try {
+        await signOut(firebaseAuth);
+        await supabase.auth.signOut();
+      } catch (e) {
+        console.warn("intro logout error", e);
+      }
+      switchScreen("login");
+    });
+  }
+
+  const signupBtn = header.querySelector("#signup-btn");
+  if (signupBtn) {
+    signupBtn.addEventListener("click", async () => {
+      try {
+        await signOut(firebaseAuth);
+        await supabase.auth.signOut();
+      } catch (e) {
+        console.warn("intro logout error", e);
+      }
+      switchScreen("signup");
+    });
+  }
+
+  const infoMenuBtn = header.querySelector("#info-menu-btn");
+  const infoDropdown = header.querySelector("#info-dropdown");
+  const termsBtn = header.querySelector("#terms-btn");
+  const privacyBtn = header.querySelector("#privacy-btn");
+  const contactBtn = header.querySelector("#contact-btn");
+  const helpBtn = header.querySelector("#help-btn");
+  const faqBtn = header.querySelector("#faq-btn");
+  const lawBtn = header.querySelector("#law-btn");
+  const externalBtn = header.querySelector("#external-btn");
+
+  if (infoMenuBtn && infoDropdown) {
+    infoMenuBtn.onclick = (e) => {
+      e.stopPropagation();
+      const willShow = !infoDropdown.classList.contains("show");
+      infoDropdown.classList.toggle("show");
+      if (willShow) {
+        document.addEventListener(
+          "click",
+          function handler(ev) {
+            if (!infoDropdown.contains(ev.target) && ev.target !== infoMenuBtn) {
+              infoDropdown.classList.remove("show");
+              document.removeEventListener("click", handler);
+            }
+          }
+        );
+      }
+    };
+  }
+
+  if (termsBtn) termsBtn.onclick = () => switchScreen("terms");
+  if (privacyBtn) privacyBtn.onclick = () => switchScreen("privacy");
+  if (contactBtn) contactBtn.onclick = () => switchScreen("contact");
+  if (helpBtn) helpBtn.onclick = () => switchScreen("help");
+  if (faqBtn) faqBtn.onclick = () => switchScreen("faq", undefined, { hideReselect: true });
+  if (lawBtn) lawBtn.onclick = () => switchScreen("law");
+  if (externalBtn) externalBtn.onclick = () => switchScreen("external");
+
+  const topBtn = header.querySelector("#intro-home-btn");
+  if (topBtn) {
+    topBtn.addEventListener("click", () => switchScreen("intro"));
+  }
+}

--- a/css/intro.css
+++ b/css/intro.css
@@ -6,7 +6,7 @@ a/* Landing page styles */
   margin-left: auto;
 }
 
-.intro-header .header-right button {
+.intro-header .header-right > button {
   border: none;
   border-radius: 6px;
   padding: 0.4em 1em;

--- a/style.css
+++ b/style.css
@@ -1182,7 +1182,7 @@ a/* Landing page styles */
   margin-left: auto;
 }
 
-.intro-header .header-right button {
+.intro-header .header-right > button {
   border: none;
   border-radius: 6px;
   padding: 0.4em 1em;


### PR DESCRIPTION
## Summary
- reuse new `introHeader` component for information screens
- fix header CSS so dropdown text isn't white on info pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685d4557819c832382bb097f2eb760f4