### PR TITLE
Restore debug UI

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -382,7 +382,6 @@ function drawQuizScreen() {
   debugAnswer.style.right = "10px";
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
-  debugAnswer.style.display = "none";
 
   const unknownBtn = document.createElement("button");
   unknownBtn.id = "unknownBtn";

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -254,7 +254,6 @@ function drawQuizScreen() {
   debugAnswer.style.right = "10px";
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
-  debugAnswer.style.display = "none";
 
   const unknownBtn = document.createElement("button");
   unknownBtn.id = "unknownBtn";

--- a/components/training_easy_note.js
+++ b/components/training_easy_note.js
@@ -46,7 +46,6 @@ export async function renderTrainingScreen(user) {
   debugAnswer.style.right = "10px";
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
-  debugAnswer.style.display = "none";
   app.appendChild(debugAnswer);
   app.appendChild(bottomWrap);
 

--- a/components/training_full.js
+++ b/components/training_full.js
@@ -44,7 +44,6 @@ export async function renderTrainingScreen(user) {
   debugAnswer.style.right = "10px";
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
-  debugAnswer.style.display = "none";
   app.appendChild(debugAnswer);
   app.appendChild(bottomWrap);
 

--- a/components/training_white_keys.js
+++ b/components/training_white_keys.js
@@ -46,7 +46,6 @@ export async function renderTrainingScreen(user) {
   debugAnswer.style.right = "10px";
   debugAnswer.style.fontSize = "0.9em";
   debugAnswer.style.color = "gray";
-  debugAnswer.style.display = "none";
   app.appendChild(debugAnswer);
   app.appendChild(bottomWrap);
 

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -140,7 +140,6 @@ export async function renderGrowthScreen(user) {
   // 🛠 デバッグ機能
   const debugPanel = document.createElement("div");
   debugPanel.style.marginBottom = "1em";
-  debugPanel.style.display = "none";
 
   const actionSelect = document.createElement("select");
   [


### PR DESCRIPTION
## Summary
- show debug information again in chord training screens
- display growth screen debug panel

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685fd13b28ec8323a24b4ebb72d106db