### PR TITLE
Adjust hero layout

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -16,18 +16,20 @@ export function renderIntroScreen() {
 
   app.innerHTML = `
     <header id="lp-top" class="hero-header">
-      <div class="hero">
-        <h1 class="hero-title">絶対音感はもう、<br>特別な才能じゃない。</h1>
+      <div class="hero-container">
+        <div class="hero">
+          <h1 class="hero-title">絶対音感はもう、<br>特別な才能じゃない。</h1>
 
-        <p class="hero-sub">「オトロン」は、遊びながら耳を育てる<br>絶対音感トレーニングアプリです。</p>
+          <p class="hero-sub">「オトロン」は、遊びながら耳を育てる<br>絶対音感トレーニングアプリです。</p>
 
-        <p class="note">※ 推奨年齢：2歳半〜6歳</p>
+          <p class="note">※ 推奨年齢：2歳半〜6歳</p>
 
-        <p class="hero-highlight">＼ 楽しみながら “聴く力” が<span class="accent">伸びる！</span>&nbsp;／</p>
-        <img class="mato-image" src="images/otolon.webp" alt="まとオトロン" />
-        <button id="hero-cta" class="cta-button">今すぐ無料体験をはじめる！</button>
+          <p class="hero-highlight">＼ 楽しみながら “聴く力” が<span class="accent">伸びる！</span>&nbsp;／</p>
+          <img class="mato-image" src="images/otolon.webp" alt="まとオトロン" />
+          <button id="hero-cta" class="cta-button">今すぐ無料体験をはじめる！</button>
+        </div>
+        <div class="hero-image"></div>
       </div>
-      <img class="hero-photo" src="images/otoron_landing_hero.webp" alt="" />
       <div class="app-header intro-header">
         <button class="home-icon" id="intro-home-btn">
           <img src="images/otolon_face.webp" alt="トップへ" />

--- a/css/intro.css
+++ b/css/intro.css
@@ -31,56 +31,55 @@
   background-color: #e57c00;
 }
 
-/* ===== ヒーローヘッダーの基本スタイル（モバイル用） ===== */
-/* 古い .hero-header の定義と差し替えてください */
+/* ===== ヒーローヘッダー ===== */
 .hero-header {
-  display: flex;
-  flex-direction: column; /* モバイルでは縦並びに */
-  align-items: center;
-  padding: 80px 1em 2em 1em; /* 上下の余白を調整 */
-  background: #fff; /* 背景画像は使わない */
+  position: relative;
 }
 
-/* PC用の画像をモバイルでは先頭に表示するための設定 */
-.hero-photo {
-  display: block; /* 画像をブロック要素として表示 */
-  order: -1;      /* HTMLの順番を無視して、視覚的に先頭に配置 */
-  width: 100%;
-  max-width: 400px; /* 画像が大きくなりすぎないように制御 */
-  height: auto;
-  margin-bottom: 2em; /* 画像とテキストの間に余白 */
+.hero-container {
+  display: flex;
+  height: 100vh;
 }
 
 .hero {
-  text-align: center; /* テキストを中央揃え */
+  width: 50%;
+  padding: 5vw;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
-/* ===== PC表示用のスタイル（画面幅768px以上） ===== */
-@media (min-width: 768px) {
-  /* PCではヒーローヘッダーを横並びに */
-  .hero-header {
-    flex-direction: row; /* 横並びに変更 */
-    justify-content: center;
-    align-items: center;
-    gap: 2em; /* 要素間の余白 */
-    padding: 2em 5vw; /* PC用の余白 */
-    min-height: 80vh;
-  }
+.hero-image {
+  width: 50%;
+  background-image: linear-gradient(to left, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1)), url('images/otoron_landing_hero.webp');
+  background-size: cover;
+  background-position: center right;
+}
 
-  /* テキストブロック（左側） */
+@media (max-width: 768px) {
+  .hero-container {
+    flex-direction: column;
+    position: relative;
+  }
   .hero {
-    order: 1; /* テキストを1番目に（HTML順） */
-    flex: 1 1 500px; /* 幅の計算を柔軟に */
-    max-width: 550px;
-    text-align: left; /* テキストを左揃えに */
+    width: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    padding: 4rem 1em;
+    box-sizing: border-box;
+    text-align: center;
+    color: #fff;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+    align-items: center;
   }
-
-  /* 画像ブロック（右側） */
-  .hero-photo {
-    order: 2; /* 画像を2番目に */
-    flex: 1 1 500px;
-    max-width: 600px;
-    margin-bottom: 0; /* モバイル用の余白をリセット */
+  .hero-image {
+    width: 100%;
+    height: 100vh;
+    background-image: url('images/otoron_landing_hero.webp');
+    background-size: cover;
+    background-position: center;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1217,84 +1217,58 @@ button:hover {
   background-color: #e57c00;
 }
 
-/* Landing hero header old styles START
+/* Landing hero header */
 .hero-header {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-  padding: 2em 1em;
-  padding-top: 56px; /* app-header height */
   position: relative;
-  color: #333;
-  overflow: hidden;
-  width: 100%;
-  background-color: #fff;
-  background-image: url('images/otoron_landing_hero.webp');
-  background-size: cover;
-  background-position: center center;
-  background-repeat: no-repeat;
 }
 
-.hero-header::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100px;
-  background: linear-gradient(to bottom, rgba(255,255,255,0), #fff8f2);
-  z-index: 1;
-  pointer-events: none;
+.hero-container {
+  display: flex;
+  height: 100vh;
 }
 
 .hero {
-  max-width: 800px;
-  margin: 1.8em auto 0;
-  padding: 2em 1em;
-  text-align: center;
+  width: 50%;
+  padding: 5vw;
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
 }
 
-.hero-photo {
-  display: none;
-  width: 100%;
-  height: auto;
-  object-fit: cover;
-  object-position: center top;
-  order: -1;
-  margin-bottom: 1em;
+.hero-image {
+  width: 50%;
+  background-image: linear-gradient(to left, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1)), url('images/otoron_landing_hero.webp');
+  background-size: cover;
+  background-position: center right;
 }
 
-.mato-image {
-  width: 120px;
-  display: block;
-  margin: 1.5em auto 0;
+@media (max-width: 768px) {
+  .hero-container {
+    flex-direction: column;
+    position: relative;
+  }
+  .hero {
+    width: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    padding: 4rem 1em;
+    box-sizing: border-box;
+    text-align: center;
+    color: #fff;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+    align-items: center;
+  }
+  .hero-image {
+    width: 100%;
+    height: 100vh;
+    background-image: url('images/otoron_landing_hero.webp');
+    background-size: cover;
+    background-position: center;
+  }
 }
-
-.app-tagline {
-  text-align: center;
-  font-weight: bold;
-  margin: 1em auto;
-  font-size: 1.2em;
-}
-
-.hero h1,
-.hero p {
-  text-shadow: 0 2px 6px rgba(255, 255, 255, 0.8);
-}
-
-.intro-wrapper {
-  padding: 4em 1em;
-  text-align: center;
-  box-sizing: border-box;
-  background-color: #fff8f2;
-}
-
+/* Landing hero header END */
 .hero-title {
   font-size: 1.6em;
   font-weight: bold;
@@ -1338,56 +1312,6 @@ button:hover {
   color: var(--color-primary);
 }
 
-@media (max-width: 767px) {
-  .hero-header {
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: 1fr;
-    place-items: center;
-    height: 100vh;
-    overflow: hidden;
-    position: relative;
-    background-color: #fff;
-  }
-
-  .hero-photo,
-  .hero {
-    grid-column: 1 / 2;
-    grid-row: 1 / 2;
-  }
-
-  .hero-photo {
-    display: block;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    object-position: center;
-    transform: scale(1.3);
-    z-index: 1;
-  }
-
-  .hero {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    padding: 0 1em;
-    box-sizing: border-box;
-    text-align: center;
-    z-index: 2;
-  }
-
-  .hero h1,
-  .hero p,
-  .hero .hero-sub,
-  .hero .note,
-  .hero .hero-highlight {
-    color: #fff;
-    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
-  }
-}
-
 @media (min-width: 768px) {
   .hero-title {
     font-size: 2.4em;
@@ -1403,52 +1327,7 @@ button:hover {
   .hero-highlight {
     font-size: 1.2em;
   }
-
-  .hero-header {
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-start;
-    padding-top: 0;
-    padding-right: 0;
-    padding-left: 5vw;
-    gap: 2vw;
-    flex-wrap: nowrap;
-    background-image: none;
-  }
-
-  .hero {
-    flex: 1 1 36vw;
-    max-width: 600px;
-    margin-left: auto;
-    margin-right: auto;
-    z-index: 2;
-    position: relative;
-    text-align: center;
-    align-items: center;
-  }
-
-  .hero-photo {
-    display: block;
-    width: 70vw;
-    max-width: 960px;
-    height: 100vh;
-    object-fit: contain;
-    object-position: center top;
-    margin-left: auto;
-    order: 0;
-    margin-bottom: 0;
-  }
-
-  .mato-image {
-    width: 160px;
-  }
-
-  .app-tagline {
-    font-size: 1.4em;
-  }
 }
-
-*/ /* Landing hero header old styles END */
 .cta-button {
   margin-top: 1.5em;
   background-color: var(--color-primary);


### PR DESCRIPTION
## Summary
- redesign hero section layout with two-column style
- update landing page styles for mobile and desktop
- adapt intro screen markup for new hero container

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6862b480b5bc83239d233fb30fdc36dd