### PR TITLE
Fix info page scroll on desktop

### DIFF
--- a/css/info.css
+++ b/css/info.css
@@ -219,9 +219,9 @@
 }
 
 @media (min-width: 768px) {
-  /* お問い合わせページ以外はPCでもスクロール可能に */
+  /* PCではbody全体でスクロールするため高さ指定を外す */
   .info-page:not(.contact-page) {
-    height: calc(100dvh - 56px);
-    overflow-y: auto;
+    height: auto;
+    overflow-y: visible;
   }
 }

--- a/style.css
+++ b/style.css
@@ -1283,10 +1283,10 @@ button:hover {
 }
 
 @media (min-width: 768px) {
-  /* お問い合わせページ以外はPCでもスクロール可能に */
+  /* PCではbody全体でスクロールするため高さ指定を外す */
   .info-page:not(.contact-page) {
-    height: calc(100dvh - 56px);
-    overflow-y: auto;
+    height: auto;
+    overflow-y: visible;
   }
 }
 /* Landing page styles */


### PR DESCRIPTION
## Summary
- remove fixed height from information pages on desktop so the body scrolls normally

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68693595b43c8323a30532b90d1d8a46