### PR TITLE
Fix single note mode toggle

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -146,11 +146,11 @@ export async function renderSettingsScreen(user) {
   slider.className = 'toggle-slider';
 
   singleWrap.appendChild(singleToggle);
+  singleWrap.appendChild(slider);
   const singleLabel = document.createElement('span');
   singleLabel.className = 'toggle-label';
   singleLabel.innerHTML = '単音分化機能';
   singleWrap.appendChild(singleLabel);
-  singleWrap.appendChild(slider);
 
   const singleSelectWrap = document.createElement('div');
   singleSelectWrap.className = 'single-note-select-wrap';


### PR DESCRIPTION
## Summary
- fix ordering of elements for the single note mode toggle in settings so that the slider reacts to checkbox state

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68734ff4da0083238d07d7fd50805767