### PR TITLE
Fix border-radius issue in help modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
   <div id="help-modal" class="modal" style="display: none;">
     <div class="modal-content">
       <span class="close" onclick="closeHelp()">×</span>
-      <div class="help-main">
+      <div class="help-main modal-scroll">
         <div class="help-header">
           <img src="images/otolon_face.webp" alt="オトロン" class="help-otolon" />
           <h2 id="help-title"></h2>

--- a/style.css
+++ b/style.css
@@ -207,12 +207,18 @@ button:hover {
   max-width: 480px;
   width: 90%;
   max-height: 80vh;
-  overflow-y: auto;
+  overflow: hidden;
   font-family: var(--font-body);
   font-size: 1.1em;
   display: flex;
   align-items: flex-start;
   gap: 1em;
+}
+
+#help-modal .modal-scroll {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  max-height: 100%;
 }
 
 /* remove speech bubble arrow */


### PR DESCRIPTION
## Summary
- keep help modal's rounded corners when scrolling
- move overflow handling to `.modal-scroll`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_686908d96e808323bff94d8017247d6b