### PR TITLE
Handle Stripe cancel redirect

### DIFF
--- a/cancel/index.html
+++ b/cancel/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <title>決済キャンセル</title>
+  <link rel="icon" href="/favicon.ico" />
+  <script type="module">
+    localStorage.setItem('showCancelToast', '1');
+    window.location.replace('/#pricing');
+  </script>
+</head>
+<body></body>
+</html>

--- a/components/pricing.js
+++ b/components/pricing.js
@@ -1,9 +1,16 @@
 import { renderHeader } from './header.js';
 import { startCheckout } from '../utils/stripeCheckout.js';
+import { showToast } from '../utils/toast.js';
 export function renderPricingScreen(user) {
   const app = document.getElementById('app');
   app.innerHTML = '';
   renderHeader(app, user);
+
+  const cancelFlag = localStorage.getItem('showCancelToast');
+  if (cancelFlag) {
+    showToast('決済がキャンセルされました');
+    localStorage.removeItem('showCancelToast');
+  }
 
   const main = document.createElement('main');
   main.className = 'pricing-page';

--- a/style.css
+++ b/style.css
@@ -3689,3 +3689,22 @@ button.disabled {
   from { transform: translateY(-10vh) rotate(0deg); }
   to   { transform: translateY(100vh) rotate(720deg); }
 }
+/* Toast notification */
+.toast {
+  position: fixed;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 4px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 1001;
+  font-size: 14px;
+}
+.toast.show {
+  opacity: 1;
+}

--- a/utils/toast.js
+++ b/utils/toast.js
@@ -1,0 +1,14 @@
+export function showToast(message, duration = 3000) {
+  let toast = document.getElementById('global-toast');
+  if (!toast) {
+    toast = document.createElement('div');
+    toast.id = 'global-toast';
+    toast.className = 'toast';
+    document.body.appendChild(toast);
+  }
+  toast.textContent = message;
+  toast.classList.add('show');
+  setTimeout(() => {
+    toast.classList.remove('show');
+  }, duration);
+}


### PR DESCRIPTION
## Summary
- implement toast utility
- show toast on pricing page when cancellation occurred
- add redirect page for Stripe cancel
- style toast notification

## Testing
- `node -e "require('./utils/toast.js'); console.log('ok')"`
- `node -e "require('./components/pricing.js'); console.log('pricing ok')" (fails: ERR_NETWORK_IMPORT_DISALLOWED)`

------
https://chatgpt.com/codex/tasks/task_b_686d221fdd7c8323ba30616b38ecfa33