### PR TITLE
Adjust intro screen layout

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -18,6 +18,7 @@ export function renderIntroScreen() {
     <header id="lp-top" class="hero-header">
       <div class="hero">
         <h1 class="hero-title">絶対音感はもう、<br>特別な才能じゃない。</h1>
+        <p class="app-tagline">絶対音感トレーニングアプリ「オトロン」</p>
         <p class="hero-sub">遊びながら耳を育てる、新しいトレーニングのかたち。</p>
         <p class="note">※推奨対象年齢：2歳半〜6歳</p>
         <p class="hero-highlight">＼遊びながら“聴く力”が<span class="accent">伸びる！</span>／</p>
@@ -46,7 +47,6 @@ export function renderIntroScreen() {
         <button id="signup-btn" class="intro-signup">無料会員登録</button>
       </div>
     </header>
-    <p class="app-tagline">絶対音感トレーニングアプリ「オトロン」</p>
     <div class="intro-wrapper">
 
       <section class="problems">
@@ -266,7 +266,7 @@ export function renderIntroScreen() {
       </section>
 
       <footer class="lp-footer">
-        <button id="footer-cta" class="cta-button">気になる方はこちらから無料体験へ！</button>
+        <button id="footer-cta" class="cta-button">気になる方は「オトロン」の無料体験へ！</button>
         <div class="social-links">
           <a href="https://x.com/otoron_onkanDev" target="_blank" rel="noopener">
             <img src="images/x-logo.png" alt="Xのロゴ" />

--- a/style.css
+++ b/style.css
@@ -1368,8 +1368,8 @@ button:hover {
     width: 70vw;
     max-width: 960px;
     height: 100vh;
-    object-fit: cover;
-    object-position: right top;
+    object-fit: contain;
+    object-position: center top;
     margin-left: auto;
     order: 0;
     margin-bottom: 0;
@@ -1421,7 +1421,8 @@ button:hover {
 
 .age-info {
   padding: 2em 1em;
-  background: #fff;
+  background: #fff4e5;
+  border: 1px solid #ffd5aa;
   border-radius: 8px;
   max-width: 600px;
   margin: 0 auto 2em;
@@ -1494,6 +1495,9 @@ button:hover {
   gap: 1.5em;
   max-width: 600px;
   margin: 0 auto;
+  margin-top: 2em;
+  padding-top: 1.5em;
+  border-top: 2px solid #ffe0b3;
 }
 
 @media (min-width: 768px) {
@@ -1634,18 +1638,7 @@ button:hover {
 }
 
 .intro-step-cta .cta-button {
-  background-color: var(--color-primary);
-  color: #fff;
-  border: 2px solid var(--color-primary-dark);
-  border-radius: 8px;
-  padding: 0.9em 2.2em;
-  font-size: 1.25em;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-}
-
-.intro-step-cta .cta-button:hover {
-  background-color: #e57c00;
+  /* reuse base cta-button style for consistency */
 }
 
 .features .intro-step {


### PR DESCRIPTION
## Summary
- add tagline directly under hero heading
- simplify CTA button styling for consistency
- separate 4-step section with margin and border
- highlight age range section with different background
- clarify app name in footer CTA
- prevent hero image cropping on desktop

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6861169542b483238cdc9538e67a1c10