### PR TITLE
Fix PC layout for intro steps

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -207,10 +207,24 @@ a/* Landing page styles */
     flex-direction: row;
     align-items: flex-start;
     text-align: left;
+    gap: 2em;
+    flex-wrap: nowrap;
+  }
+
+  .intro-step-video-wrapper {
+    max-width: 220px;
+    aspect-ratio: 412 / 915;
   }
 
   .intro-step-text {
+    flex: 1;
     text-align: left;
+    min-width: 0;
+    word-break: break-word;
+  }
+
+  .intro-step-header {
+    align-items: center;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1375,10 +1375,24 @@ a/* Landing page styles */
     flex-direction: row;
     align-items: flex-start;
     text-align: left;
+    gap: 2em;
+    flex-wrap: nowrap;
+  }
+
+  .intro-step-video-wrapper {
+    max-width: 220px;
+    aspect-ratio: 412 / 915;
   }
 
   .intro-step-text {
+    flex: 1;
     text-align: left;
+    min-width: 0;
+    word-break: break-word;
+  }
+
+  .intro-step-header {
+    align-items: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak desktop layout of intro steps to avoid overflow

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_685fc1c9c8808323b64963378dd382e1