### PR TITLE
Fix auth redirect by using production domain

### DIFF
--- a/firebase/firebase-init.js
+++ b/firebase/firebase-init.js
@@ -3,7 +3,7 @@ import { getAuth } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-aut
 
 const firebaseConfig = {
   apiKey: "AIzaSyAunlq7BhL9A4JvcXszpYkDoXAPPSvhlxo",
-  authDomain: "otoron-app.firebaseapp.com",
+  authDomain: "playotoron.com",
   projectId: "otoron-app",
   storageBucket: "otoron-app.appspot.com",
   messagingSenderId: "572910581480",


### PR DESCRIPTION
## Summary
- update Firebase config `authDomain` to use the production domain

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686a58ebf14083239e69bfce6ff6c7a8