### PR TITLE
Update intro-step responsive styles

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -150,22 +150,24 @@ a/* Landing page styles */
 /* 各ステップ */
 .intro-step {
   display: flex;
-  flex-direction: row;
-  align-items: flex-start;
+  flex-direction: column;
+  align-items: center;
   gap: 1.5em;
   background: #fff;
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
   padding: 1.5em;
   flex-wrap: wrap;
   writing-mode: horizontal-tb;
   text-orientation: mixed;
+  text-align: center;
 }
 
 
 .intro-step-video-wrapper {
-  width: 180px;
-  aspect-ratio: 9 / 16;
+  width: 100%;
+  max-width: 260px;
+  aspect-ratio: 412 / 915;
   border-radius: 8px;
   overflow: hidden;
   background: #000;
@@ -197,6 +199,18 @@ a/* Landing page styles */
   .intro-step-video-wrapper {
     width: 100%;
     max-width: 320px;
+  }
+}
+
+@media (min-width: 768px) {
+  .intro-step {
+    flex-direction: row;
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .intro-step-text {
+    text-align: left;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1338,7 +1338,7 @@ a/* Landing page styles */
   background: #fff;
   padding: 1.2em;
   border-radius: 12px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1351,7 +1351,7 @@ a/* Landing page styles */
 .intro-step-video-wrapper {
   width: 100%;
   max-width: 260px;
-  aspect-ratio: 9 / 16;
+  aspect-ratio: 412 / 915;
   border-radius: 8px;
   overflow: hidden;
   margin-bottom: 1em;
@@ -1372,7 +1372,13 @@ a/* Landing page styles */
 
 @media (min-width: 768px) {
   .intro-step {
-    flex-direction: column;
+    flex-direction: row;
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .intro-step-text {
+    text-align: left;
   }
 }
 
@@ -1456,6 +1462,9 @@ a/* Landing page styles */
 
 @media (min-width: 768px) {
   .features .intro-step {
+    flex-direction: row;
+    align-items: flex-start;
+    text-align: left;
     gap: 2em;
   }
 }
@@ -1463,7 +1472,7 @@ a/* Landing page styles */
 .features .intro-step-video-wrapper {
   width: 100%;
   max-width: 260px;
-  aspect-ratio: 9 / 16;
+  aspect-ratio: 412 / 915;
   overflow: hidden;
   border-radius: 8px;
   background: #000;


### PR DESCRIPTION
## Summary
- tweak `.intro-step` layout so cards display vertically on mobile and horizontally on desktop
- maintain vertical phone screen aspect ratio
- align text left on large screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685fb7d6a2c88323b81d7346f774bf67