### PR TITLE
Update settings screen labels and layout

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -148,14 +148,14 @@ export async function renderSettingsScreen(user) {
   singleWrap.appendChild(singleToggle);
   const singleLabel = document.createElement('span');
   singleLabel.className = 'toggle-label';
-  singleLabel.innerHTML = '🎵 単音分化機能';
+  singleLabel.innerHTML = '単音分化機能';
   singleWrap.appendChild(singleLabel);
   singleWrap.appendChild(slider);
 
   const singleSelectWrap = document.createElement('div');
   singleSelectWrap.className = 'single-note-select-wrap';
   const singleSelectLabel = document.createElement('span');
-  singleSelectLabel.textContent = '出題音:';
+  singleSelectLabel.textContent = '出題音';
   const singleSelect = document.createElement('select');
   singleSelect.innerHTML = `
     <option value="random">ランダム</option>

--- a/css/settings.css
+++ b/css/settings.css
@@ -302,7 +302,7 @@
   white-space: nowrap;
 }
 .single-note-select-wrap select {
-  padding: 6px 12px;
+  padding: 6px 4px;
 }
 
 /* 縦型の設定カード */
@@ -320,6 +320,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 0.5em;
   width: 150px;
   min-height: 100px;

--- a/style.css
+++ b/style.css
@@ -3020,7 +3020,7 @@ button:hover {
   white-space: nowrap;
 }
 .single-note-select-wrap select {
-  padding: 6px 12px;
+  padding: 6px 4px;
 }
 
 /* 縦型の設定カード */
@@ -3038,6 +3038,7 @@ button:hover {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 0.5em;
   width: 150px;
   min-height: 100px;


### PR DESCRIPTION
## Summary
- update label text for the single note mode
- adjust spacing of the single note dropdown
- center items in settings cards

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68713a1032008323bd35d2af6221c755