### PR TITLE
Add login debug logs

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -7,15 +7,23 @@
 </head>
 <body>
   <p>ログイン処理中です...</p>
+  <pre id="debug-log" style="white-space: pre-wrap; color: red; font-size: 0.9em;"></pre>
   <script type="module">
     import { firebaseAuth } from './firebase/firebase-init.js';
     import { signInWithRedirect, getRedirectResult, GoogleAuthProvider, onAuthStateChanged, fetchSignInMethodsForEmail, signOut } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
     import { ensureSupabaseAuth } from './utils/supabaseAuthHelper.js';
     import { createInitialChordProgress } from './utils/progressUtils.js';
+    import { addDebugLog, showDebugLog } from './utils/loginDebug.js';
+
+    const debugMode = new URLSearchParams(window.location.search).get('debug') === '1';
+    addDebugLog('callback.html loaded');
+    showDebugLog();
 
     const provider = new GoogleAuthProvider();
 
     onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
+      addDebugLog('onAuthStateChanged', firebaseUser ? { email: firebaseUser.email } : 'no user');
+      showDebugLog();
       if (!firebaseUser) return;
       try {
         await firebaseUser.getIdToken();
@@ -23,30 +31,44 @@
         if (methods.includes('password') && !methods.includes('google.com')) {
           await signOut(firebaseAuth);
           alert('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。');
-          window.location.href = '/';
+          addDebugLog('redirect: login exists');
+          showDebugLog();
+          if (!debugMode) window.location.href = '/';
           return;
         }
         const { user, isNew } = await ensureSupabaseAuth(firebaseUser);
         if (isNew) {
           await createInitialChordProgress(user.id);
-          window.location.href = '/register-thankyou.html';
+          addDebugLog('redirect: register-thankyou');
+          showDebugLog();
+          if (!debugMode) window.location.href = '/register-thankyou.html';
         } else {
-          window.location.href = '/';
+          addDebugLog('redirect: home');
+          showDebugLog();
+          if (!debugMode) window.location.href = '/';
         }
       } catch (e) {
         console.error('auth flow error', e);
-        window.location.href = '/';
+        addDebugLog('auth flow error', e.message);
+        showDebugLog();
+        if (!debugMode) window.location.href = '/';
       }
     });
 
     try {
       const result = await getRedirectResult(firebaseAuth);
+      addDebugLog('getRedirectResult', result ? 'has result' : 'null');
+      showDebugLog();
       if (!result) {
+        addDebugLog('signInWithRedirect');
+        showDebugLog();
         await signInWithRedirect(firebaseAuth, provider);
       }
     } catch (e) {
       console.error('redirect error', e);
-      window.location.href = '/';
+      addDebugLog('redirect error', e.message);
+      showDebugLog();
+      if (!debugMode) window.location.href = '/';
     }
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -39,6 +39,19 @@
 
     gtag('config', 'G-QCRGGLGDER');
   </script>
+  <script type="module">
+    import { showDebugLog } from './utils/loginDebug.js';
+    const debugMode = new URLSearchParams(window.location.search).get('debug') === '1';
+    if (debugMode) {
+      const pre = document.createElement('pre');
+      pre.id = 'debug-log';
+      pre.style.whiteSpace = 'pre-wrap';
+      pre.style.color = 'red';
+      pre.style.fontSize = '0.9em';
+      document.body.prepend(pre);
+      showDebugLog();
+    }
+  </script>
 </head>
 
 <body class="app-root">

--- a/utils/loginDebug.js
+++ b/utils/loginDebug.js
@@ -1,0 +1,24 @@
+export const LOG_KEY = 'login-debug-log';
+
+export function addDebugLog(step, data) {
+  try {
+    const log = JSON.parse(localStorage.getItem(LOG_KEY) || '[]');
+    log.push({ time: new Date().toISOString(), step, data });
+    if (log.length > 50) log.shift();
+    localStorage.setItem(LOG_KEY, JSON.stringify(log));
+    console.log('[login-debug]', step, data);
+  } catch (e) {
+    console.warn('[login-debug] failed to record log', e);
+  }
+}
+
+export function showDebugLog(containerId = 'debug-log') {
+  try {
+    const el = document.getElementById(containerId);
+    if (!el) return;
+    const log = JSON.parse(localStorage.getItem(LOG_KEY) || '[]');
+    el.textContent = log.map(l => `[${l.time}] ${l.step}${l.data ? ' ' + JSON.stringify(l.data) : ''}`).join('\n');
+  } catch (e) {
+    console.warn('[login-debug] failed to show log', e);
+  }
+}


### PR DESCRIPTION
## Summary
- add new debug utility to persist login flow messages
- log auth steps in `callback.html` with option to pause redirects
- display recorded logs if `?debug=1` is present
- support log display on index page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686a3ab9951083238596cf644964da15