### PR TITLE
Add responsive landing hero

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -32,18 +32,17 @@
 }
 
 .hero-header {
-  background-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.35)), url("images/otoron_landing_hero.webp");
-  background-size: cover;
-  background-position: center 20%;
-  height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
-  color: #fff;
-  text-shadow: 0 2px 6px rgba(0,0,0,0.5);
-  position: relative;
+  background-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.35)), url("images/otoron_landing_hero.webp");
+  background-size: cover;
+  background-position: center;
+  height: 100vh;
+  padding: 2em 1em;
   padding-top: 56px; /* app-header height */
+  position: relative;
+  color: #333;
 }
 
 .hero {
@@ -53,9 +52,23 @@
   text-align: center;
 }
 
+.hero h1,
+.hero p {
+  text-shadow: 0 2px 4px rgba(255, 255, 255, 0.8);
+}
+
 @media (min-width: 768px) {
+  .hero-header {
+    flex-direction: row;
+    align-items: center;
+    background-position: right center;
+    padding: 4em;
+  }
+
   .hero {
-    padding: 2em 1em;
+    width: 50%;
+    max-width: 600px;
+    padding-right: 2em;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1218,18 +1218,17 @@ button:hover {
 }
 
 .hero-header {
-  background-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.35)), url("images/otoron_landing_hero.webp");
-  background-size: cover;
-  background-position: center 20%;
-  height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
-  color: #fff;
-  text-shadow: 0 2px 6px rgba(0,0,0,0.5);
-  position: relative;
+  background-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.35)), url("images/otoron_landing_hero.webp");
+  background-size: cover;
+  background-position: center;
+  height: 100vh;
+  padding: 2em 1em;
   padding-top: 56px; /* app-header height */
+  position: relative;
+  color: #333;
 }
 
 .hero {
@@ -1237,6 +1236,11 @@ button:hover {
   margin: 0 auto;
   padding: 2em 1em;
   text-align: center;
+}
+
+.hero h1,
+.hero p {
+  text-shadow: 0 2px 4px rgba(255, 255, 255, 0.8);
 }
 
 .intro-wrapper {
@@ -1303,6 +1307,19 @@ button:hover {
 
   .hero-highlight {
     font-size: 1.2em;
+  }
+
+  .hero-header {
+    flex-direction: row;
+    align-items: center;
+    background-position: right center;
+    padding: 4em;
+  }
+
+  .hero {
+    width: 50%;
+    max-width: 600px;
+    padding-right: 2em;
   }
 }
 


### PR DESCRIPTION
## Summary
- style landing hero with otoron_landing_hero.webp
- adjust layout for desktop with flex row and 50% text width
- improve text readability with shadows

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6860f51cb0288323853b94fd3a0c9a8b