### PR TITLE
Fix button wrapping on intro screen

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -203,6 +203,8 @@ body.intro-scroll {
   display: block;
   margin-left: auto;
   margin-right: auto;
+  white-space: nowrap; /* prevent wrapping so text stays on two lines */
+  word-break: keep-all;
 }
 
 .cta-button:hover {

--- a/style.css
+++ b/style.css
@@ -1490,6 +1490,8 @@ button:hover {
   display: block;
   margin-left: auto;
   margin-right: auto;
+  white-space: nowrap; /* prevent unwanted wrapping on small screens */
+  word-break: keep-all; /* respect explicit <br> only */
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
## Summary
- ensure the CTA text on the landing page stays on two lines

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686bb32262c08323954d84142d7a2b0f