### PR TITLE
Fix desktop plan card layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -2204,7 +2204,6 @@ button:hover {
   .pricing-page .plan-card {
     flex: 1 1 280px;
     max-width: 320px;
-    min-height: 320px;
     box-sizing: border-box;
     align-self: flex-start;
   }


### PR DESCRIPTION
## Summary
- reduce vertical space on pricing page cards by removing min-height

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6868dd31c9c0832386fd67eac93a173f