### PR TITLE
Fix layout of pricing cards

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -176,7 +176,7 @@ a/* Landing page styles */
   display: flex;
   flex-direction: column;
   gap: 1em;
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
 }
 
@@ -190,7 +190,7 @@ a/* Landing page styles */
   .intro-pricing .plan-card {
     flex: 1 1 280px;
     max-width: 320px;
-    min-height: 380px;
+    min-height: 320px;
     box-sizing: border-box;
   }
 }

--- a/style.css
+++ b/style.css
@@ -1362,7 +1362,7 @@ a/* Landing page styles */
   display: flex;
   flex-direction: column;
   gap: 1em;
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
 }
 
@@ -1376,7 +1376,7 @@ a/* Landing page styles */
   .intro-pricing .plan-card {
     flex: 1 1 280px;
     max-width: 320px;
-    min-height: 380px;
+    min-height: 320px;
     box-sizing: border-box;
   }
 }
@@ -2122,7 +2122,7 @@ a/* Landing page styles */
   .pricing-page .plan-card {
     flex: 1 1 280px;
     max-width: 320px;
-    min-height: 380px;
+    min-height: 320px;
     box-sizing: border-box;
     align-self: flex-start;
   }


### PR DESCRIPTION
## Summary
- expand width for plan cards on the landing page
- reduce card minimum height so there is less blank space

## Testing
- `npm run` *(shows available commands)*

------
https://chatgpt.com/codex/tasks/task_b_68602ce948bc8323ab2c7e60a26e60b8