### PR TITLE
Fix intro page PC layout

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -203,9 +203,15 @@ a/* Landing page styles */
 }
 
 @media (min-width: 768px) {
+  .intro-steps-container {
+    flex-direction: column;
+    gap: 3em;
+  }
+
   .intro-step {
     flex-direction: row;
     align-items: flex-start;
+    justify-content: center;
     text-align: left;
     gap: 2em;
     flex-wrap: nowrap;
@@ -224,7 +230,11 @@ a/* Landing page styles */
   }
 
   .intro-step-header {
+    display: flex;
     align-items: center;
+    justify-content: flex-start;
+    gap: 0.8em;
+    margin-bottom: 0.5em;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1371,15 +1371,23 @@ a/* Landing page styles */
 }
 
 @media (min-width: 768px) {
+  .intro-steps-container {
+    display: flex;
+    flex-direction: column;
+    gap: 3em;
+  }
+
   .intro-step {
     flex-direction: row;
     align-items: flex-start;
+    justify-content: center;
     text-align: left;
     gap: 2em;
     flex-wrap: nowrap;
   }
 
   .intro-step-video-wrapper {
+    flex-shrink: 0;
     max-width: 220px;
     aspect-ratio: 412 / 915;
   }
@@ -1392,7 +1400,11 @@ a/* Landing page styles */
   }
 
   .intro-step-header {
+    display: flex;
     align-items: center;
+    justify-content: flex-start;
+    gap: 0.8em;
+    margin-bottom: 0.5em;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak PC layout for intro steps on the landing page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685fc81132988323b925a9980adf30fb