### PR TITLE
Add ensureChordProgress helper

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -10,7 +10,7 @@ import { switchScreen } from "../main.js";
 import { addDebugLog } from "../utils/loginDebug.js";
 import { supabase } from "../utils/supabaseClient.js";
 import { ensureSupabaseAuth } from "../utils/supabaseAuthHelper.js";
-import { chords } from "../data/chords.js";
+import { ensureChordProgress } from "../utils/progressUtils.js";
 import { showCustomAlert } from "./home.js";
 
 export function renderLoginScreen(container, onLoginSuccess) {
@@ -96,31 +96,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       
     }
   
-    // user_chord_progress にすでにデータがあるか確認
-    const { data: progress } = await supabase
-      .from("user_chord_progress")
-      .select("id")
-      .eq("user_id", userId)
-      .limit(1);
-  
-    if (!progress || progress.length === 0) {
-      const chordKeys = chords.map(ch => ch.key);
-      const insertData = chordKeys.map((key, index) => ({
-        user_id: userId,
-        chord_key: key,
-        status: index === 0 ? "in_progress" : "locked"
-      }));
-  
-      const { error } = await supabase
-        .from("user_chord_progress")
-        .insert(insertData);
-  
-      if (error) {
-        console.error("❌ 和音進捗の初期登録失敗:", error);
-      } else {
-        
-      }
-    }
+    await ensureChordProgress(userId);
   }
   
 

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ import { renderInitialSetupScreen } from "./components/initialSetup.js";
 import { supabase } from "./utils/supabaseClient.js";
 import { ensureSupabaseAuth } from "./utils/supabaseAuthHelper.js";
 import { getLockType } from "./utils/accessControl.js";
-import { createInitialChordProgress } from "./utils/progressUtils.js";
+import { ensureChordProgress } from "./utils/progressUtils.js";
 import { loadTrainingRecords } from "./utils/recordStore_supabase.js";
 import { getToday } from "./utils/growthUtils.js";
 import { showCustomAlert } from "./components/home.js";
@@ -236,6 +236,8 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
   }
   const { user, isNew } = authResult;
 
+  await ensureChordProgress(user.id);
+
   const lockType = getLockType(user);
   if (lockType) {
     switchScreen("lock", user, { lockType });
@@ -243,7 +245,6 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
   }
 
   if (isNew) {
-    await createInitialChordProgress(user.id);
     window.location.href = "/register-thankyou.html";
     return;
   }

--- a/utils/progressUtils.js
+++ b/utils/progressUtils.js
@@ -247,3 +247,26 @@ export async function resetProgressAndUnlock(userId, startIndex) {
 
   return true;
 }
+
+// ✅ ユーザーの和音進捗が存在するか確認し、なければ初期データを作成
+export async function ensureChordProgress(userId) {
+  if (!userId) {
+    console.warn("ensureChordProgress called without valid user ID");
+    return;
+  }
+
+  const { data, error } = await supabase
+    .from("user_chord_progress")
+    .select("id")
+    .eq("user_id", userId)
+    .limit(1);
+
+  if (error) {
+    console.error("❌ ensureChordProgress query failed:", error);
+    return;
+  }
+
+  if (!data || data.length === 0) {
+    await createInitialChordProgress(userId);
+  }
+}


### PR DESCRIPTION
## Summary
- add new `ensureChordProgress` helper to guarantee `user_chord_progress` rows
- call this helper on login and auth state change
- simplify login component to use helper instead of custom logic

## Testing
- `node --check utils/progressUtils.js`
- `node --check components/login.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_b_687925bdf4dc8323a6924426ee64e8bf