### PR TITLE
Hide debug elements

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -376,6 +376,7 @@ function drawQuizScreen() {
   debugAnswer.style.right = "10px";
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
+  debugAnswer.style.display = "none";
 
   const unknownBtn = document.createElement("button");
   unknownBtn.id = "unknownBtn";

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -248,6 +248,7 @@ function drawQuizScreen() {
   debugAnswer.style.right = "10px";
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
+  debugAnswer.style.display = "none";
 
   const unknownBtn = document.createElement("button");
   unknownBtn.id = "unknownBtn";

--- a/components/training_easy_note.js
+++ b/components/training_easy_note.js
@@ -46,6 +46,7 @@ export async function renderTrainingScreen(user) {
   debugAnswer.style.right = "10px";
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
+  debugAnswer.style.display = "none";
   app.appendChild(debugAnswer);
   app.appendChild(bottomWrap);
 

--- a/components/training_full.js
+++ b/components/training_full.js
@@ -44,6 +44,7 @@ export async function renderTrainingScreen(user) {
   debugAnswer.style.right = "10px";
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
+  debugAnswer.style.display = "none";
   app.appendChild(debugAnswer);
   app.appendChild(bottomWrap);
 

--- a/components/training_white_keys.js
+++ b/components/training_white_keys.js
@@ -46,6 +46,7 @@ export async function renderTrainingScreen(user) {
   debugAnswer.style.right = "10px";
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
+  debugAnswer.style.display = "none";
   app.appendChild(debugAnswer);
   app.appendChild(bottomWrap);
 

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -140,6 +140,7 @@ export async function renderGrowthScreen(user) {
   // 🛠 デバッグ機能
   const debugPanel = document.createElement("div");
   debugPanel.style.marginBottom = "1em";
+  debugPanel.style.display = "none";
 
   const actionSelect = document.createElement("select");
   [


### PR DESCRIPTION
## Summary
- hide debug text across training screens
- hide debug panel in growth screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685d62ac07148323878283e7bc767b25