### PR TITLE
Fix hero highlight line break

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -23,7 +23,7 @@ export function renderIntroScreen() {
 
         <p class="note">※ 推奨年齢：2歳半〜6歳</p>
 
-        <p class="hero-highlight">＼ 楽しみながら “聴く力” が<span class="accent">伸びる！</span> ／</p>
+        <p class="hero-highlight">＼ 楽しみながら “聴く力” が<span class="accent">伸びる！</span>&nbsp;／</p>
         <img class="mato-image" src="images/otolon.webp" alt="まとオトロン" />
         <button id="hero-cta" class="cta-button">今すぐ無料体験をはじめる！</button>
       </div>


### PR DESCRIPTION
## Summary
- prevent unwanted wrap on the hero highlight line by using a non-breaking space

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686141a1d3a4832383ac38f2f6dfdaae