### PR TITLE
Fix hero photo layout

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -87,7 +87,7 @@
     justify-content: flex-start;
     padding-left: 5vw;
     gap: 2vw;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     background-image: none;
   }
 

--- a/style.css
+++ b/style.css
@@ -1355,7 +1355,7 @@ button:hover {
     padding-right: 0;
     padding-left: 5vw;
     gap: 2vw;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     background-image: none;
   }
 


### PR DESCRIPTION
## Summary
- keep hero image and text on the same row in wide layouts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686136a7da1c8323ab9b0f7625e70c74