### PR TITLE
Fix help modal scroll clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,9 +49,11 @@
       <img src="images/otolon_face.webp" alt="オトロン" class="help-otolon" />
       <div class="help-main">
         <span class="close" onclick="closeHelp()">×</span>
-        <h2 id="help-title"></h2>
-        <div id="help-text"></div>
-        <div id="help-table"></div>
+        <div class="help-body">
+          <h2 id="help-title"></h2>
+          <div id="help-text"></div>
+          <div id="help-table"></div>
+        </div>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -207,7 +207,7 @@ button:hover {
   max-width: 480px;
   width: 90%;
   max-height: 80vh;
-  overflow-y: auto;
+  overflow: hidden;
   font-family: var(--font-body);
   font-size: 1.1em;
   display: flex;
@@ -270,6 +270,14 @@ button:hover {
 #help-modal .help-main {
   flex: 1 1 auto;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+}
+
+#help-modal .help-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
 }
 
 .growth-title-row {


### PR DESCRIPTION
## Summary
- ensure help modal keeps border radius while scrolling
- wrap help content in a new `help-body` div
- make the outer modal hide overflow
- scroll the inner body instead

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686904a7be5c8323a78fe89b748547d8