### PR TITLE
Fix plan card spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -1461,7 +1461,6 @@ button:hover {
   .intro-pricing .plan-card {
     flex: 1 1 280px;
     max-width: 320px;
-    min-height: 320px;
     box-sizing: border-box;
   }
 }


### PR DESCRIPTION
## Summary
- fix spacing for intro pricing cards on desktop

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6867ce45cd70832380d725c37c2b3975