### PR TITLE
Fix help modal scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -207,7 +207,7 @@ button:hover {
   max-width: 480px;
   width: 90%;
   max-height: 80vh;
-  overflow: hidden;
+  overflow-y: auto;
   font-family: var(--font-body);
   font-size: 1.1em;
   display: flex;


### PR DESCRIPTION
## Summary
- make the help modal content scrollable so longer help text can be viewed

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686906fa4c6c8323bd8e88df464323c5