### PR TITLE
Fix help modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,10 +46,12 @@
 
   <div id="help-modal" class="modal" style="display: none;">
     <div class="modal-content">
-      <img src="images/otolon_face.webp" alt="オトロン" class="help-otolon" />
+      <span class="close" onclick="closeHelp()">×</span>
       <div class="help-main">
-        <span class="close" onclick="closeHelp()">×</span>
-        <h2 id="help-title"></h2>
+        <div class="help-header">
+          <img src="images/otolon_face.webp" alt="オトロン" class="help-otolon" />
+          <h2 id="help-title"></h2>
+        </div>
         <div id="help-text"></div>
         <div id="help-table"></div>
       </div>

--- a/style.css
+++ b/style.css
@@ -210,9 +210,6 @@ button:hover {
   overflow-y: auto;
   font-family: var(--font-body);
   font-size: 1.1em;
-  display: flex;
-  align-items: flex-start;
-  gap: 1em;
 }
 
 /* remove speech bubble arrow */
@@ -232,6 +229,12 @@ button:hover {
   line-height: 1.8em;
   border-radius: 50%;
   text-align: center;
+}
+
+#help-modal .help-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
 }
 
 #help-modal table {
@@ -263,13 +266,11 @@ button:hover {
 }
 
 #help-modal .help-otolon {
-  flex: 0 0 auto;
   width: 60px;
   height: auto;
 }
 
 #help-modal .help-main {
-  flex: 1 1 auto;
   min-width: 0;
 }
 


### PR DESCRIPTION
## Summary
- move the Otoron icon next to the help title
- adjust help modal styles for new layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6869059ad9688323931669074ac41aed