### PR TITLE
Add 1 second delay before first training question

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -141,7 +141,11 @@ export async function renderTrainingScreen(user) {
   if (!questionQueue.length) {
     questionQueue = createQuestionQueue();
   }
-  nextQuestion(); // ✅ 出題開始！
+  // 初回は1秒待ってから出題を開始
+  showFeedback("はじめるよ", "good");
+  setTimeout(() => {
+    nextQuestion(); // ✅ 出題開始！
+  }, 1000);
 }
 
 async function nextQuestion() {

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -83,7 +83,11 @@ export function renderTrainingScreen(user) {
   isForcedAnswer = false;
   firstMistakeInSession.flag = false;
   questionQueue = createQuestionQueue();
-  nextQuestion();
+  // 初回は1秒待ってから出題を開始
+  showFeedback("はじめるよ", "good");
+  setTimeout(() => {
+    nextQuestion();
+  }, 1000);
 }
 
 async function nextQuestion() {

--- a/components/training_easy_note.js
+++ b/components/training_easy_note.js
@@ -157,5 +157,13 @@ export async function renderTrainingScreen(user) {
     });
   }
 
-  nextQuestion();
+  // 最初は1秒待ってからスタート
+  isSoundPlaying = true;
+  setInteraction(false);
+  const fb = document.getElementById("feedback");
+  if (fb) fb.textContent = "はじめるよ";
+  setTimeout(() => {
+    if (fb) fb.textContent = "";
+    nextQuestion();
+  }, 1000);
 }

--- a/components/training_full.js
+++ b/components/training_full.js
@@ -152,5 +152,13 @@ export async function renderTrainingScreen(user) {
     });
   }
 
-  nextQuestion();
+  // 最初は1秒待ってからスタート
+  isSoundPlaying = true;
+  setInteraction(false);
+  const fb = document.getElementById("feedback");
+  if (fb) fb.textContent = "はじめるよ";
+  setTimeout(() => {
+    if (fb) fb.textContent = "";
+    nextQuestion();
+  }, 1000);
 }

--- a/components/training_white_keys.js
+++ b/components/training_white_keys.js
@@ -142,5 +142,13 @@ export async function renderTrainingScreen(user) {
     });
   }
 
-  nextQuestion();
+  // 最初は1秒待ってからスタート
+  isSoundPlaying = true;
+  setInteraction(false);
+  const fb = document.getElementById("feedback");
+  if (fb) fb.textContent = "はじめるよ";
+  setTimeout(() => {
+    if (fb) fb.textContent = "";
+    nextQuestion();
+  }, 1000);
 }


### PR DESCRIPTION
## Summary
- delay first question by 1s for every training mode
- show `はじめるよ` during the delay

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68732e94a6b88323aab9adbc17352669