### PR TITLE
Adjust hero layout for desktop

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -23,6 +23,7 @@ export function renderIntroScreen() {
         <p class="hero-highlight">＼遊びながら“聴く力”が<span class="accent">伸びる！</span>／</p>
         <button id="hero-cta" class="cta-button">今すぐ無料体験をはじめる！</button>
       </div>
+      <img class="hero-photo" src="images/otoron_landing_hero.webp" alt="" />
       <div class="app-header intro-header">
         <button class="home-icon" id="intro-home-btn">
           <img src="images/otolon_face.webp" alt="トップへ" />

--- a/css/intro.css
+++ b/css/intro.css
@@ -78,14 +78,30 @@
 
 @media (min-width: 768px) {
   .hero-header {
-    padding: 0 5%;
-    align-items: flex-start;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    padding-left: 5vw;
+    gap: 2vw;
+    flex-wrap: wrap;
+    background-image: none;
   }
 
   .hero {
-    max-width: 600px;
-    padding-right: 2em;
+    flex: 1 1 30vw;
+    max-width: 400px;
+    z-index: 2;
     text-align: left;
+  }
+
+  .hero-photo {
+    display: block;
+    width: 70vw;
+    max-width: 960px;
+    height: auto;
+    object-fit: contain;
+    object-position: right center;
+    margin-left: auto;
   }
 }
 
@@ -169,6 +185,12 @@
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
   cursor: pointer;
   transition: transform 0.1s ease, background-color 0.3s ease;
+}
+
+.hero .cta-button {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .cta-button:hover {

--- a/style.css
+++ b/style.css
@@ -1329,16 +1329,31 @@ button:hover {
   }
 
   .hero-header {
-    padding: 0 5%;
-    align-items: flex-start;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    padding-left: 5vw;
+    gap: 2vw;
+    flex-wrap: wrap;
+    background-image: none;
   }
 
   .hero {
-    max-width: 600px;
-    padding-right: 2em;
+    flex: 1 1 30vw;
+    max-width: 400px;
     z-index: 2;
     position: relative;
     text-align: left;
+  }
+
+  .hero-photo {
+    display: block;
+    width: 70vw;
+    max-width: 960px;
+    height: auto;
+    object-fit: contain;
+    object-position: right center;
+    margin-left: auto;
   }
 }
 
@@ -1355,6 +1370,12 @@ button:hover {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
   cursor: pointer;
   transition: transform 0.1s ease, background-color 0.3s ease;
+}
+
+.hero .cta-button {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .cta-button:hover {


### PR DESCRIPTION
## Summary
- add hero image element to intro screen
- style hero section for desktop with new flex layout
- center CTA button within hero area

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68610d81f2688323915c46837c28e168