### PR TITLE
Fix signup progress initialization

### DIFF
--- a/components/signup.js
+++ b/components/signup.js
@@ -65,8 +65,8 @@ export function renderSignUpScreen() {
     }
 
     try {
-      await createUserWithEmailAndPassword(firebaseAuth, email, password);
-      const { user } = await ensureSupabaseAuth(firebaseAuth.currentUser);
+      const cred = await createUserWithEmailAndPassword(firebaseAuth, email, password);
+      const { user } = await ensureSupabaseAuth(cred.user);
       if (user) {
         await createInitialChordProgress(user.id);
       }


### PR DESCRIPTION
## Summary
- ensure we pass the newly created Firebase user to `ensureSupabaseAuth` so chord progress records are created correctly after email sign-up

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686a60cbe7988323bf3289fa5daa0b22