### PR TITLE
Fix hero layout on intro page

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -37,8 +37,10 @@
 }
 
 .hero-container {
+  position: relative;
   display: flex;
   height: 100vh;
+  overflow: hidden;
 }
 
 .hero {
@@ -47,10 +49,15 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
+  text-align: center;
+  position: relative;
+  z-index: 2;
 }
 
 .hero-image {
-  width: 50%;
+  position: absolute;
+  inset: 0;
   background-image: linear-gradient(to left, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1)), url('images/otoron_landing_hero.webp');
   background-size: cover;
   background-position: center right;
@@ -63,18 +70,19 @@
   }
   .hero {
     width: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
+    position: relative;
+    height: auto;
     padding: 4rem 1em;
     box-sizing: border-box;
     text-align: center;
     color: #fff;
     text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
     align-items: center;
+    z-index: 2;
   }
   .hero-image {
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100vh;
     background-image: url('images/otoron_landing_hero.webp');
@@ -132,6 +140,13 @@
 
 .hero-highlight .accent {
   color: var(--color-primary);
+}
+
+.mato-image {
+  width: 200px;
+  max-width: 60%;
+  height: auto;
+  margin: 1em auto 0;
 }
 
 

--- a/style.css
+++ b/style.css
@@ -1223,9 +1223,11 @@ button:hover {
 }
 
 .hero-container {
+  position: relative;
   display: flex;
   height: 100vh;
   min-height: 600px;
+  overflow: hidden;
 }
 
 .hero {
@@ -1236,10 +1238,13 @@ button:hover {
   justify-content: center;
   align-items: center;
   text-align: center;
+  position: relative;
+  z-index: 2;
 }
 
 .hero-image {
-  width: 50%;
+  position: absolute;
+  inset: 0;
   background-image: linear-gradient(to left, transparent, #fef6ee), url('images/otoron_landing_hero.webp');
   background-size: cover;
   background-position: center right;
@@ -1252,16 +1257,15 @@ button:hover {
   }
   .hero {
     width: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
+    position: relative;
+    height: auto;
     padding: 4rem 1em;
     box-sizing: border-box;
     text-align: center;
     color: #fff;
     text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
     align-items: center;
+    z-index: 2;
   }
   .hero-title,
   .hero-sub,
@@ -1270,6 +1274,8 @@ button:hover {
     color: #fff;
   }
   .hero-image {
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100vh;
     background-image: url('images/otoron_landing_hero.webp');
@@ -1279,14 +1285,10 @@ button:hover {
 }
 
 .mato-image {
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
   width: 200px;
   max-width: 60%;
   height: auto;
-  z-index: 2;
+  margin: 1em auto 0;
 }
 /* Landing hero header END */
 .hero-title {


### PR DESCRIPTION
## Summary
- improve hero layout to avoid hard split and show character under highlight text
- ensure mobile hero overlay uses white text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6862bcc566848323a0e145459b14bbf7