### PR TITLE
Fix modal text color at night

### DIFF
--- a/style.css
+++ b/style.css
@@ -1142,6 +1142,13 @@ button:hover {
   color: #543014 !important;
 }
 
+/* Ensure modal text stays readable on the night theme */
+.app-root.night .modal,
+.app-root.night .modal-box,
+.app-root.night #help-modal .modal-content {
+  color: #543014;
+}
+
 .info-page h1 {
   font-family: var(--font-heading);
   text-align: center;


### PR DESCRIPTION
## Summary
- ensure modals use dark text when night theme is active

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686a82a7ec6483239edfb6dc8ef13b79