### PR TITLE
Fix freeze after wrong answer on training screen

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -48,6 +48,8 @@ async function playSoundThen(name, callback) {
     await currentAudio.play();
   } catch (e) {
     console.warn("🎧 audio.play() エラー:", e);
+    // Playback failed so invoke callback to avoid freezing the UI
+    callback();
   }
 }
 

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -39,6 +39,8 @@ async function playSoundThen(name, callback) {
     await currentAudio.play();
   } catch (e) {
     console.warn("🎧 audio.play() エラー:", e);
+    // Playback failed so invoke callback to avoid freezing the UI
+    callback();
   }
 }
 


### PR DESCRIPTION
## Summary
- call callback even when audio playback fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685f48a491708323990bfc3db4487eb8