### PR TITLE
Add error handling for audio.play

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -81,7 +81,13 @@ export async function renderHomeScreen(user, options = {}) {
   faceImg.className = "otolon-face";
   faceImg.addEventListener("pointerdown", () => {
     const audio = getAudio("audio/touch.mp3");
-    audio.play().catch((e) => console.warn("touch sound error", e));
+    (async () => {
+      try {
+        await audio.play();
+      } catch (e) {
+        console.warn("🎧 audio.play() エラー:", e);
+      }
+    })();
     faceImg.classList.add("bounce");
     faceImg.addEventListener(
       "animationend",

--- a/components/soundPlayer.js
+++ b/components/soundPlayer.js
@@ -24,10 +24,14 @@ export function playNote(noteName) {
       console.warn(`音声再生エラー: ${noteName}`);
       resolve();
     });
-    audio.play().catch((e) => {
-      console.warn(`音声再生エラー: ${noteName}`, e);
+    (async () => {
+      try {
+        await audio.play();
+      } catch (e) {
+        console.warn(`音声再生エラー: ${noteName}`, e);
+      }
       resolve();
-    });
+    })();
   });
 }
 

--- a/components/training.js
+++ b/components/training.js
@@ -32,7 +32,7 @@ export const firstMistakeInSession = { flag: false, wrong: null };
 export let lastResults = [];
 export let correctCount = 0;
 
-function playSoundThen(name, callback) {
+async function playSoundThen(name, callback) {
   if (currentAudio) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
@@ -44,7 +44,11 @@ function playSoundThen(name, callback) {
     console.error("⚠️ 音声ファイルが読み込めませんでした:", name);
     callback();
   };
-  currentAudio.play();
+  try {
+    await currentAudio.play();
+  } catch (e) {
+    console.warn("🎧 audio.play() エラー:", e);
+  }
 }
 
 function createQuestionQueue() {
@@ -433,7 +437,7 @@ if (correctBtn) {
 }
 
 
-function playChordFile(filename) {
+async function playChordFile(filename) {
   if (!chordSoundOn) return;
   if (currentAudio) {
     currentAudio.pause();
@@ -441,7 +445,11 @@ function playChordFile(filename) {
   }
   currentAudio = getAudio(`audio/${filename}`);
   currentAudio.onerror = () => console.error("音声ファイルが見つかりません:", filename);
-  currentAudio.play();
+  try {
+    await currentAudio.play();
+  } catch (e) {
+    console.warn("🎧 audio.play() エラー:", e);
+  }
 }
 
 function normalizeNoteName(name) {
@@ -458,7 +466,7 @@ function normalizeNoteName(name) {
     .replace("♯", "#");
 }
 
-function playNoteFile(note, callback) {
+async function playNoteFile(note, callback) {
   if (currentAudio) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
@@ -469,7 +477,11 @@ function playNoteFile(note, callback) {
   if (callback) {
     currentAudio.onended = () => setTimeout(callback, 100);
   }
-  currentAudio.play();
+  try {
+    await currentAudio.play();
+  } catch (e) {
+    console.warn("🎧 audio.play() エラー:", e);
+  }
 }
 
 function noteToMidi(n) {

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -24,7 +24,7 @@ export const firstMistakeInSession = { flag: false, wrong: null };
 export let lastResults = [];
 export let correctCount = 0;
 
-function playSoundThen(name, callback) {
+async function playSoundThen(name, callback) {
   if (currentAudio) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
@@ -35,7 +35,11 @@ function playSoundThen(name, callback) {
     console.error("⚠️ 音声ファイルが読み込めませんでした:", name);
     callback();
   };
-  currentAudio.play();
+  try {
+    await currentAudio.play();
+  } catch (e) {
+    console.warn("🎧 audio.play() エラー:", e);
+  }
 }
 
 function createQuestionQueue() {
@@ -305,14 +309,18 @@ if (correctBtn) {
 }
 
 
-function playChordFile(filename) {
+async function playChordFile(filename) {
   if (currentAudio) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
   }
   currentAudio = getAudio(`audio/${filename}`);
   currentAudio.onerror = () => console.error("音声ファイルが見つかりません:", filename);
-  currentAudio.play();
+  try {
+    await currentAudio.play();
+  } catch (e) {
+    console.warn("🎧 audio.play() エラー:", e);
+  }
 }
 
 let feedbackTimeoutId;

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -238,10 +238,14 @@ export async function renderGrowthScreen(user) {
       }
     }
 
-    circle.onclick = () => {
+    circle.onclick = async () => {
       if (chord.file) {
         const audio = getAudio(`audio/${chord.file}`);
-        audio.play();
+        try {
+          await audio.play();
+        } catch (e) {
+          console.warn("🎧 audio.play() エラー:", e);
+        }
       }
     };
 

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -112,8 +112,16 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
         if (success) {
           const audio = getAudio("audio/unlock_chord.mp3");
           const applause = getAudio("audio/applause.mp3");
-          audio.play();
-          applause.play();
+          try {
+            await audio.play();
+          } catch (e) {
+            console.warn("🎧 audio.play() エラー:", e);
+          }
+          try {
+            await applause.play();
+          } catch (e) {
+            console.warn("🎧 audio.play() エラー:", e);
+          }
           launchConfetti();
           await applyRecommendedSelection(user.id);
           forceUnlock();


### PR DESCRIPTION
## Summary
- add try/catch around `audio.play()` calls on training screens and other UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685d7aab7d9c83239608022151b76663