### PR TITLE
Fix settings card width on mobile

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -322,7 +322,8 @@
   align-items: center;
   justify-content: center;
   gap: 0.5em;
-  width: 150px;
+  flex: 1 1 280px;
+  max-width: 280px;
   min-height: 100px;
   font-size: 0.9em;
   box-sizing: border-box;
@@ -414,6 +415,13 @@
     background: transparent;
     box-shadow: none;
     border-radius: 0;
+  }
+  .settings-card-row {
+    width: 100%;
+  }
+  .settings-card {
+    flex-basis: 100%;
+    max-width: 100%;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -3040,7 +3040,8 @@ button:hover {
   align-items: center;
   justify-content: center;
   gap: 0.5em;
-  width: 150px;
+  flex: 1 1 280px;
+  max-width: 280px;
   min-height: 100px;
   font-size: 0.9em;
   box-sizing: border-box;
@@ -3151,6 +3152,13 @@ button:hover {
     background: transparent;
     box-shadow: none;
     border-radius: 0;
+  }
+  .settings-card-row {
+    width: 100%;
+  }
+  .settings-card {
+    flex-basis: 100%;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- widen settings cards to match main card width
- make settings cards full width on small screens

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68713ce14dec8323a5d3c4dbc4fd9607