### PR TITLE
Update settings layout

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -172,17 +172,22 @@ export async function renderSettingsScreen(user) {
   controlBar.className = 'settings-controls';
   controlBar.appendChild(titleLine);
 
+  const cardRow = document.createElement('div');
+  cardRow.className = 'settings-card-row';
+
   const singleCard = document.createElement('div');
   singleCard.className = 'settings-card';
   singleCard.appendChild(singleWrap);
   singleCard.appendChild(singleSelectWrap);
-  controlBar.appendChild(singleCard);
+  cardRow.appendChild(singleCard);
 
   const bulkCard = document.createElement('div');
   bulkCard.className = 'settings-card';
   bulkCard.appendChild(resetBtn);
   bulkCard.appendChild(bulkDropdown);
-  controlBar.appendChild(bulkCard);
+  cardRow.appendChild(bulkCard);
+
+  controlBar.appendChild(cardRow);
 
   headerBar.appendChild(controlBar);
   container.appendChild(headerBar);

--- a/css/settings.css
+++ b/css/settings.css
@@ -306,6 +306,12 @@
 }
 
 /* 縦型の設定カード */
+.settings-card-row {
+  display: flex;
+  justify-content: center;
+  gap: 0.75em;
+}
+
 .settings-card {
   background: #fff;
   border-radius: 12px;
@@ -315,11 +321,18 @@
   flex-direction: column;
   align-items: center;
   gap: 0.5em;
-  width: 180px;
+  width: 150px;
+  min-height: 100px;
+  font-size: 0.9em;
   box-sizing: border-box;
 }
 .settings-card > * {
   width: 100%;
+}
+.settings-card button,
+.settings-card select {
+  font-size: 0.9em;
+  font-weight: normal;
 }
 
 /* その他のトレーニング */
@@ -371,8 +384,9 @@
 }
 
 .toggle-label {
-  font-weight: bold;
+  font-weight: normal;
   white-space: nowrap;
+  font-size: 0.9em;
 }
 
 /* 温かみのある背景 */

--- a/style.css
+++ b/style.css
@@ -3006,7 +3006,8 @@ button:hover {
 }
 .toggle-label {
   white-space: nowrap;
-  font-weight: bold;
+  font-weight: normal;
+  font-size: 0.9em;
 }
 
 .single-note-select-wrap {
@@ -3023,6 +3024,12 @@ button:hover {
 }
 
 /* 縦型の設定カード */
+.settings-card-row {
+  display: flex;
+  justify-content: center;
+  gap: 0.75em;
+}
+
 .settings-card {
   background: #fff;
   border-radius: 12px;
@@ -3032,11 +3039,18 @@ button:hover {
   flex-direction: column;
   align-items: center;
   gap: 0.5em;
-  width: 180px;
+  width: 150px;
+  min-height: 100px;
+  font-size: 0.9em;
   box-sizing: border-box;
 }
 .settings-card > * {
   width: 100%;
+}
+.settings-card button,
+.settings-card select {
+  font-size: 0.9em;
+  font-weight: normal;
 }
 
 /* その他のトレーニング */


### PR DESCRIPTION
## Summary
- keep "単音分化機能" and "推奨出題" cards side-by-side on all devices
- standardize the cards' height and smaller fonts
- ensure text in cards is not bold

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687136d4961c83238fee5954b3246697