### PR TITLE
Fix hero image fade with new asset

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -67,6 +67,7 @@
   width: 100%;
   height: auto;
   object-fit: cover;
+  object-position: right center;
   display: block;
 }
 
@@ -94,8 +95,6 @@
     height: 100vh;
     object-fit: cover;
     object-position: right center;
-    -webkit-mask-image: linear-gradient(to left, transparent 0%, black 20%);
-    mask-image: linear-gradient(to left, transparent 0%, black 20%);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1253,6 +1253,7 @@ button:hover {
   width: 100%;
   height: auto;
   object-fit: cover;
+  object-position: right center;
   display: block;
 }
 
@@ -1347,8 +1348,6 @@ button:hover {
     height: 100vh;
     object-fit: cover;
     object-position: right center;
-    -webkit-mask-image: linear-gradient(to left, transparent 0%, black 20%);
-    mask-image: linear-gradient(to left, transparent 0%, black 20%);
   }
 }
 


### PR DESCRIPTION
## Summary
- position hero image so the right side stays focused
- remove CSS masking because the image has pre-applied fade

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686108e92bb4832382d28724d1172e04