### PR TITLE
Fix hero highlight wrapping

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -151,11 +151,11 @@
   font-size: 1.1em;
   color: #333;
   font-weight: bold;
-  margin-bottom: 1em;
-  max-width: 90%;
+  margin: 1.5em auto;
   text-align: center;
-  margin-left: auto;
-  margin-right: auto;
+  display: block;
+  white-space: nowrap;
+  width: fit-content;
 }
 
 .hero-highlight .accent {

--- a/style.css
+++ b/style.css
@@ -1320,11 +1320,11 @@ button:hover {
   font-size: 1.1em;
   color: #333;
   font-weight: bold;
-  margin-bottom: 1em;
-  max-width: 90%;
+  margin: 1.5em auto;
   text-align: center;
-  margin-left: auto;
-  margin-right: auto;
+  display: block;
+  white-space: nowrap;
+  width: fit-content;
 }
 
 .hero-highlight .accent {


### PR DESCRIPTION
## Summary
- prevent unwanted line breaks in hero highlight text

## Testing
- `npm run reset-expired-premiums` *(fails: Missing supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_b_68614361800883238a906ba67466a794