### PR TITLE
Switch Google login to redirect

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>Googleログイン処理中</title>
+  <meta name="robots" content="noindex">
+</head>
+<body>
+  <p>ログイン処理中です...</p>
+  <script type="module">
+    import { firebaseAuth } from './firebase/firebase-init.js';
+    import { signInWithRedirect, getRedirectResult, GoogleAuthProvider, onAuthStateChanged, fetchSignInMethodsForEmail, signOut } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+    import { ensureSupabaseAuth } from './utils/supabaseAuthHelper.js';
+    import { createInitialChordProgress } from './utils/progressUtils.js';
+
+    const provider = new GoogleAuthProvider();
+
+    onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
+      if (!firebaseUser) return;
+      try {
+        await firebaseUser.getIdToken();
+        const methods = await fetchSignInMethodsForEmail(firebaseAuth, firebaseUser.email);
+        if (methods.includes('password') && !methods.includes('google.com')) {
+          await signOut(firebaseAuth);
+          alert('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。');
+          window.location.href = '/';
+          return;
+        }
+        const { user, isNew } = await ensureSupabaseAuth(firebaseUser);
+        if (isNew) {
+          await createInitialChordProgress(user.id);
+          window.location.href = '/register-thankyou.html';
+        } else {
+          window.location.href = '/';
+        }
+      } catch (e) {
+        console.error('auth flow error', e);
+        window.location.href = '/';
+      }
+    });
+
+    try {
+      const result = await getRedirectResult(firebaseAuth);
+      if (!result) {
+        await signInWithRedirect(firebaseAuth, provider);
+      }
+    } catch (e) {
+      console.error('redirect error', e);
+      window.location.href = '/';
+    }
+  </script>
+</body>
+</html>

--- a/components/login.js
+++ b/components/login.js
@@ -1,9 +1,6 @@
 import {
   signInWithEmailAndPassword,
-  GoogleAuthProvider,
-  signInWithPopup,
-  fetchSignInMethodsForEmail,
-  signOut
+  fetchSignInMethodsForEmail
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
 import { firebaseAuth } from "../firebase/firebase-init.js";
@@ -154,33 +151,9 @@ export function renderLoginScreen(container, onLoginSuccess) {
     }
   });
 
-  // Googleログイン処理
-  container.querySelector("#google-login").addEventListener("click", async () => {
-    const provider = new GoogleAuthProvider();
-    try {
-      const result = await signInWithPopup(firebaseAuth, provider);
-      const user = result.user;
-      const methods = await fetchSignInMethodsForEmail(firebaseAuth, user.email);
-      if (methods.includes('password') && !methods.includes('google.com')) {
-        await signOut(firebaseAuth);
-        showCustomAlert('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。');
-        return;
-      }
-      try {
-        await ensureSupabaseAuth(user);
-      } catch (e) {
-        console.error("❌ Supabaseサインイン処理でエラー:", e);
-        return;
-      }
-      await ensureUserAndProgress(user);
-      onLoginSuccess();
-    } catch (err) {
-      if (err.code === 'auth/account-exists-with-different-credential') {
-        showCustomAlert('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。');
-      } else {
-        showCustomAlert("Googleログイン失敗：" + err.message);
-      }
-    }
+  // Googleログイン処理（リダイレクト方式）
+  container.querySelector("#google-login").addEventListener("click", () => {
+    window.location.href = "/callback.html";
   });
 
   // 戻るボタン

--- a/main.js
+++ b/main.js
@@ -228,6 +228,7 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 
   let authResult;
   try {
+    await firebaseUser.getIdToken();
     authResult = await ensureSupabaseAuth(firebaseUser);
   } catch (e) {
     console.error("❌ Supabase認証処理エラー:", e);


### PR DESCRIPTION
## Summary
- implement auth redirect flow via `callback.html`
- update login and signup flows to use the new redirect page
- ensure Firebase ID token is fetched before Supabase auth

## Testing
- `npm test` *(fails: missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_b_686a3749ab6083239ad8928c6a363352