### PR TITLE
Fix settings controls alignment

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -196,6 +196,7 @@
 
 .settings-controls {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;

--- a/style.css
+++ b/style.css
@@ -2909,6 +2909,7 @@ button:hover {
 
 .settings-controls {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Center `.settings-card-row` items by updating `.settings-controls` style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68714234c7788323b9b3a2fcbea5d91a