### PR TITLE
Improve settings screen layout

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -171,10 +171,18 @@ export async function renderSettingsScreen(user) {
   const controlBar = document.createElement('div');
   controlBar.className = 'settings-controls';
   controlBar.appendChild(titleLine);
-  controlBar.appendChild(singleWrap);
-  controlBar.appendChild(singleSelectWrap);
-  controlBar.appendChild(resetBtn);
-  controlBar.appendChild(bulkDropdown);
+
+  const singleCard = document.createElement('div');
+  singleCard.className = 'settings-card';
+  singleCard.appendChild(singleWrap);
+  singleCard.appendChild(singleSelectWrap);
+  controlBar.appendChild(singleCard);
+
+  const bulkCard = document.createElement('div');
+  bulkCard.className = 'settings-card';
+  bulkCard.appendChild(resetBtn);
+  bulkCard.appendChild(bulkDropdown);
+  controlBar.appendChild(bulkCard);
 
   headerBar.appendChild(controlBar);
   container.appendChild(headerBar);

--- a/css/settings.css
+++ b/css/settings.css
@@ -302,6 +302,23 @@
   padding: 6px 12px;
 }
 
+/* 縦型の設定カード */
+.settings-card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5em;
+  width: 180px;
+  box-sizing: border-box;
+}
+.settings-card > * {
+  width: 100%;
+}
+
 /* その他のトレーニング */
 .other-training {
   background: white;

--- a/style.css
+++ b/style.css
@@ -3015,6 +3015,23 @@ button:hover {
   padding: 6px 12px;
 }
 
+/* 縦型の設定カード */
+.settings-card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5em;
+  width: 180px;
+  box-sizing: border-box;
+}
+.settings-card > * {
+  width: 100%;
+}
+
 /* その他のトレーニング */
 .other-training {
   background: white;


### PR DESCRIPTION
## Summary
- group single-note mode toggle with its dropdown in a vertical card
- group recommended and bulk controls into another card
- style the new `.settings-card` component

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6871310d886883238fd9cc8add5b0369