### PR TITLE
Fix Google redirect auth loop

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -60,16 +60,16 @@
       addDebugLog('getRedirectResult', result ? 'has result' : 'null');
       showDebugLog();
       if (!result || !result.user) {
+        console.error('no redirect result');
         addDebugLog('no redirect result');
         showDebugLog();
-        if (!debugMode) window.location.href = '/';
         return;
       }
     } catch (e) {
       console.error('redirect error', e);
       addDebugLog('redirect error', e.message);
       showDebugLog();
-      if (!debugMode) window.location.href = '/';
+      return;
     }
     })();
   </script>

--- a/components/login.js
+++ b/components/login.js
@@ -1,6 +1,8 @@
 import {
   signInWithEmailAndPassword,
-  fetchSignInMethodsForEmail
+  fetchSignInMethodsForEmail,
+  GoogleAuthProvider,
+  signInWithRedirect
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
 import { firebaseAuth } from "../firebase/firebase-init.js";
@@ -152,8 +154,9 @@ export function renderLoginScreen(container, onLoginSuccess) {
   });
 
   // Googleログイン処理（リダイレクト方式）
+  const googleProvider = new GoogleAuthProvider();
   container.querySelector("#google-login").addEventListener("click", () => {
-    window.location.href = "/callback.html";
+    signInWithRedirect(firebaseAuth, googleProvider);
   });
 
   // 戻るボタン

--- a/components/signup.js
+++ b/components/signup.js
@@ -1,6 +1,10 @@
 import { switchScreen } from "../main.js";
 import { firebaseAuth } from "../firebase/firebase-init.js";
-import { createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+import {
+  createUserWithEmailAndPassword,
+  GoogleAuthProvider,
+  signInWithRedirect
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 import { ensureSupabaseAuth } from "../utils/supabaseAuthHelper.js";
 import { createInitialChordProgress } from "../utils/progressUtils.js";
 
@@ -73,8 +77,9 @@ export function renderSignUpScreen() {
 
   // Googleサインアップ処理（リダイレクト方式）
   const googleBtn = container.querySelector("#google-signup");
+  const googleProvider = new GoogleAuthProvider();
   googleBtn.addEventListener("click", () => {
-    window.location.href = "/callback.html";
+    signInWithRedirect(firebaseAuth, googleProvider);
   });
 
   // 戻るボタン


### PR DESCRIPTION
## Summary
- call `signInWithRedirect` when clicking Google login/signup buttons
- only log error on `callback.html` when no redirect result

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686a41081b8c8323aecf10f749554518