### PR TITLE
Fix modal scroll clipping

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -135,7 +135,6 @@ button:hover {
   left: 0;
   width: 100%;
   height: 100%;
-  overflow-y: auto;
   background: rgba(0, 0, 0, 0.6);
   display: flex;
   justify-content: center;
@@ -151,6 +150,8 @@ button:hover {
   background: #fff;
   padding: 1.5em;
   border-radius: 10px;
+  max-height: 90vh;
+  overflow-y: auto;
   text-align: center;
 }
 

--- a/css/result.css
+++ b/css/result.css
@@ -162,7 +162,6 @@
   /* Avoid horizontal scrollbars caused by viewport units */
   width: 100%;
   height: 100%;
-  overflow-y: auto;
   background: rgba(0, 0, 0, 0.7);
   display: flex;
   justify-content: center;

--- a/style.css
+++ b/style.css
@@ -168,7 +168,6 @@ button:hover {
   left: 0;
   width: 100%;
   height: 100%;
-  overflow-y: auto;
   background: rgba(0, 0, 0, 0.6);
   display: flex;
   justify-content: center;
@@ -184,6 +183,8 @@ button:hover {
   background: #fff;
   padding: 1.5em;
   border-radius: 10px;
+  max-height: 90vh;
+  overflow-y: auto;
   text-align: center;
 }
 
@@ -203,6 +204,8 @@ button:hover {
 #help-modal .modal-content {
   max-width: 480px;
   border-radius: 20px;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 #help-modal .modal-scroll {


### PR DESCRIPTION
## Summary
- adjust `.modal` styles to avoid cutting off rounded corners when content is long
- allow scrolling within the modal box instead of the overlay

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_68690cc6fe1c8323b882d4d2496f3216