### PR TITLE
Allow chord question count above 5

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -264,7 +264,7 @@ export async function renderSettingsScreen(user) {
         let val = parseInt(numSpan.textContent) || 0;
         val += delta;
         if (val < 0) val = 0;
-        if (val > 5) val = 5;
+        if (val > 20) val = 20; // allow manual counts up to 20
         numSpan.textContent = val;
         updateSelection();
       }


### PR DESCRIPTION
## Summary
- fix question count setter to cap at 20 instead of 5

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687b7a4596408323a82de1061ec8752b