### PR TITLE
Force setup for new users

### DIFF
--- a/main.js
+++ b/main.js
@@ -246,7 +246,7 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
   }
 
   currentUser = user;
-  if (!user.name || user.name === "名前未設定") {
+  if (isNew || !user.name || user.name === "名前未設定") {
     switchScreen("setup", user, { showWelcome: isNew });
   } else {
     switchScreen("home", user, { showWelcome: isNew });


### PR DESCRIPTION
## Summary
- show setup screen after sign-up even if the user's name was imported from Google

## Testing
- `npm test` *(fails: missing script and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_686a2475266c8323b7a657244ea3855c