### PR TITLE
Adjust hero photo cropping on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1357,10 +1357,10 @@ button:hover {
 
   .hero-photo {
     display: block;
-    width: 150vw;
-    height: auto;
+    width: 120vw;
+    height: 100vh;
     object-fit: cover;
-    object-position: center top;
+    object-position: center;
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 1em;


### PR DESCRIPTION
## Summary
- tweak `.hero-photo` style for small screens to keep the person centered

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68616a1e114c832397fff58c8cb0e9d3