### PR TITLE
Refine intro screen layout

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -41,7 +41,7 @@ export function renderIntroScreen() {
         <h1 class="hero-title">絶対音感はもう、<br>特別な才能じゃない。</h1>
         <p class="hero-sub">遊びながら耳を育てる、新しいトレーニングのかたち。</p>
         <p class="note">※推奨対象年齢：2歳半〜6歳</p>
-        <p class="hero-highlight">＼遊びながら“聴く力”が伸びる！／</p>
+        <p class="hero-highlight">＼遊びながら“聴く力”が<span class="accent">伸びる！</span>／</p>
         <div class="hero-visual">
           <img src="images/otolon.webp" alt="アプリ画面イメージ" />
         </div>
@@ -180,10 +180,12 @@ export function renderIntroScreen() {
 
       <section class="age-info">
         <h2>なぜ2歳半〜6歳が絶対音感の適齢期なの？</h2>
-        <p>絶対音感の習得は、生まれつきの才能ではなく、「何歳のうちに訓練を始めたか」が大きく関係しています。一般に、2歳半〜6歳頃までは「耳の臨界期」と呼ばれ、音の高さや響きの違いを区別する力が自然に育ちやすい時期とされています。</p>
-        <p>この時期に、楽しく・繰り返し・感覚的に音を聴く体験を積むことで、音の記憶や聴き分け能力が脳内に定着しやすくなるのです。</p>
-        <p>一方で、7歳以降になると相対音感に頼る傾向が強まり、絶対音感の習得が難しくなることが多いとされています。</p>
-        <p>そのため、「楽しく遊びながら耳を育てられる」時期にスタートすることがとても大切なのです。<br>※この臨界期の考え方は、日本国内の音楽教育法や海外の音楽心理学研究などにおいても広く言及されています。</p>
+        <ul class="age-points">
+          <li><strong>✔ なぜ大切？</strong><br>絶対音感の習得は、生まれつきの才能ではなく、「何歳のうちに訓練を始めたか」が大きく関係しています。一般に2歳半〜6歳頃までは耳の臨界期と呼ばれ、音を区別する力が育ちやすい時期です。</li>
+          <li><strong>✔ 何を鍛えるのか？</strong><br>この時期に楽しく繰り返し音を聴くことで、音の記憶や聴き分け能力が脳内に定着しやすくなります。</li>
+          <li><strong>✔ 7歳以降は？</strong><br>7歳以降になると相対音感に頼る傾向が強まり、絶対音感の習得が難しくなることが多いとされています。</li>
+        </ul>
+        <p class="age-note">そのため、「楽しく遊びながら耳を育てられる」時期にスタートすることがとても大切なのです。<br>※この臨界期の考え方は、日本国内の音楽教育法や海外の音楽心理学研究などにおいても広く言及されています。</p>
       </section>
 
       <section class="faq">
@@ -258,6 +260,10 @@ export function renderIntroScreen() {
 
       <footer class="lp-footer">
         <button id="footer-cta" class="cta-button">気になる方はこちらから無料体験へ！</button>
+        <div class="social-links">
+          <a href="https://x.com/otoron_onkanDev" target="_blank" rel="noopener">X</a>
+          <a href="https://note.com/otoron" target="_blank" rel="noopener">note</a>
+        </div>
         <p>&copy; 2024 Otoron</p>
       </footer>
     </div>

--- a/css/intro.css
+++ b/css/intro.css
@@ -42,9 +42,9 @@ a/* Landing page styles */
   font-size: 1.6em;
   font-weight: bold;
   text-align: center;
-  line-height: 1.6;
+  line-height: 1.65;
   max-width: 90%;
-  margin: 0 auto 0.6em;
+  margin: 0 auto 0.8em;
   word-break: keep-all;
   white-space: normal;
 }
@@ -54,7 +54,7 @@ a/* Landing page styles */
   text-align: center;
   line-height: 1.6;
   max-width: 90%;
-  margin: 0 auto 1em;
+  margin: 0 auto 1.2em;
   color: #333;
 }
 
@@ -68,13 +68,17 @@ a/* Landing page styles */
 
 .hero-highlight {
   font-size: 1.1em;
-  color: var(--color-primary);
+  color: #333;
   font-weight: bold;
   margin-bottom: 1em;
   max-width: 90%;
   text-align: center;
   margin-left: auto;
   margin-right: auto;
+}
+
+.hero-highlight .accent {
+  color: var(--color-primary);
 }
 
 @media (min-width: 768px) {
@@ -105,11 +109,22 @@ a/* Landing page styles */
   margin-top: 1.5em;
   background-color: var(--color-primary);
   color: #fff;
-  border: none;
+  border: 2px solid var(--color-primary-dark);
   border-radius: 8px;
-  padding: 0.6em 1.4em;
+  padding: 0.7em 1.6em;
   font-size: 1.1em;
+  font-weight: bold;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
   cursor: pointer;
+  transition: transform 0.1s ease, background-color 0.3s ease;
+}
+
+.cta-button:hover {
+  background-color: var(--color-primary-dark);
+}
+
+.cta-button:active {
+  transform: scale(0.97);
 }
 
 .problems,
@@ -125,6 +140,20 @@ a/* Landing page styles */
   max-width: 600px;
   margin: 0 auto 2em;
   line-height: 1.6;
+}
+
+.age-info ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1em 0;
+}
+
+.age-info li {
+  margin-bottom: 1em;
+}
+
+.age-note {
+  margin-top: 1em;
 }
 
 .age-info h2 {
@@ -149,6 +178,7 @@ a/* Landing page styles */
 
 /* 各ステップ */
 .intro-step {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -156,11 +186,25 @@ a/* Landing page styles */
   background: #fff;
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-  padding: 1.5em;
+  padding: 2.4em 1.5em 1.5em 1.5em;
   flex-wrap: wrap;
   writing-mode: horizontal-tb;
   text-orientation: mixed;
   text-align: center;
+}
+
+.step-badge {
+  position: absolute;
+  top: -1.2em;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff;
+  border: 2px solid var(--color-primary);
+  border-radius: 999px;
+  padding: 0.2em 0.8em;
+  font-size: 0.9rem;
+  font-weight: bold;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
 
@@ -277,15 +321,18 @@ a/* Landing page styles */
 .intro-step-cta {
   text-align: center;
   margin-top: 2em;
+  padding-bottom: 2em;
+  border-bottom: 2px solid #ffe0b3;
+  margin-bottom: 2em;
 }
 
 .intro-step-cta .cta-button {
   background-color: var(--color-primary);
   color: #fff;
-  border: none;
+  border: 2px solid var(--color-primary-dark);
   border-radius: 8px;
-  padding: 0.8em 2em;
-  font-size: 1.1em;
+  padding: 0.9em 2.2em;
+  font-size: 1.25em;
   cursor: pointer;
   transition: background-color 0.3s ease;
 }
@@ -328,7 +375,7 @@ a/* Landing page styles */
   background: #e6e6e6;
   border-radius: 1.5em;
   padding: 1em 1.5em;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 1.6;
   color: #333;
   max-width: 320px;
@@ -405,6 +452,19 @@ a/* Landing page styles */
 
 .lp-footer .cta-button {
   margin-bottom: 1em;
+}
+
+.social-links {
+  display: flex;
+  justify-content: center;
+  gap: 1em;
+  margin-bottom: 1em;
+}
+
+.social-links a {
+  color: #333;
+  text-decoration: none;
+  font-size: 0.9em;
 }
 
 /* FAQ accordion */

--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@
   --font-main: var(--font-body);
   /* Theming variables */
   --color-primary: #ff9900;
+  --color-primary-dark: #e57c00;
   --color-accent: #FFD44C;
   --color-background: #fff8f0;
   --color-night-bg: #1a1a2a;
@@ -1227,9 +1228,9 @@ a/* Landing page styles */
   font-size: 1.6em;
   font-weight: bold;
   text-align: center;
-  line-height: 1.6;
+  line-height: 1.65;
   max-width: 90%;
-  margin: 0 auto 0.6em;
+  margin: 0 auto 0.8em;
   word-break: keep-all;
   white-space: normal;
 }
@@ -1239,7 +1240,7 @@ a/* Landing page styles */
   text-align: center;
   line-height: 1.6;
   max-width: 90%;
-  margin: 0 auto 1em;
+  margin: 0 auto 1.2em;
   color: #333;
 }
 
@@ -1253,13 +1254,17 @@ a/* Landing page styles */
 
 .hero-highlight {
   font-size: 1.1em;
-  color: var(--color-primary);
+  color: #333;
   font-weight: bold;
   margin-bottom: 1em;
   max-width: 90%;
   text-align: center;
   margin-left: auto;
   margin-right: auto;
+}
+
+.hero-highlight .accent {
+  color: var(--color-primary);
 }
 
 @media (min-width: 768px) {
@@ -1290,11 +1295,22 @@ a/* Landing page styles */
   margin-top: 1.5em;
   background-color: var(--color-primary);
   color: #fff;
-  border: none;
+  border: 2px solid var(--color-primary-dark);
   border-radius: 8px;
-  padding: 0.6em 1.4em;
+  padding: 0.7em 1.6em;
   font-size: 1.1em;
+  font-weight: bold;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
   cursor: pointer;
+  transition: transform 0.1s ease, background-color 0.3s ease;
+}
+
+.cta-button:hover {
+  background-color: var(--color-primary-dark);
+}
+
+.cta-button:active {
+  transform: scale(0.97);
 }
 
 .problems,
@@ -1310,6 +1326,20 @@ a/* Landing page styles */
   max-width: 600px;
   margin: 0 auto 2em;
   line-height: 1.6;
+}
+
+.age-info ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1em 0;
+}
+
+.age-info li {
+  margin-bottom: 1em;
+}
+
+.age-note {
+  margin-top: 1em;
 }
 
 .age-info h2 {
@@ -1349,8 +1379,9 @@ a/* Landing page styles */
 
 /* 各ステップ */
 .intro-step {
+  position: relative;
   background: #fff;
-  padding: 1.2em;
+  padding: 2.4em 1.2em 1.2em 1.2em;
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0,0,0,0.08);
   border: 3px solid #ddd;
@@ -1364,14 +1395,17 @@ a/* Landing page styles */
 }
 
 .step-badge {
-  align-self: center;
+  position: absolute;
+  top: -1.2em;
+  left: 50%;
+  transform: translateX(-50%);
   background: #fff;
   border: 2px solid var(--color-primary);
   border-radius: 999px;
   padding: 0.2em 0.8em;
   font-size: 0.9rem;
   font-weight: bold;
-  margin-bottom: 0.5em;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
 .intro-step-video-wrapper {
@@ -1461,15 +1495,18 @@ a/* Landing page styles */
 .intro-step-cta {
   text-align: center;
   margin-top: 2em;
+  padding-bottom: 2em;
+  border-bottom: 2px solid #ffe0b3;
+  margin-bottom: 2em;
 }
 
 .intro-step-cta .cta-button {
   background-color: var(--color-primary);
   color: #fff;
-  border: none;
+  border: 2px solid var(--color-primary-dark);
   border-radius: 8px;
-  padding: 0.8em 2em;
-  font-size: 1.1em;
+  padding: 0.9em 2.2em;
+  font-size: 1.25em;
   cursor: pointer;
   transition: background-color 0.3s ease;
 }
@@ -1565,7 +1602,7 @@ a/* Landing page styles */
   background: #e6e6e6;
   border-radius: 1.5em;
   padding: 1em 1.5em;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 1.6;
   color: #333;
   max-width: 320px;
@@ -1642,6 +1679,19 @@ a/* Landing page styles */
 
 .lp-footer .cta-button {
   margin-bottom: 1em;
+}
+
+.social-links {
+  display: flex;
+  justify-content: center;
+  gap: 1em;
+  margin-bottom: 1em;
+}
+
+.social-links a {
+  color: #333;
+  text-decoration: none;
+  font-size: 0.9em;
 }
 
 /* FAQ accordion */


### PR DESCRIPTION
## Summary
- enhance hero layout spacing and highlight style
- add offline CSS updates for CTA buttons and step badges
- restructure age info section with bullet list
- provide social links in footer

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6860106671c88323ae4e17f1affbde24