### PR TITLE
Modify single-note feature UI

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -146,11 +146,11 @@ export async function renderSettingsScreen(user) {
   slider.className = 'toggle-slider';
 
   singleWrap.appendChild(singleToggle);
-  singleWrap.appendChild(slider);
   const singleLabel = document.createElement('span');
   singleLabel.className = 'toggle-label';
-  singleLabel.innerHTML = '🎵 単音分化モード';
+  singleLabel.innerHTML = '🎵 単音分化機能';
   singleWrap.appendChild(singleLabel);
+  singleWrap.appendChild(slider);
 
   const singleSelectWrap = document.createElement('div');
   singleSelectWrap.className = 'single-note-select-wrap';

--- a/css/settings.css
+++ b/css/settings.css
@@ -298,6 +298,9 @@
   gap: 6px;
   margin: 0.5em 1em;
 }
+.single-note-select-wrap span {
+  white-space: nowrap;
+}
 .single-note-select-wrap select {
   padding: 6px 12px;
 }
@@ -369,6 +372,7 @@
 
 .toggle-label {
   font-weight: bold;
+  white-space: nowrap;
 }
 
 /* 温かみのある背景 */

--- a/style.css
+++ b/style.css
@@ -3004,12 +3004,19 @@ button:hover {
 .toggle-input:checked + .toggle-slider::before {
   transform: translateX(20px);
 }
+.toggle-label {
+  white-space: nowrap;
+  font-weight: bold;
+}
 
 .single-note-select-wrap {
   display: flex;
   align-items: center;
   gap: 6px;
   margin: 0.5em 1em;
+}
+.single-note-select-wrap span {
+  white-space: nowrap;
 }
 .single-note-select-wrap select {
   padding: 6px 12px;


### PR DESCRIPTION
## Summary
- rename and reposition single note toggle
- keep labels on a single line to align card heights

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_b_6871345740708323a61f75b14932380f