### PR TITLE
Add hero background to landing page

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -16,12 +16,13 @@ export function renderIntroScreen() {
 
   app.classList.add("with-header");
   app.innerHTML = `
-    <header class="app-header intro-header">
-      <button class="home-icon" id="intro-home-btn">
-        <img src="images/otolon_face.webp" alt="トップへ" />
-      </button>
-      <div class="header-right">
-        <div class="info-menu">
+    <header id="lp-top" class="hero-header">
+      <div class="app-header intro-header">
+        <button class="home-icon" id="intro-home-btn">
+          <img src="images/otolon_face.webp" alt="トップへ" />
+        </button>
+        <div class="header-right">
+          <div class="info-menu">
           <button id="info-menu-btn" aria-label="インフォメーション">ℹ️</button>
           <div id="info-dropdown" class="info-dropdown">
             <button id="terms-btn">利用規約</button>
@@ -36,18 +37,15 @@ export function renderIntroScreen() {
         <button id="login-btn" class="intro-login">ログイン</button>
         <button id="signup-btn" class="intro-signup">無料会員登録</button>
       </div>
-    </header>
-    <div id="lp-top" class="intro-wrapper">
-      <section class="hero">
+      <div class="hero">
         <h1 class="hero-title">絶対音感はもう、<br>特別な才能じゃない。</h1>
         <p class="hero-sub">遊びながら耳を育てる、新しいトレーニングのかたち。</p>
         <p class="note">※推奨対象年齢：2歳半〜6歳</p>
         <p class="hero-highlight">＼遊びながら“聴く力”が<span class="accent">伸びる！</span>／</p>
-        <div class="hero-visual">
-          <img src="images/otolon.webp" alt="アプリ画面イメージ" />
-        </div>
         <button id="hero-cta" class="cta-button">今すぐ無料体験をはじめる！</button>
-      </section>
+      </div>
+    </header>
+    <div class="intro-wrapper">
 
       <section class="problems">
         <p class="trouble-lead">絶対音感に興味はあるけど...</p>

--- a/css/intro.css
+++ b/css/intro.css
@@ -1,4 +1,4 @@
-a/* Landing page styles */
+/* Landing page styles */
 
 .intro-header .header-right {
   display: flex;
@@ -29,6 +29,26 @@ a/* Landing page styles */
 
 .intro-header #signup-btn:hover {
   background-color: #e57c00;
+}
+
+.hero-header {
+  background-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.35)), url("images/otoron_landing_hero.webp");
+  background-size: cover;
+  background-position: center 20%;
+  color: #fff;
+  text-shadow: 0 2px 6px rgba(0,0,0,0.5);
+  margin-top: -56px;
+}
+
+.hero-header .hero {
+  padding: 120px 20px 80px;
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .hero-header .hero {
+    padding: 160px 20px;
+  }
 }
 
 .intro-wrapper {
@@ -98,12 +118,6 @@ a/* Landing page styles */
   }
 }
 
-.hero-visual img {
-  width: 25%;
-  max-width: 200px;
-  margin: 0 auto;
-  display: block;
-}
 
 .cta-button {
   margin-top: 1.5em;

--- a/style.css
+++ b/style.css
@@ -1184,7 +1184,7 @@ button:hover {
     overflow-y: auto;
   }
 }
-a/* Landing page styles */
+/* Landing page styles */
 
 .intro-header .header-right {
   display: flex;
@@ -1215,6 +1215,26 @@ a/* Landing page styles */
 
 .intro-header #signup-btn:hover {
   background-color: #e57c00;
+}
+
+.hero-header {
+  background-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.35)), url("images/otoron_landing_hero.webp");
+  background-size: cover;
+  background-position: center 20%;
+  color: #fff;
+  text-shadow: 0 2px 6px rgba(0,0,0,0.5);
+  margin-top: -56px;
+}
+
+.hero-header .hero {
+  padding: 120px 20px 80px;
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .hero-header .hero {
+    padding: 160px 20px;
+  }
 }
 
 .intro-wrapper {
@@ -1284,12 +1304,6 @@ a/* Landing page styles */
   }
 }
 
-.hero-visual img {
-  width: 25%;
-  max-width: 200px;
-  margin: 0 auto;
-  display: block;
-}
 
 .cta-button {
   margin-top: 1.5em;


### PR DESCRIPTION
## Summary
- integrate hero section into the header
- style hero with background image and gradient overlay
- remove old inline hero image

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6860e3b8847c832398f09a36ad89cfe7