### PR TITLE
Add webhook deduplication via Stripe events log

### DIFF
--- a/sql/create_stripe_events.sql
+++ b/sql/create_stripe_events.sql
@@ -1,0 +1,5 @@
+-- Create table to store processed Stripe webhook events
+create table if not exists stripe_events (
+  event_id text primary key,
+  received_at timestamp with time zone default current_timestamp
+);

--- a/sql/user_subscriptions_unique.sql
+++ b/sql/user_subscriptions_unique.sql
@@ -1,0 +1,3 @@
+-- Ensure duplicate subscription rows cannot be inserted manually
+alter table user_subscriptions
+  add constraint user_subscriptions_user_started_at_key unique (user_id, started_at);


### PR DESCRIPTION
## Summary
- log processed Stripe webhook events
- create helper SQL for `stripe_events` table
- enforce unique `user_subscriptions` entries
- document deduplication SQL in README

## Testing
- `node --check api/stripe-webhook.js`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6877967baa7883238430d840aeda526b