### PR TITLE
Add step video for intro features

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -63,29 +63,48 @@ export function renderIntroScreen() {
       <section class="features">
         <h2>4ステップで身につく絶対音感</h2>
 
-        <div class="step-header">
-          <span class="step-number">1</span>
-          <h3 class="step-title">色と和音で楽しくトレーニング</h3>
-        </div>
-        <p class="step-description">色旗×コードの組み合わせで、小さな子どもでも直感的に音を覚えていける</p>
+        <div class="steps-container">
+          <div class="step">
+            <video class="step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            <div class="step-text">
+              <div class="step-header">
+                <span class="step-number">1</span>
+                <h3 class="step-title">色と和音で楽しくトレーニング</h3>
+              </div>
+              <p class="step-description">色旗×コードの組み合わせで、小さな子どもでも直感的に音を覚えていける</p>
+            </div>
+          </div>
 
-        <div class="step-header">
-          <span class="step-number">2</span>
-          <h3 class="step-title">進捗に応じて和音が増える「育成モード」</h3>
-        </div>
-        <p class="step-description">毎日のがんばりで和音がアンロックされる、ゲーム感覚の育成モード搭載</p>
+          <div class="step">
+            <div class="step-text">
+              <div class="step-header">
+                <span class="step-number">2</span>
+                <h3 class="step-title">進捗に応じて和音が増える「育成モード」</h3>
+              </div>
+              <p class="step-description">毎日のがんばりで和音がアンロックされる、ゲーム感覚の育成モード搭載</p>
+            </div>
+          </div>
 
-        <div class="step-header">
-          <span class="step-number">3</span>
-          <h3 class="step-title">結果は保護者と共有して見守れる</h3>
-        </div>
-        <p class="step-description">分析グラフは未搭載。代わりに、保護者と成績を「共有」できる機能を提供</p>
+          <div class="step">
+            <div class="step-text">
+              <div class="step-header">
+                <span class="step-number">3</span>
+                <h3 class="step-title">結果は保護者と共有して見守れる</h3>
+              </div>
+              <p class="step-description">分析グラフは未搭載。代わりに、保護者と成績を「共有」できる機能を提供</p>
+            </div>
+          </div>
 
-        <div class="step-header">
-          <span class="step-number">4</span>
-          <h3 class="step-title">単音分化モードあり</h3>
+          <div class="step">
+            <div class="step-text">
+              <div class="step-header">
+                <span class="step-number">4</span>
+                <h3 class="step-title">単音分化モードあり</h3>
+              </div>
+              <p class="step-description">和音から単音への移行トレーニングも搭載。柔軟な設定も多数（出題比率、構成音限定など）</p>
+            </div>
+          </div>
         </div>
-        <p class="step-description">和音から単音への移行トレーニングも搭載。柔軟な設定も多数（出題比率、構成音限定など）</p>
 
         <div class="step-cta">
           <button id="step-cta" class="cta-button">アプリの進化を体験してみる</button>

--- a/css/intro.css
+++ b/css/intro.css
@@ -155,6 +155,28 @@ a/* Landing page styles */
   text-orientation: mixed;
 }
 
+.step-video {
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 1em;
+}
+
+.step-text {
+  flex: 1;
+}
+
+@media (min-width: 768px) {
+  .step {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+  .step-video {
+    width: 45%;
+    max-width: 260px;
+    margin: 0 1em 0 0;
+  }
+}
+
 /* ステップ番号とタイトルの行 */
 .step-header {
   display: flex;

--- a/style.css
+++ b/style.css
@@ -1340,6 +1340,28 @@ a/* Landing page styles */
   text-orientation: mixed;
 }
 
+.step-video {
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 1em;
+}
+
+.step-text {
+  flex: 1;
+}
+
+@media (min-width: 768px) {
+  .step {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+  .step-video {
+    width: 45%;
+    max-width: 260px;
+    margin: 0 1em 0 0;
+  }
+}
+
 /* ステップ番号とタイトルの行 */
 .step-header {
   display: flex;


### PR DESCRIPTION
## Summary
- restructure feature steps to support video beside description
- embed training demo video for the first step
- add responsive styles for video/text layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685f528d4bec8323a4eaa77006214431