### PR TITLE
Fix hero layout for intro page

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -23,6 +23,7 @@ export function renderIntroScreen() {
         <p class="hero-highlight">＼遊びながら“聴く力”が<span class="accent">伸びる！</span>／</p>
         <button id="hero-cta" class="cta-button">今すぐ無料体験をはじめる！</button>
       </div>
+      <img class="hero-photo" src="images/otoron_landing_hero.webp" alt="オトロンで遊ぶ子どもの写真" />
       <div class="app-header intro-header">
         <button class="home-icon" id="intro-home-btn">
           <img src="images/otolon_face.webp" alt="トップへ" />

--- a/css/intro.css
+++ b/css/intro.css
@@ -36,15 +36,12 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.35)), url("images/otoron_landing_hero.webp");
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
   height: 100vh;
   padding: 2em 1em;
   padding-top: 56px; /* app-header height */
   color: #333;
   overflow: hidden;
+  background-color: #fff;
 }
 
 .hero-header::after {
@@ -66,6 +63,12 @@
   text-align: center;
 }
 
+.hero-photo {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
 .hero h1,
 .hero p {
   text-shadow: 0 2px 4px rgba(255, 255, 255, 0.8);
@@ -75,9 +78,6 @@
   .hero-header {
     flex-direction: row;
     align-items: center;
-    background-position: right center;
-    background-size: contain;
-    background-repeat: no-repeat;
     padding: 0 5%;
   }
 
@@ -86,6 +86,14 @@
     max-width: 600px;
     padding-right: 2em;
     text-align: left;
+  }
+
+  .hero-photo {
+    width: 50%;
+    height: 100%;
+    object-fit: cover;
+    -webkit-mask-image: linear-gradient(to left, transparent 0%, black 20%);
+    mask-image: linear-gradient(to left, transparent 0%, black 20%);
   }
 }
 


### PR DESCRIPTION
## Summary
- show hero image as a separate element
- style hero photo so it fades into the text section on desktop

## Testing
- `npm run reset-expired-premiums` *(fails: Cannot find package '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_b_6861010ed5688323a8ab9ebe66ceb382