### PR TITLE
Fix intro step style conflicts

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -63,53 +63,53 @@ export function renderIntroScreen() {
       <section class="features">
         <h2>4ステップで身につく絶対音感</h2>
 
-        <div class="steps-container">
-          <div class="step">
-            <video class="step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
-            <div class="step-text">
-              <div class="step-header">
-                <span class="step-number">1</span>
-                <h3 class="step-title">色と和音で楽しくトレーニング</h3>
+        <div class="intro-steps-container">
+          <div class="intro-step">
+            <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            <div class="intro-step-text">
+              <div class="intro-step-header">
+                <span class="intro-step-number">1</span>
+                <h3 class="intro-step-title">色と和音で楽しくトレーニング</h3>
               </div>
-              <p class="step-description">色旗×コードの組み合わせで、小さな子どもでも直感的に音を覚えていける</p>
+              <p class="intro-step-description">色旗×コードの組み合わせで、小さな子どもでも直感的に音を覚えていける</p>
             </div>
           </div>
 
-          <div class="step">
-            <video class="step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
-            <div class="step-text">
-              <div class="step-header">
-                <span class="step-number">2</span>
-                <h3 class="step-title">進捗に応じて和音が増える「育成モード」</h3>
+          <div class="intro-step">
+            <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            <div class="intro-step-text">
+              <div class="intro-step-header">
+                <span class="intro-step-number">2</span>
+                <h3 class="intro-step-title">進捗に応じて和音が増える「育成モード」</h3>
               </div>
-              <p class="step-description">毎日のがんばりで和音がアンロックされる、ゲーム感覚の育成モード搭載</p>
+              <p class="intro-step-description">毎日のがんばりで和音がアンロックされる、ゲーム感覚の育成モード搭載</p>
             </div>
           </div>
 
-          <div class="step">
-            <video class="step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
-            <div class="step-text">
-              <div class="step-header">
-                <span class="step-number">3</span>
-                <h3 class="step-title">結果は保護者と共有して見守れる</h3>
+          <div class="intro-step">
+            <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            <div class="intro-step-text">
+              <div class="intro-step-header">
+                <span class="intro-step-number">3</span>
+                <h3 class="intro-step-title">結果は保護者と共有して見守れる</h3>
               </div>
-              <p class="step-description">分析グラフは未搭載。代わりに、保護者と成績を「共有」できる機能を提供</p>
+              <p class="intro-step-description">分析グラフは未搭載。代わりに、保護者と成績を「共有」できる機能を提供</p>
             </div>
           </div>
 
-          <div class="step">
-            <video class="step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
-            <div class="step-text">
-              <div class="step-header">
-                <span class="step-number">4</span>
-                <h3 class="step-title">単音分化モードあり</h3>
+          <div class="intro-step">
+            <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            <div class="intro-step-text">
+              <div class="intro-step-header">
+                <span class="intro-step-number">4</span>
+                <h3 class="intro-step-title">単音分化モードあり</h3>
               </div>
-              <p class="step-description">和音から単音への移行トレーニングも搭載。柔軟な設定も多数（出題比率、構成音限定など）</p>
+              <p class="intro-step-description">和音から単音への移行トレーニングも搭載。柔軟な設定も多数（出題比率、構成音限定など）</p>
             </div>
           </div>
         </div>
 
-        <div class="step-cta">
+        <div class="intro-step-cta">
           <button id="step-cta" class="cta-button">アプリの進化を体験してみる</button>
         </div>
       </section>

--- a/css/intro.css
+++ b/css/intro.css
@@ -139,7 +139,7 @@ a/* Landing page styles */
   background: #fffaf5;
 }
 
-.steps-container {
+.intro-steps-container {
   display: flex;
   flex-direction: column;
   gap: 2em;
@@ -148,7 +148,7 @@ a/* Landing page styles */
 }
 
 /* 各ステップ */
-.step {
+.intro-step {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
@@ -162,7 +162,7 @@ a/* Landing page styles */
   text-orientation: mixed;
 }
 
-.step-video {
+.intro-step-video {
   width: 180px;
   min-height: 280px;
   object-fit: contain;
@@ -171,23 +171,23 @@ a/* Landing page styles */
   flex-shrink: 0;
 }
 
-.step-text {
+.intro-step-text {
   flex: 1;
   min-width: 200px;
 }
 
 @media (max-width: 600px) {
-  .step {
+  .intro-step {
     flex-direction: column;
     align-items: center;
     text-align: center;
   }
 
-  .step-text {
+  .intro-step-text {
     text-align: left;
   }
 
-  .step-video {
+  .intro-step-video {
     width: 100%;
     max-width: 300px;
     min-height: 200px;
@@ -195,7 +195,7 @@ a/* Landing page styles */
 }
 
 /* ステップ番号とタイトルの行 */
-.step-header {
+.intro-step-header {
   display: flex;
   align-items: center;
   gap: 0.8em;
@@ -204,7 +204,7 @@ a/* Landing page styles */
 
 
 /* ステップ番号 */
-.step-number {
+.intro-step-number {
   background: orange;
   color: white;
   font-size: 1.2rem;
@@ -215,7 +215,7 @@ a/* Landing page styles */
 }
 
 /* ステップタイトル */
-.step-title {
+.intro-step-title {
   font-size: 1.2rem;
   font-weight: bold;
   margin: 0;
@@ -223,19 +223,19 @@ a/* Landing page styles */
 }
 
 /* 説明文（step-description） */
-.step-description {
+.intro-step-description {
   font-size: 1rem;
   margin: 0.5em 0 0;
   color: #444;
 }
 
 /* CTAボタン */
-.step-cta {
+.intro-step-cta {
   text-align: center;
   margin-top: 2em;
 }
 
-.step-cta .cta-button {
+.intro-step-cta .cta-button {
   background-color: var(--color-primary);
   color: #fff;
   border: none;
@@ -246,15 +246,15 @@ a/* Landing page styles */
   transition: background-color 0.3s ease;
 }
 
-.step-cta .cta-button:hover {
+.intro-step-cta .cta-button:hover {
   background-color: #e57c00;
 }
 
 
-.step,
-.step-text,
-.step-title,
-.step-description {
+.intro-step,
+.intro-step-text,
+.intro-step-title,
+.intro-step-description {
   writing-mode: horizontal-tb !important;
   text-orientation: mixed;
 }


### PR DESCRIPTION
## Summary
- avoid class name collisions between intro page and app styles
- prefix intro page step classes with `intro-`

## Testing
- `npm run` *(fails: Unknown env config)*

------
https://chatgpt.com/codex/tasks/task_b_685f710a75248323b0a86b0f33b1cdc8