### PR TITLE
Improve help modal scrolling

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -135,6 +135,7 @@ button:hover {
   left: 0;
   width: 100%;
   height: 100%;
+  overflow-y: auto;
   background: rgba(0, 0, 0, 0.6);
   display: flex;
   justify-content: center;

--- a/css/result.css
+++ b/css/result.css
@@ -162,6 +162,7 @@
   /* Avoid horizontal scrollbars caused by viewport units */
   width: 100%;
   height: 100%;
+  overflow-y: auto;
   background: rgba(0, 0, 0, 0.7);
   display: flex;
   justify-content: center;

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
   <div id="help-modal" class="modal" style="display: none;">
     <div class="modal-content">
       <span class="close" onclick="closeHelp()">×</span>
-      <div class="help-main modal-scroll">
+      <div class="help-main">
         <div class="help-header">
           <img src="images/otolon_face.webp" alt="オトロン" class="help-otolon" />
           <h2 id="help-title"></h2>

--- a/style.css
+++ b/style.css
@@ -168,6 +168,7 @@ button:hover {
   left: 0;
   width: 100%;
   height: 100%;
+  overflow-y: auto;
   background: rgba(0, 0, 0, 0.6);
   display: flex;
   justify-content: center;
@@ -200,25 +201,13 @@ button:hover {
 
 /* Help modal specific */
 #help-modal .modal-content {
-  position: relative;
-  background: #ffe6f0;
-  padding: 1.5em;
-  border-radius: 20px;
   max-width: 480px;
-  width: 90%;
-  max-height: 80vh;
-  overflow: hidden;
-  font-family: var(--font-body);
-  font-size: 1.1em;
-  display: flex;
-  align-items: flex-start;
-  gap: 1em;
+  border-radius: 20px;
 }
 
 #help-modal .modal-scroll {
   flex: 1 1 auto;
-  overflow-y: auto;
-  max-height: 100%;
+  
 }
 
 /* remove speech bubble arrow */
@@ -286,12 +275,10 @@ button:hover {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  max-height: 100%;
 }
 
 #help-modal .help-body {
   flex: 1 1 auto;
-  overflow-y: auto;
 }
 
 .growth-title-row {
@@ -2581,6 +2568,7 @@ button:hover {
   /* Avoid horizontal scrollbars caused by viewport units */
   width: 100%;
   height: 100%;
+  overflow-y: auto;
   background: rgba(0, 0, 0, 0.7);
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- allow `.modal` container itself to scroll vertically
- simplify help modal content styling and remove internal overflow
- update markup to drop redundant `modal-scroll` class

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68690a563e34832381bf64755bcd61fc