### PR TITLE
Fix google signup return error

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -15,6 +15,8 @@
     import { createInitialChordProgress } from './utils/progressUtils.js';
     import { addDebugLog, showDebugLog } from './utils/loginDebug.js';
 
+    (async () => {
+
     const debugMode = new URLSearchParams(window.location.search).get('debug') === '1';
     addDebugLog('callback.html loaded');
     showDebugLog();
@@ -69,6 +71,7 @@
       showDebugLog();
       if (!debugMode) window.location.href = '/';
     }
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- avoid illegal top-level `return` in `callback.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686a3f5eff108323aac5d1115fadf6a0