### PR TITLE
Revamp intro step cards

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -61,16 +61,16 @@ export function renderIntroScreen() {
       </section>
 
       <section class="features">
-        <h2>4ステップで身につく絶対音感</h2>
+        <h2 class="features-heading">4ステップで身につく絶対音感</h2>
 
         <div class="intro-steps-container">
           <div class="intro-step">
+            <div class="step-badge step1">🟡 Step 1</div>
             <div class="intro-step-video-wrapper">
               <video class="intro-step-video" src="/videos/training-demo.webm" autoplay muted loop playsinline></video>
             </div>
             <div class="intro-step-text">
               <div class="intro-step-header">
-                <span class="intro-step-number">1</span>
                 <h3 class="intro-step-title">色と和音で楽しくトレーニング</h3>
               </div>
               <p class="intro-step-description">色旗×コードの組み合わせで、小さな子どもでも直感的に音を覚えていける</p>
@@ -78,12 +78,12 @@ export function renderIntroScreen() {
           </div>
 
           <div class="intro-step">
+            <div class="step-badge step2">🟣 Step 2</div>
             <div class="intro-step-video-wrapper">
               <video class="intro-step-video" src="/videos/growth-mode-demo.webm" autoplay muted loop playsinline></video>
             </div>
             <div class="intro-step-text">
               <div class="intro-step-header">
-                <span class="intro-step-number">2</span>
                 <h3 class="intro-step-title">進捗に応じて和音が増える「育成モード」</h3>
               </div>
               <p class="intro-step-description">毎日のがんばりで和音がアンロックされる、ゲーム感覚の育成モード搭載</p>
@@ -91,12 +91,12 @@ export function renderIntroScreen() {
           </div>
 
           <div class="intro-step">
+            <div class="step-badge step3">🔵 Step 3</div>
             <div class="intro-step-video-wrapper">
               <video class="intro-step-video" src="/videos/analysis-screen-demo.webm" autoplay muted loop playsinline></video>
             </div>
             <div class="intro-step-text">
               <div class="intro-step-header">
-                <span class="intro-step-number">3</span>
                 <h3 class="intro-step-title">結果は保護者と共有して見守れる</h3>
               </div>
               <p class="intro-step-description">トレーニング結果をさかのぼれる！分析結果を保護者と成績を「共有」できる機能を提供</p>
@@ -104,12 +104,12 @@ export function renderIntroScreen() {
           </div>
 
           <div class="intro-step">
+            <div class="step-badge step4">🟢 Step 4</div>
             <div class="intro-step-video-wrapper">
               <video class="intro-step-video" src="/videos/settings-screen-demo.webm" autoplay muted loop playsinline></video>
             </div>
             <div class="intro-step-text">
               <div class="intro-step-header">
-                <span class="intro-step-number">4</span>
                 <h3 class="intro-step-title">単音分化モード・設定も柔軟に</h3>
               </div>
               <p class="intro-step-description">和音から単音への移行トレーニングも搭載。柔軟な設定も多数（出題数、出題和音など）</p>

--- a/style.css
+++ b/style.css
@@ -1318,6 +1318,12 @@ a/* Landing page styles */
   text-align: center;
 }
 
+.features-heading {
+  font-size: 2rem;
+  text-align: center;
+  margin-bottom: 1.5em;
+}
+
 /* 4ステップの横並びスタイル修正 */
 .intro-steps-container {
   display: grid;
@@ -1347,6 +1353,7 @@ a/* Landing page styles */
   padding: 1.2em;
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  border: 3px solid #ddd;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1354,6 +1361,17 @@ a/* Landing page styles */
   text-align: center;
   writing-mode: horizontal-tb;
   text-orientation: mixed;
+}
+
+.step-badge {
+  align-self: center;
+  background: #fff;
+  border: 2px solid var(--color-primary);
+  border-radius: 999px;
+  padding: 0.2em 0.8em;
+  font-size: 0.9rem;
+  font-weight: bold;
+  margin-bottom: 0.5em;
 }
 
 .intro-step-video-wrapper {
@@ -1433,7 +1451,7 @@ a/* Landing page styles */
 .intro-step-description {
   max-width: 600px;
   margin: 0.2em auto 1em auto;
-  font-size: 1rem;
+  font-size: 0.95rem;
   color: #555;
   line-height: 1.6;
   text-align: center;


### PR DESCRIPTION
## Summary
- improve the landing page "4ステップ" section
- add badge titles for each step and tweak copy layout
- adjust styles for new card borders, badge, heading and description size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685ffd7d68bc8323a1799a3204bec7ad