### PR TITLE
Align help modal image with title

### DIFF
--- a/style.css
+++ b/style.css
@@ -268,6 +268,13 @@ button:hover {
   height: auto;
 }
 
+#help-modal .help-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5em;
+}
+
 #help-modal .help-main {
   flex: 1 1 auto;
   min-width: 0;


### PR DESCRIPTION
## Summary
- adjust help modal styles so that the Otoron image sits next to the title text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686908aa70448323b3b89de04918432f