### PR TITLE
Update plan button to redirect to signup

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -409,8 +409,14 @@ export function renderIntroScreen() {
       btn.addEventListener('click', () => {
         showCustomAlert(
           'このプランは無料会員登録後にお申し込みいただけます。',
-          () => {
-            window.location.href = 'https://playotoron.com/#signup';
+          async () => {
+            try {
+              await signOut(firebaseAuth);
+              await supabase.auth.signOut();
+            } catch (e) {
+              console.warn('intro logout error', e);
+            }
+            switchScreen('signup');
           }
         );
       });


### PR DESCRIPTION
## Summary
- update intro screen plan selection button callback
- after acknowledging the alert, user is redirected to the signup flow just like pressing the signup button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6860bfe363608323a81ea7467ee7a28e