### PR TITLE
Improve help button and modal style

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
 
   <div id="help-modal" class="modal" style="display: none;">
     <div class="modal-content">
+      <img src="images/otolon_face.webp" alt="オトロン" class="help-otolon" />
       <span class="close" onclick="closeHelp()">×</span>
       <h2 id="help-title"></h2>
       <div id="help-text"></div>

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -49,6 +49,7 @@ export async function renderGrowthScreen(user) {
 
   const helpBtn = document.createElement("button");
   helpBtn.id = "growth-help-btn";
+  helpBtn.className = "help-button";
   helpBtn.textContent = "？";
   helpBtn.onclick = () => openHelp("育成モード");
 

--- a/main.js
+++ b/main.js
@@ -74,6 +74,9 @@ export function closeHelp() {
   document.getElementById('help-modal').style.display = 'none';
 }
 
+// make closeHelp available for inline onclick handlers
+window.closeHelp = closeHelp;
+
 window.addEventListener("error", (e) => {
   console.error("Uncaught error", e.error);
 });

--- a/style.css
+++ b/style.css
@@ -200,19 +200,37 @@ button:hover {
 
 /* Help modal specific */
 #help-modal .modal-content {
-  background: #fff;
+  position: relative;
+  background: #ffe6f0;
   padding: 1.5em;
-  border-radius: 10px;
+  border-radius: 20px;
   max-width: 480px;
   width: 90%;
   max-height: 80vh;
   overflow-y: auto;
+  font-family: var(--font-body);
+  font-size: 1.1em;
+}
+
+#help-modal .modal-content::before {
+  content: "";
+  position: absolute;
+  bottom: -20px;
+  left: 40px;
+  border: 20px solid transparent;
+  border-top-color: #ffe6f0;
 }
 
 #help-modal .close {
   cursor: pointer;
   float: right;
-  font-size: 1.5rem;
+  font-size: 1.2rem;
+  background: #fff;
+  width: 1.8em;
+  height: 1.8em;
+  line-height: 1.8em;
+  border-radius: 50%;
+  text-align: center;
 }
 
 #help-modal table {
@@ -225,27 +243,28 @@ button:hover {
   border-bottom: 1px solid #ccc;
 }
 
-#growth-help-btn {
-  margin-left: 0.4em;
-  font-size: 0.9em;
-  cursor: pointer;
-  background: transparent;
-  border: none;
-}
 
 .help-button {
-  margin-left: 0.4em;
-  font-size: 0.9em;
+  margin-left: 0.2em;
+  font-size: 0.8em;
   cursor: pointer;
   background: var(--color-accent);
   color: #fff;
   border: none;
-  width: 1.6em;
-  height: 1.6em;
+  width: 1.3em;
+  height: 1.3em;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: 50%;
+}
+
+#help-modal .help-otolon {
+  position: absolute;
+  left: -40px;
+  top: 10px;
+  width: 60px;
+  height: auto;
 }
 
 .growth-title-row {


### PR DESCRIPTION
## Summary
- tweak help button style and apply to growth screen
- style help modal with cute design and icon
- place otolon image in help modal
- make closeHelp globally accessible

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6868fedd7cb48323a690c409ea80b46c