### PR TITLE
Fix hero header layout on mobile

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -45,7 +45,7 @@
   background-color: #fff;
   background-image: url('images/otoron_landing_hero.webp');
   background-size: cover;
-  background-position: right center;
+  background-position: center center;
   background-repeat: no-repeat;
 }
 

--- a/style.css
+++ b/style.css
@@ -1229,6 +1229,10 @@ button:hover {
   color: #333;
   overflow: hidden;
   background-color: #fff;
+  background-image: url('images/otoron_landing_hero.webp');
+  background-size: cover;
+  background-position: center center;
+  background-repeat: no-repeat;
 }
 
 .hero-header::after {
@@ -1255,7 +1259,7 @@ button:hover {
 }
 
 .hero-photo {
-  display: block;
+  display: none;
   width: 100%;
   height: auto;
   object-fit: cover;


### PR DESCRIPTION
## Summary
- adjust hero header background for mobile
- hide hero photo on mobile

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6861625a21e88323b8e7f3a83ec38f5c