### PR TITLE
Ensure username setup after Google login

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -78,7 +78,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
         .insert([
           {
             firebase_uid: user.uid,
-            name: user.displayName || "名前未設定",
+            name: "名前未設定",
             email: user.email,
           },
         ])

--- a/components/signup.js
+++ b/components/signup.js
@@ -87,7 +87,7 @@ export function renderSignUpScreen() {
             .insert([
               {
                 firebase_uid: user.uid,
-                name: user.displayName || "名前未設定",
+                name: "名前未設定",
                 email: user.email,
               },
             ])

--- a/utils/supabaseAuthHelper.js
+++ b/utils/supabaseAuthHelper.js
@@ -52,7 +52,7 @@ export async function ensureSupabaseAuth(firebaseUser) {
         [
           {
             firebase_uid: firebaseUser.uid,
-            name: firebaseUser.displayName || '名前未設定',
+            name: '名前未設定',
             email,
             trial_active: true,
             trial_end_date: trialEnd,


### PR DESCRIPTION
## Summary
- avoid using Google display name when creating new users
- always default to "名前未設定" so setup screen is triggered

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686a2926800883239cc1bdba4e7fd576