### PR TITLE
Fix settings card alignment

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -297,7 +297,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  margin: 0.5em 1em;
+  margin: 0.5em 0;
 }
 .single-note-select-wrap span {
   white-space: nowrap;

--- a/style.css
+++ b/style.css
@@ -3015,7 +3015,7 @@ button:hover {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin: 0.5em 1em;
+  margin: 0.5em 0;
 }
 .single-note-select-wrap span {
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- tweak single-note card CSS margin so setting cards align properly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68714ed3c8d48323b21657bbcdbab219