### PR TITLE
Fix Google auth domain

### DIFF
--- a/firebase/firebase-init.js
+++ b/firebase/firebase-init.js
@@ -3,7 +3,7 @@ import { getAuth } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-aut
 
 const firebaseConfig = {
   apiKey: "AIzaSyAunlq7BhL9A4JvcXszpYkDoXAPPSvhlxo",
-  authDomain: "playotoron.com",
+  authDomain: "otoron-app.firebaseapp.com",
   projectId: "otoron-app",
   storageBucket: "otoron-app.appspot.com",
   messagingSenderId: "572910581480",


### PR DESCRIPTION
## Summary
- use firebaseapp.com auth domain for Google login

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_b_686a5b83fff4832380c043808b2b5463