### PR TITLE
Fix intro step card layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -1321,10 +1321,16 @@ a/* Landing page styles */
 /* 4ステップの横並びスタイル修正 */
 .intro-steps-container {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, 1fr);
   gap: 1.5em;
   max-width: 600px;
   margin: 0 auto;
+}
+
+@media (max-width: 767px) {
+  .intro-steps-container {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* 各ステップ */
@@ -1335,17 +1341,17 @@ a/* Landing page styles */
   box-shadow: 0 2px 6px rgba(0,0,0,0.08);
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: 1em;
-  text-align: left;
+  text-align: center;
   writing-mode: horizontal-tb;
   text-orientation: mixed;
 }
 
 .intro-step-video-wrapper {
   width: 100%;
-  max-width: 180px;
-  aspect-ratio: 412 / 915;
+  max-width: 260px;
+  aspect-ratio: 9 / 16;
   border-radius: 8px;
   overflow: hidden;
   margin-bottom: 1em;
@@ -1361,24 +1367,19 @@ a/* Landing page styles */
 
 .intro-step-text {
   flex: 1;
+  text-align: center;
 }
 
 @media (min-width: 768px) {
   .intro-step {
-    flex-direction: row;
-    align-items: flex-start;
-  }
-  .intro-step-video-wrapper {
-    width: 45%;
-    max-width: 260px;
-    margin: 0 1em 0 0;
+    flex-direction: column;
   }
 }
 
 /* ステップ番号とタイトルの行 */
 .intro-step-header {
   display: flex;
-  justify-content: flex-start; /* ←中央から左揃えに変更 */
+  justify-content: center;
   align-items: center;
   gap: 0.6em;
   margin: 1em auto 0.2em auto;
@@ -1418,7 +1419,7 @@ a/* Landing page styles */
   font-size: 1rem;
   color: #555;
   line-height: 1.6;
-  text-align: left;  /* ←左寄せ */
+  text-align: center;
 }
 
 /* CTAボタン */
@@ -1460,10 +1461,9 @@ a/* Landing page styles */
 }
 
 .features .intro-step-video-wrapper {
-  min-height: 200px;
-  width: 66%;
-  max-width: 186px;
-  aspect-ratio: 412 / 915;
+  width: 100%;
+  max-width: 260px;
+  aspect-ratio: 9 / 16;
   overflow: hidden;
   border-radius: 8px;
   background: #000;


### PR DESCRIPTION
## Summary
- adjust layout for intro-step cards with responsive two-column grid
- standardize video wrapper size and aspect ratio
- center step text and headers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685fb3f2b77483238a76c04be666ab0e