### PR TITLE
Improve growth help modal behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,10 +47,12 @@
   <div id="help-modal" class="modal" style="display: none;">
     <div class="modal-content">
       <img src="images/otolon_face.webp" alt="オトロン" class="help-otolon" />
-      <span class="close" onclick="closeHelp()">×</span>
-      <h2 id="help-title"></h2>
-      <div id="help-text"></div>
-      <div id="help-table"></div>
+      <div class="help-main">
+        <span class="close" onclick="closeHelp()">×</span>
+        <h2 id="help-title"></h2>
+        <div id="help-text"></div>
+        <div id="help-table"></div>
+      </div>
     </div>
   </div>
 

--- a/main.js
+++ b/main.js
@@ -46,6 +46,9 @@ const DUMMY_PASSWORD = "secure_dummy_password";
 
 const DEBUG_AUTO_LOGIN = false;
 
+let helpOutsideHandler = null;
+let helpKeyHandler = null;
+
 export async function openHelp(topic) {
   const res = await fetch('helpData.json');
   const data = await res.json();
@@ -67,11 +70,30 @@ export async function openHelp(topic) {
     document.getElementById('help-table').innerHTML = '';
   }
 
-  document.getElementById('help-modal').style.display = 'block';
+  const modal = document.getElementById('help-modal');
+  modal.style.display = 'flex';
+
+  helpOutsideHandler = (e) => {
+    if (e.target === modal) closeHelp();
+  };
+  helpKeyHandler = (e) => {
+    if (e.key === 'Escape') closeHelp();
+  };
+  modal.addEventListener('click', helpOutsideHandler);
+  document.addEventListener('keydown', helpKeyHandler);
 }
 
 export function closeHelp() {
-  document.getElementById('help-modal').style.display = 'none';
+  const modal = document.getElementById('help-modal');
+  modal.style.display = 'none';
+  if (helpOutsideHandler) {
+    modal.removeEventListener('click', helpOutsideHandler);
+    helpOutsideHandler = null;
+  }
+  if (helpKeyHandler) {
+    document.removeEventListener('keydown', helpKeyHandler);
+    helpKeyHandler = null;
+  }
 }
 
 // make closeHelp available for inline onclick handlers

--- a/style.css
+++ b/style.css
@@ -210,20 +210,21 @@ button:hover {
   overflow-y: auto;
   font-family: var(--font-body);
   font-size: 1.1em;
+  display: flex;
+  align-items: flex-start;
+  gap: 1em;
 }
 
+/* remove speech bubble arrow */
 #help-modal .modal-content::before {
-  content: "";
-  position: absolute;
-  bottom: -20px;
-  left: 40px;
-  border: 20px solid transparent;
-  border-top-color: #ffe6f0;
+  display: none;
 }
 
 #help-modal .close {
   cursor: pointer;
-  float: right;
+  position: absolute;
+  top: 10px;
+  right: 10px;
   font-size: 1.2rem;
   background: #fff;
   width: 1.8em;
@@ -251,8 +252,9 @@ button:hover {
   background: var(--color-accent);
   color: #fff;
   border: none;
-  width: 1.3em;
-  height: 1.3em;
+  width: 1.6em;
+  height: 1.6em;
+  line-height: 1.6em;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -260,11 +262,14 @@ button:hover {
 }
 
 #help-modal .help-otolon {
-  position: absolute;
-  left: -40px;
-  top: 10px;
+  flex: 0 0 auto;
   width: 60px;
   height: auto;
+}
+
+#help-modal .help-main {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .growth-title-row {


### PR DESCRIPTION
## Summary
- tweak help modal styles so that it's centered and pink with rounded corners
- display Otolon image next to help text
- ensure help button is a perfect circle
- allow closing help modal by clicking outside or pressing Escape

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6869013b4500832386e63459de308044