### PR TITLE
Refine single-note card layout

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -322,8 +322,8 @@
   align-items: center;
   justify-content: center;
   gap: 0.5em;
-  flex: 1 1 280px;
-  max-width: 280px;
+  flex: 0 1 200px;
+  max-width: 200px;
   min-height: 100px;
   font-size: 0.9em;
   box-sizing: border-box;

--- a/style.css
+++ b/style.css
@@ -3040,8 +3040,8 @@ button:hover {
   align-items: center;
   justify-content: center;
   gap: 0.5em;
-  flex: 1 1 280px;
-  max-width: 280px;
+  flex: 0 1 200px;
+  max-width: 200px;
   min-height: 100px;
   font-size: 0.9em;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- shrink `.settings-card` width to remove excess space

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_68713efd5ed0832394ea014bec3bf675