### PR TITLE
Fix intro video container alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -1335,6 +1335,7 @@ a/* Landing page styles */
   box-shadow: 0 2px 6px rgba(0,0,0,0.08);
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 1em;
   text-align: left;
   writing-mode: horizontal-tb;
@@ -1342,11 +1343,13 @@ a/* Landing page styles */
 }
 
 .intro-step-video {
-  width: 100%;
+  width: 180px;
+  height: 280px;
   border-radius: 8px;
   margin-bottom: 1em;
-  max-height: 400px;
   object-fit: cover;
+  background: #000;
+  flex-shrink: 0;
 }
 
 .intro-step-text {


### PR DESCRIPTION
## Summary
- prevent flexbox stretch on `.intro-step`
- restore fixed dimensions for `.intro-step-video`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685fa347139c8323ba4c39e8b8d2b97f