### PR TITLE
Update hero header to use background image

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -23,7 +23,6 @@ export function renderIntroScreen() {
         <p class="hero-highlight">＼遊びながら“聴く力”が<span class="accent">伸びる！</span>／</p>
         <button id="hero-cta" class="cta-button">今すぐ無料体験をはじめる！</button>
       </div>
-      <img class="hero-photo" src="images/otoron_landing_hero.webp" alt="オトロンで遊ぶ子どもの写真" />
       <div class="app-header intro-header">
         <button class="home-icon" id="intro-home-btn">
           <img src="images/otolon_face.webp" alt="トップへ" />

--- a/css/intro.css
+++ b/css/intro.css
@@ -42,6 +42,10 @@
   color: #333;
   overflow: hidden;
   background-color: #fff;
+  background-image: url('images/otoron_landing_hero.webp');
+  background-size: cover;
+  background-position: right center;
+  background-repeat: no-repeat;
 }
 
 .hero-header::after {
@@ -64,11 +68,7 @@
 }
 
 .hero-photo {
-  width: 100%;
-  height: auto;
-  object-fit: cover;
-  object-position: right center;
-  display: block;
+  display: none;
 }
 
 .hero h1,
@@ -78,23 +78,14 @@
 
 @media (min-width: 768px) {
   .hero-header {
-    flex-direction: row;
-    align-items: center;
     padding: 0 5%;
+    align-items: flex-start;
   }
 
   .hero {
-    width: 50%;
     max-width: 600px;
     padding-right: 2em;
     text-align: left;
-  }
-
-  .hero-photo {
-    width: 50%;
-    height: 100vh;
-    object-fit: cover;
-    object-position: right center;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1228,6 +1228,10 @@ button:hover {
   color: #333;
   overflow: hidden;
   background-color: #fff;
+  background-image: url('images/otoron_landing_hero.webp');
+  background-size: cover;
+  background-position: right center;
+  background-repeat: no-repeat;
 }
 
 .hero-header::after {
@@ -1250,11 +1254,7 @@ button:hover {
 }
 
 .hero-photo {
-  width: 100%;
-  height: auto;
-  object-fit: cover;
-  object-position: right center;
-  display: block;
+  display: none;
 }
 
 .hero h1,
@@ -1329,25 +1329,16 @@ button:hover {
   }
 
   .hero-header {
-    flex-direction: row;
-    align-items: center;
     padding: 0 5%;
+    align-items: flex-start;
   }
 
   .hero {
-    width: 50%;
     max-width: 600px;
     padding-right: 2em;
     z-index: 2;
     position: relative;
     text-align: left;
-  }
-
-  .hero-photo {
-    width: 50%;
-    height: 100vh;
-    object-fit: cover;
-    object-position: right center;
   }
 }
 


### PR DESCRIPTION
## Summary
- show landing hero image as a background instead of a separate element
- remove unused `<img>` tag in hero markup

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68610b7c01d4832393d5d53537f21df8