### PR TITLE
Fix stripe key injection

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,10 @@
     }, 100);
   </script>
   <script src="https://js.stripe.com/v3/" defer></script>
+  <script>
+    window.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY =
+      'pk_live_51RUmpeGGyh8a8OqPGUhgmjdyp2fIhSCIOILTUb2eCV8s90gefDwt48Jel6dnphs41Rp3If2Asrh1UsMwsGI25a9000EgU9Rp1R';
+  </script>
 
   <!-- ✅ 最後に main.js をモジュールとして読み込む -->
   <script type="module" src="main.js"></script>


### PR DESCRIPTION
## Summary
- expose Stripe publishable key on `window` in `index.html`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68616d6f6b348323b949840b6ccf296c