### PR TITLE
Update hero section layout

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -21,6 +21,7 @@ export function renderIntroScreen() {
         <p class="hero-sub">遊びながら耳を育てる、新しいトレーニングのかたち。</p>
         <p class="note">※推奨対象年齢：2歳半〜6歳</p>
         <p class="hero-highlight">＼遊びながら“聴く力”が<span class="accent">伸びる！</span>／</p>
+        <img class="mato-image" src="images/otolon.webp" alt="まとオトロン" />
         <button id="hero-cta" class="cta-button">今すぐ無料体験をはじめる！</button>
       </div>
       <img class="hero-photo" src="images/otoron_landing_hero.webp" alt="" />
@@ -45,6 +46,7 @@ export function renderIntroScreen() {
         <button id="signup-btn" class="intro-signup">無料会員登録</button>
       </div>
     </header>
+    <p class="app-tagline">絶対音感トレーニングアプリ「オトロン」</p>
     <div class="intro-wrapper">
 
       <section class="problems">

--- a/style.css
+++ b/style.css
@@ -1228,10 +1228,6 @@ button:hover {
   color: #333;
   overflow: hidden;
   background-color: #fff;
-  background-image: url('images/otoron_landing_hero.webp');
-  background-size: cover;
-  background-position: right center;
-  background-repeat: no-repeat;
 }
 
 .hero-header::after {
@@ -1254,7 +1250,26 @@ button:hover {
 }
 
 .hero-photo {
-  display: none;
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  object-position: center top;
+  order: -1;
+  margin-bottom: 1em;
+}
+
+.mato-image {
+  width: 120px;
+  display: block;
+  margin: 0.5em auto;
+}
+
+.app-tagline {
+  text-align: center;
+  font-weight: bold;
+  margin: 1em auto;
+  font-size: 1.2em;
 }
 
 .hero h1,
@@ -1332,6 +1347,8 @@ button:hover {
     flex-direction: row;
     align-items: center;
     justify-content: flex-start;
+    padding-top: 0;
+    padding-right: 0;
     padding-left: 5vw;
     gap: 2vw;
     flex-wrap: wrap;
@@ -1350,10 +1367,20 @@ button:hover {
     display: block;
     width: 70vw;
     max-width: 960px;
-    height: auto;
-    object-fit: contain;
-    object-position: right center;
+    height: 100vh;
+    object-fit: cover;
+    object-position: right top;
     margin-left: auto;
+    order: 0;
+    margin-bottom: 0;
+  }
+
+  .mato-image {
+    width: 160px;
+  }
+
+  .app-tagline {
+    font-size: 1.4em;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust hero layout for desktop so the hero image aligns flush to the edges
- display hero image above the text on small screens
- restore mascot image below the highlight text
- add tagline under the hero section

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686110d26c08832393ed08000a22e9c2