### PR TITLE
Fix quit button in single note mode

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -539,7 +539,6 @@ function showSingleNoteQuiz(chord, onFinish, isLast = false) {
   const unknownBtn = document.getElementById('unknownBtn');
   const quitBtn = document.getElementById('quitBtn');
   if (layout) layout.style.display = 'none';
-  if (quitBtn) quitBtn.style.display = 'none';
 
   let prevUnknownHandler = null;
   if (unknownBtn) {


### PR DESCRIPTION
## Summary
- keep the quit button visible during single note quizzes in training mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685d6a5f5fdc8323907c5d7682699e23