### PR TITLE
Reduce plan card height

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -276,7 +276,7 @@ body.intro-scroll {
   .intro-pricing .plan-card {
     flex: 1 1 280px;
     max-width: 320px;
-    min-height: 320px;
+    min-height: 224px;
     box-sizing: border-box;
   }
 }

--- a/css/pricing.css
+++ b/css/pricing.css
@@ -34,7 +34,7 @@
   flex-direction: column;
   gap: 0.6em;
   /* Keep all plan cards the same height */
-  min-height: 320px;
+  min-height: 224px;
 }
 
 .plan-card.recommended {

--- a/style.css
+++ b/style.css
@@ -2318,7 +2318,7 @@ button:hover {
   flex-direction: column;
   gap: 0.6em;
   /* Keep all plan cards the same height */
-  min-height: 320px;
+  min-height: 224px;
 }
 
 .plan-card.recommended {


### PR DESCRIPTION
## Summary
- adjust plan card min-height to 224px in `style.css`, `css/pricing.css` and `css/intro.css` for a smaller display

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6869fdcc1f448323a6284f0f8e281ca3