### PR TITLE
Update hero section background images

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -65,10 +65,10 @@ body.intro-scroll {
   inset: 0;
   background-image: url('images/otoron_landing_hero.webp');
   background-size: cover;
-  background-position: 110% center;
+  background-position: right center;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .hero-container {
     flex-direction: column;
     position: relative;
@@ -96,9 +96,9 @@ body.intro-scroll {
     inset: 0;
     width: 100%;
     height: 100vh;
-    background-image: url('images/otoron_landing_hero.webp');
+    background-image: url('images/otoron_landing_hero_sp.webp');
     background-size: cover;
-    background-position: center;
+    background-position: center top;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1253,10 +1253,10 @@ button:hover {
   background-image: url('images/otoron_landing_hero.webp');
   background-size: contain;
   background-repeat: no-repeat;
-  background-position: center;
+  background-position: right center;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .hero-container {
     flex-direction: column;
     position: relative;
@@ -1284,9 +1284,9 @@ button:hover {
     inset: 0;
     width: 100%;
     height: 100vh;
-    background-image: url('images/otoron_landing_hero.webp');
+    background-image: url('images/otoron_landing_hero_sp.webp');
     background-size: cover;
-    background-position: center;
+    background-position: center top;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak hero background to right-align desktop hero image
- switch mobile hero image and center top position

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68668e99881c8323b0bb5debfc20bd1d