### PR TITLE
Fix hero background layout

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -14,9 +14,15 @@ export function renderIntroScreen() {
 
   document.body.classList.add('intro-scroll');
 
-  app.classList.add("with-header");
   app.innerHTML = `
     <header id="lp-top" class="hero-header">
+      <div class="hero">
+        <h1 class="hero-title">絶対音感はもう、<br>特別な才能じゃない。</h1>
+        <p class="hero-sub">遊びながら耳を育てる、新しいトレーニングのかたち。</p>
+        <p class="note">※推奨対象年齢：2歳半〜6歳</p>
+        <p class="hero-highlight">＼遊びながら“聴く力”が<span class="accent">伸びる！</span>／</p>
+        <button id="hero-cta" class="cta-button">今すぐ無料体験をはじめる！</button>
+      </div>
       <div class="app-header intro-header">
         <button class="home-icon" id="intro-home-btn">
           <img src="images/otolon_face.webp" alt="トップへ" />
@@ -36,13 +42,6 @@ export function renderIntroScreen() {
         </div>
         <button id="login-btn" class="intro-login">ログイン</button>
         <button id="signup-btn" class="intro-signup">無料会員登録</button>
-      </div>
-      <div class="hero">
-        <h1 class="hero-title">絶対音感はもう、<br>特別な才能じゃない。</h1>
-        <p class="hero-sub">遊びながら耳を育てる、新しいトレーニングのかたち。</p>
-        <p class="note">※推奨対象年齢：2歳半〜6歳</p>
-        <p class="hero-highlight">＼遊びながら“聴く力”が<span class="accent">伸びる！</span>／</p>
-        <button id="hero-cta" class="cta-button">今すぐ無料体験をはじめる！</button>
       </div>
     </header>
     <div class="intro-wrapper">

--- a/css/intro.css
+++ b/css/intro.css
@@ -35,19 +35,27 @@
   background-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.35)), url("images/otoron_landing_hero.webp");
   background-size: cover;
   background-position: center 20%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   color: #fff;
   text-shadow: 0 2px 6px rgba(0,0,0,0.5);
-  margin-top: -56px;
+  position: relative;
+  padding-top: 56px; /* app-header height */
 }
 
-.hero-header .hero {
-  padding: 120px 20px 80px;
+.hero {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2em 1em;
   text-align: center;
 }
 
 @media (min-width: 768px) {
-  .hero-header .hero {
-    padding: 160px 20px;
+  .hero {
+    padding: 2em 1em;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1221,20 +1221,22 @@ button:hover {
   background-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.35)), url("images/otoron_landing_hero.webp");
   background-size: cover;
   background-position: center 20%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   color: #fff;
   text-shadow: 0 2px 6px rgba(0,0,0,0.5);
-  margin-top: -56px;
+  position: relative;
+  padding-top: 56px; /* app-header height */
 }
 
-.hero-header .hero {
-  padding: 120px 20px 80px;
+.hero {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2em 1em;
   text-align: center;
-}
-
-@media (min-width: 768px) {
-  .hero-header .hero {
-    padding: 160px 20px;
-  }
 }
 
 .intro-wrapper {


### PR DESCRIPTION
## Summary
- restructure `hero-header` so the hero image spans full viewport
- update CSS for hero header
- drop `with-header` padding on intro page

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_b_6860eb2d111883238c0dbabb2d39b5eb