### PR TITLE
Fix intro video layout

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -164,7 +164,8 @@ a/* Landing page styles */
 
 .intro-step-video {
   width: 180px;
-  height: 280px;
+  min-height: 280px;
+  height: 100%;
   object-fit: cover;
   border-radius: 8px;
   background: #000;


### PR DESCRIPTION
## Summary
- remove fixed height on intro-step-video to fill container

## Testing
- `npm run reset-expired-premiums` *(fails: cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_b_685f9e47cedc83239cf8c5d4f66c3a96