### PR TITLE
Fix card row width in settings

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -311,6 +311,7 @@
   display: flex;
   justify-content: center;
   gap: 0.75em;
+  width: 100%;
 }
 
 .settings-card {

--- a/style.css
+++ b/style.css
@@ -3029,6 +3029,7 @@ button:hover {
   display: flex;
   justify-content: center;
   gap: 0.75em;
+  width: 100%;
 }
 
 .settings-card {


### PR DESCRIPTION
## Summary
- ensure `.settings-card-row` spans the entire header width
- reflect the same in the compiled stylesheet

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6871482a58148323b016a0ea42115a09