### PR TITLE
Group quiz setting controls at top

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -78,19 +78,14 @@ export async function renderSettingsScreen(user) {
   titleLine.className = "header-title-line";
   titleLine.innerHTML = `🎼 <strong>出題設定</strong> <span id="total-count">累計出題回数: 0 回</span>`;
 
-  const buttonGroup = document.createElement("div");
-const resetBtn = document.createElement("button");
-resetBtn.className = "shadow-button";
-resetBtn.innerHTML = "✅ 推奨出題";
-resetBtn.onclick = () => {
-  showCustomConfirm("本当に推奨出題にしますか？", () => {
-    resetToRecommendedChords(unlockedKeys, user); // ← user を渡す！
-  });
-};
-buttonGroup.appendChild(resetBtn);
-
-  buttonGroup.className = "header-button-group";
-
+  const resetBtn = document.createElement("button");
+  resetBtn.className = "shadow-button";
+  resetBtn.innerHTML = "✅ 推奨出題";
+  resetBtn.onclick = () => {
+    showCustomConfirm("本当に推奨出題にしますか？", () => {
+      resetToRecommendedChords(unlockedKeys, user); // ← user を渡す！
+    });
+  };
 
   const bulkDropdown = document.createElement("select");
   bulkDropdown.innerHTML = `
@@ -114,11 +109,6 @@ buttonGroup.appendChild(resetBtn);
     });
     updateSelection();
   };
-
-  buttonGroup.appendChild(bulkDropdown);
-  headerBar.appendChild(titleLine);
-  headerBar.appendChild(buttonGroup);
-  container.appendChild(headerBar);
 
   const singleWrap = document.createElement('label');
   singleWrap.className = 'toggle-wrap';
@@ -150,7 +140,6 @@ buttonGroup.appendChild(resetBtn);
   singleLabel.className = 'toggle-label';
   singleLabel.innerHTML = '🎵 単音分化モード';
   singleWrap.appendChild(singleLabel);
-  container.appendChild(singleWrap);
 
   const singleSelectWrap = document.createElement('div');
   singleSelectWrap.className = 'single-note-select-wrap';
@@ -167,7 +156,17 @@ buttonGroup.appendChild(resetBtn);
   };
   singleSelectWrap.appendChild(singleSelectLabel);
   singleSelectWrap.appendChild(singleSelect);
-  container.appendChild(singleSelectWrap);
+
+  const controlBar = document.createElement('div');
+  controlBar.className = 'settings-controls';
+  controlBar.appendChild(titleLine);
+  controlBar.appendChild(singleWrap);
+  controlBar.appendChild(singleSelectWrap);
+  controlBar.appendChild(resetBtn);
+  controlBar.appendChild(bulkDropdown);
+
+  headerBar.appendChild(controlBar);
+  container.appendChild(headerBar);
 
   const mainSection = document.createElement("div");
   mainSection.className = "main-section";

--- a/css/settings.css
+++ b/css/settings.css
@@ -163,20 +163,21 @@
 .header-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   flex-wrap: wrap;
   gap: 0.75em;
   padding: 0.5em 1em;
   max-width: 860px; /* ← 少し狭くて美しい */
   margin: 0 auto;
   box-sizing: border-box;
+  text-align: center;
 }
 
 .header-title-line {
   display: flex;
   align-items: center;
   gap: 1em;
-  font-size: 1.2em;
+  font-size: 1.3em;
   font-weight: bold;
   white-space: nowrap;
 }
@@ -191,6 +192,26 @@
   padding: 6px 12px;
   font-size: 1em;
   height: 2.2em; /* 高さを揃える */
+}
+
+.settings-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75em;
+}
+.settings-controls button,
+.settings-controls select {
+  padding: 6px 12px;
+  font-size: 1em;
+  height: 2.2em;
+}
+.settings-controls .toggle-wrap {
+  height: 2.2em;
+  margin: 0;
+  display: flex;
+  align-items: center;
 }
 
 .header-title-line #total-count {

--- a/style.css
+++ b/style.css
@@ -2577,20 +2577,21 @@ a/* Landing page styles */
 .header-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   flex-wrap: wrap;
   gap: 0.75em;
   padding: 0.5em 1em;
   max-width: 860px; /* ← 少し狭くて美しい */
   margin: 0 auto;
   box-sizing: border-box;
+  text-align: center;
 }
 
 .header-title-line {
   display: flex;
   align-items: center;
   gap: 1em;
-  font-size: 1.2em;
+  font-size: 1.3em;
   font-weight: bold;
   white-space: nowrap;
 }
@@ -2605,6 +2606,26 @@ a/* Landing page styles */
   padding: 6px 12px;
   font-size: 1em;
   height: 2.2em; /* 高さを揃える */
+}
+
+.settings-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75em;
+}
+.settings-controls button,
+.settings-controls select {
+  padding: 6px 12px;
+  font-size: 1em;
+  height: 2.2em;
+}
+.settings-controls .toggle-wrap {
+  height: 2.2em;
+  margin: 0;
+  display: flex;
+  align-items: center;
 }
 
 .header-title-line #total-count {


### PR DESCRIPTION
## Summary
- group quiz setting controls under a new flex container
- center layout of the header bar and enlarge the title
- match styles in css/settings.css

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685ffd8de98c832389a5e58790abee1c