### PR TITLE
Fix welcome alert on first login

### DIFF
--- a/main.js
+++ b/main.js
@@ -250,7 +250,7 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 
   currentUser = user;
   if (!user.name || user.name === "名前未設定") {
-    switchScreen("setup", user, { showWelcome: false });
+    switchScreen("setup", user, { showWelcome: true });
   } else {
     switchScreen("home", user, { showWelcome: false });
   }


### PR DESCRIPTION
## Summary
- show the trial welcome message after completing initial setup

## Testing
- `npm run reset-expired-premiums` *(fails: Cannot find package '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_b_686a5d801120832385fb326f7a620ff7