### PR TITLE
Fix help button padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -252,6 +252,7 @@ button:hover {
   background: var(--color-accent);
   color: #fff;
   border: none;
+  padding: 0;
   width: 1.6em;
   height: 1.6em;
   line-height: 1.6em;


### PR DESCRIPTION
## Summary
- keep `.help-button` circular by removing inherited padding

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686904866c808323848f387be1b82a15