### PR TITLE
Fix label for flat notes in result

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -11,7 +11,11 @@ import { kanaToHiragana, noteLabels } from "../utils/noteUtils.js";
 let resultShownInThisSession = false;
 
 function labelNote(n) {
-  const pitch = n ? n.replace(/\d/g, '') : '';
+  if (!n) return '';
+  const pitch = n
+    .replace(/[0-9-]/g, '')
+    .replace('♭', 'b')
+    .replace('♯', '#');
   return noteLabels[pitch] || n;
 }
 


### PR DESCRIPTION
## Summary
- handle ♭/♯ symbols in the result screen's note labels

## Testing
- `node - <<'NODE'
const { noteLabels } = require('./utils/noteUtils.js');
function labelNote(n){ if(!n) return ''; const pitch = n.replace(/[0-9-]/g,'').replace('♭','b').replace('♯','#'); return noteLabels[pitch] || n; }
console.log(labelNote('B♭3'));
console.log(labelNote('E♭3'));
console.log(labelNote('C#4'));
NODE`

------
https://chatgpt.com/codex/tasks/task_b_686c502955c48323b9b309dd472f45db