### PR TITLE
Fix list alignment on info pages

### DIFF
--- a/css/info.css
+++ b/css/info.css
@@ -27,8 +27,17 @@
   text-align: center;
 }
 
+/* Center lists while keeping bullet indentation */
+.info-page ul {
+  display: inline-block;
+  text-align: left;
+  margin: 0 auto 1em;
+  padding-left: 1.4em;
+}
+
 /* Ensure bullet lists aren't flush against the edge on wide screens */
 .info-page.full-page ul {
+  display: inline-block;
   text-align: left;
   padding-left: 1.4em;
 }

--- a/style.css
+++ b/style.css
@@ -993,8 +993,17 @@ button:hover {
   text-align: center;
 }
 
+/* Center lists while keeping bullet indentation */
+.info-page ul {
+  display: inline-block;
+  text-align: left;
+  margin: 0 auto 1em;
+  padding-left: 1.6em;
+}
+
 /* Ensure bullet lists aren't flush against the edge on wide screens */
 .info-page.full-page ul {
+  display: inline-block;
   text-align: left;
   max-width: 800px;
   margin: 0 auto 1em;


### PR DESCRIPTION
## Summary
- keep bullet list indentation while centering the block
- apply the rule across all info-page sections

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685d4c85f3148323b14e16318c3b859c