### PR TITLE
Responsive layout for intro steps

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -76,6 +76,7 @@ export function renderIntroScreen() {
           </div>
 
           <div class="step">
+            <video class="step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
             <div class="step-text">
               <div class="step-header">
                 <span class="step-number">2</span>
@@ -86,6 +87,7 @@ export function renderIntroScreen() {
           </div>
 
           <div class="step">
+            <video class="step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
             <div class="step-text">
               <div class="step-header">
                 <span class="step-number">3</span>
@@ -96,6 +98,7 @@ export function renderIntroScreen() {
           </div>
 
           <div class="step">
+            <video class="step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
             <div class="step-text">
               <div class="step-header">
                 <span class="step-number">4</span>

--- a/css/intro.css
+++ b/css/intro.css
@@ -150,6 +150,7 @@ a/* Landing page styles */
   box-shadow: 0 2px 6px rgba(0,0,0,0.08);
   display: flex;
   flex-direction: column;
+  gap: 1em;
   text-align: left;
   writing-mode: horizontal-tb;
   text-orientation: mixed;
@@ -159,6 +160,8 @@ a/* Landing page styles */
   width: 100%;
   border-radius: 8px;
   margin-bottom: 1em;
+  max-height: 400px;
+  object-fit: contain;
 }
 
 .step-text {

--- a/style.css
+++ b/style.css
@@ -1335,6 +1335,7 @@ a/* Landing page styles */
   box-shadow: 0 2px 6px rgba(0,0,0,0.08);
   display: flex;
   flex-direction: column;
+  gap: 1em;
   text-align: left;
   writing-mode: horizontal-tb;
   text-orientation: mixed;
@@ -1344,6 +1345,8 @@ a/* Landing page styles */
   width: 100%;
   border-radius: 8px;
   margin-bottom: 1em;
+  max-height: 400px;
+  object-fit: contain;
 }
 
 .step-text {


### PR DESCRIPTION
## Summary
- show smartphone demo videos for all four steps
- adjust step layout styles for responsive column/row
- limit step video height with object-fit

## Testing
- `npm run reset-expired-premiums` *(fails: Cannot find package '@supabase/supabase-js' imported)*

------
https://chatgpt.com/codex/tasks/task_b_685f56ecdb9c8323af1f1e3ea9a883ae