### PR TITLE
Ensure info pages use correct header

### DIFF
--- a/components/info/chordReset.js
+++ b/components/info/chordReset.js
@@ -1,4 +1,5 @@
 import { renderIntroHeader } from "../introHeader.js";
+import { renderHeader } from "../header.js";
 import { chords } from "../../data/chords.js";
 import { resetProgressAndUnlock } from "../../utils/progressUtils.js";
 import { showCustomConfirm, showCustomAlert } from "../home.js";
@@ -7,7 +8,11 @@ import { switchScreen } from "../../main.js";
 export function renderChordResetScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderIntroHeader(app);
+  if (user) {
+    renderHeader(app, user);
+  } else {
+    renderIntroHeader(app);
+  }
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/contact.js
+++ b/components/info/contact.js
@@ -1,4 +1,5 @@
 import { renderIntroHeader } from "../introHeader.js";
+import { renderHeader } from "../header.js";
 import { switchScreen } from "../../main.js";
 
 const GAS_URL = "https://script.google.com/macros/s/AKfycbxuLk3wnuOENw8lqC0oZq-rLTvH8MJbzSPeMMwDLPYNpfDg10qQ2koVcvsIiPEepLSu/exec";
@@ -6,7 +7,11 @@ const GAS_URL = "https://script.google.com/macros/s/AKfycbxuLk3wnuOENw8lqC0oZq-r
 export function renderContactScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderIntroHeader(app);
+  if (user) {
+    renderHeader(app, user);
+  } else {
+    renderIntroHeader(app);
+  }
 
   const main = document.createElement("main");
   main.className = "info-page contact-page";

--- a/components/info/external.js
+++ b/components/info/external.js
@@ -1,9 +1,14 @@
 import { renderIntroHeader } from "../introHeader.js";
+import { renderHeader } from "../header.js";
 
 export function renderExternalScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderIntroHeader(app);
+  if (user) {
+    renderHeader(app, user);
+  } else {
+    renderIntroHeader(app);
+  }
 
   const main = document.createElement("main");
   main.className = "info-page full-page";

--- a/components/info/faq.js
+++ b/components/info/faq.js
@@ -1,11 +1,16 @@
 import { renderIntroHeader } from "../introHeader.js";
+import { renderHeader } from "../header.js";
 import { switchScreen } from "../../main.js";
 
 export function renderFaqScreen(user, options = {}) {
   const { hideReselect = false } = options;
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderIntroHeader(app);
+  if (user) {
+    renderHeader(app, user);
+  } else {
+    renderIntroHeader(app);
+  }
 
   const faqs = [
     {

--- a/components/info/help.js
+++ b/components/info/help.js
@@ -1,9 +1,14 @@
 import { renderIntroHeader } from "../introHeader.js";
+import { renderHeader } from "../header.js";
 
 export function renderHelpScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderIntroHeader(app);
+  if (user) {
+    renderHeader(app, user);
+  } else {
+    renderIntroHeader(app);
+  }
 
   const main = document.createElement("main");
   main.className = "info-page";

--- a/components/info/law.js
+++ b/components/info/law.js
@@ -1,10 +1,15 @@
 import { renderIntroHeader } from "../introHeader.js";
+import { renderHeader } from "../header.js";
 import { switchScreen } from "../../main.js";
 
 export function renderLawScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderIntroHeader(app);
+  if (user) {
+    renderHeader(app, user);
+  } else {
+    renderIntroHeader(app);
+  }
 
   const main = document.createElement("main");
   main.className = "info-page full-page";

--- a/components/info/privacy.js
+++ b/components/info/privacy.js
@@ -1,10 +1,15 @@
 import { renderIntroHeader } from "../introHeader.js";
+import { renderHeader } from "../header.js";
 import { switchScreen } from "../../main.js";
 
 export function renderPrivacyScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderIntroHeader(app);
+  if (user) {
+    renderHeader(app, user);
+  } else {
+    renderIntroHeader(app);
+  }
 
   const main = document.createElement("main");
   main.className = "info-page full-page";

--- a/components/info/terms.js
+++ b/components/info/terms.js
@@ -1,9 +1,14 @@
 import { renderIntroHeader } from "../introHeader.js";
+import { renderHeader } from "../header.js";
 
 export function renderTermsScreen(user) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  renderIntroHeader(app);
+  if (user) {
+    renderHeader(app, user);
+  } else {
+    renderIntroHeader(app);
+  }
 
   const main = document.createElement("main");
   main.className = "info-page full-page";


### PR DESCRIPTION
## Summary
- show logged-in header on info pages when a user is present
- fall back to intro header when no user

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685d5580413083239ca98668c03e0708