### PR TITLE
Fix video letterboxing with responsive wrapper

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -65,7 +65,9 @@ export function renderIntroScreen() {
 
         <div class="intro-steps-container">
           <div class="intro-step">
-            <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            <div class="intro-step-video-wrapper">
+              <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            </div>
             <div class="intro-step-text">
               <div class="intro-step-header">
                 <span class="intro-step-number">1</span>
@@ -76,7 +78,9 @@ export function renderIntroScreen() {
           </div>
 
           <div class="intro-step">
-            <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            <div class="intro-step-video-wrapper">
+              <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            </div>
             <div class="intro-step-text">
               <div class="intro-step-header">
                 <span class="intro-step-number">2</span>
@@ -87,7 +91,9 @@ export function renderIntroScreen() {
           </div>
 
           <div class="intro-step">
-            <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            <div class="intro-step-video-wrapper">
+              <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            </div>
             <div class="intro-step-text">
               <div class="intro-step-header">
                 <span class="intro-step-number">3</span>
@@ -98,7 +104,9 @@ export function renderIntroScreen() {
           </div>
 
           <div class="intro-step">
-            <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            <div class="intro-step-video-wrapper">
+              <video class="intro-step-video" src="videos/training-demo.mp4" autoplay loop muted playsinline></video>
+            </div>
             <div class="intro-step-text">
               <div class="intro-step-header">
                 <span class="intro-step-number">4</span>

--- a/css/intro.css
+++ b/css/intro.css
@@ -162,13 +162,20 @@ a/* Landing page styles */
   text-orientation: mixed;
 }
 
-.intro-step-video {
+
+.intro-step-video-wrapper {
   width: 180px;
-  height: 280px;
-  object-fit: cover;
+  aspect-ratio: 9 / 16;
   border-radius: 8px;
+  overflow: hidden;
   background: #000;
   flex-shrink: 0;
+}
+
+.intro-step-video-wrapper .intro-step-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .intro-step-text {
@@ -187,11 +194,9 @@ a/* Landing page styles */
     text-align: left;
   }
 
-  .intro-step-video {
+  .intro-step-video-wrapper {
     width: 100%;
     max-width: 320px;
-    height: auto;
-    object-fit: cover;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1342,14 +1342,20 @@ a/* Landing page styles */
   text-orientation: mixed;
 }
 
-.intro-step-video {
+.intro-step-video-wrapper {
   width: 180px;
-  height: 280px;
+  aspect-ratio: 9 / 16;
   border-radius: 8px;
+  overflow: hidden;
   margin-bottom: 1em;
-  object-fit: cover;
   background: #000;
   flex-shrink: 0;
+}
+
+.intro-step-video-wrapper .intro-step-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .intro-step-text {
@@ -1361,7 +1367,7 @@ a/* Landing page styles */
     flex-direction: row;
     align-items: flex-start;
   }
-  .intro-step-video {
+  .intro-step-video-wrapper {
     width: 45%;
     max-width: 260px;
     margin: 0 1em 0 0;
@@ -1451,10 +1457,18 @@ a/* Landing page styles */
   }
 }
 
-.features .intro-step-video {
+.features .intro-step-video-wrapper {
   min-height: 200px;
   width: 280px;
-  height: 180px;
+  aspect-ratio: 9 / 16;
+  overflow: hidden;
+  border-radius: 8px;
+  background: #000;
+}
+
+.features .intro-step-video-wrapper .intro-step-video {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
 }
 


### PR DESCRIPTION
## Summary
- wrap intro videos in a new `.intro-step-video-wrapper`
- add responsive CSS with `aspect-ratio` to prevent letterboxing
- update shared stylesheet to match new structure

## Testing
- `npm test` *(fails: Missing script)*
- `npm run reset-expired-premiums` *(fails: Cannot find package)*


------
https://chatgpt.com/codex/tasks/task_b_685fa7a5d3b08323b2e80096790a6b77