### PR TITLE
Show signup thanks page before home

### DIFF
--- a/main.js
+++ b/main.js
@@ -243,13 +243,15 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 
   if (isNew) {
     await createInitialChordProgress(user.id);
+    window.location.href = "/register-thankyou.html";
+    return;
   }
 
   currentUser = user;
-  if (isNew || !user.name || user.name === "名前未設定") {
-    switchScreen("setup", user, { showWelcome: isNew });
+  if (!user.name || user.name === "名前未設定") {
+    switchScreen("setup", user, { showWelcome: false });
   } else {
-    switchScreen("home", user, { showWelcome: isNew });
+    switchScreen("home", user, { showWelcome: false });
   }
 });
 

--- a/register-thankyou.html
+++ b/register-thankyou.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>登録完了</title>
+  <meta name="robots" content="noindex" />
+  <script>
+    setTimeout(() => {
+      window.location.href = "/";
+    }, 1500);
+  </script>
+  <!-- Google Ads Conversion Tag 挿入位置 -->
+</head>
+<body style="display: flex; justify-content: center; align-items: center; height: 100vh; background: #fffce9;">
+  <img src="images/register_complete_oton.webp" alt="会員登録ありがとうございます" style="max-width: 80%; height: auto;" />
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `register-thankyou.html` temporary page with automatic redirect
- redirect new users to that page after Google signup

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686a26ae42348323a0f9df1c8aea083e