### PR TITLE
Fix hero layout on mobile

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -173,6 +173,22 @@
     margin-left: auto;
     margin-right: auto;
   }
+
+  .hero-photo {
+    width: 91vw;
+    height: 70vh;
+    object-fit: cover;
+    object-position: center;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .hero {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 @media (min-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -1363,8 +1363,8 @@ button:hover {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 130vw;
-    height: 100vh;
+    width: 91vw;
+    height: 70vh;
     object-fit: cover;
     object-position: center;
     margin: 0;
@@ -1375,6 +1375,8 @@ button:hover {
     position: relative;
     z-index: 2;
     width: 100%;
+    margin-left: auto;
+    margin-right: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- center hero section on small screens
- shrink mobile hero photo to 70% of its original size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6862a2745b088323bdfdcca9afe1944c