### PR TITLE
Fix note layout and font size

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -320,9 +320,15 @@ function drawQuizScreen() {
 
       const inner = document.createElement("div");
       inner.className = `square-btn-content ${only.colorClass}`;
-      inner.innerHTML = chordProgressCount >= 10 && only.italian
-        ? only.italian.map(kanaToHiragana).join("")
-        : only.labelHtml;
+      let showNote = false;
+      if (chordProgressCount >= 10 && only.italian) {
+        inner.innerHTML = only.italian.map(kanaToHiragana).join("");
+        showNote = true;
+      } else {
+        inner.innerHTML = only.labelHtml;
+        if (only.type === "black-inv") showNote = true;
+      }
+      if (showNote) inner.classList.add("note-small");
       inner.setAttribute("data-name", only.name);
       inner.style.pointerEvents = "auto";
       inner.style.opacity = "1";
@@ -358,11 +364,15 @@ function drawQuizScreen() {
 
       const inner = document.createElement("div");
       inner.className = `square-btn-content ${chord.colorClass}`;
+      let noteFlag = false;
       if (chordProgressCount >= 10 && chord.italian) {
         inner.innerHTML = chord.italian.map(kanaToHiragana).join("");
+        noteFlag = true;
       } else {
         inner.innerHTML = chord.labelHtml;
+        if (chord.type === "black-inv") noteFlag = true;
       }
+      if (noteFlag) inner.classList.add("note-small");
       inner.setAttribute("data-name", chord.name);
       inner.style.pointerEvents = "auto";
       inner.style.opacity = "1";

--- a/css/training.css
+++ b/css/training.css
@@ -48,6 +48,9 @@
   border-radius: 10px;
   box-sizing: border-box;
 }
+.square-btn-content.note-small {
+  font-size: calc(1em - 2pt) !important;
+}
 
 /* --- dynamic grid layouts --- */
 .grid-container.cols-1 { grid-template-columns: repeat(1, 1fr); max-width: 240px; }

--- a/data/chords.js
+++ b/data/chords.js
@@ -18,20 +18,20 @@ export const chords = [
   { name: "E♭-G-B♭", key: "mizuiro", label: "水色", labelHiragana: "みずいろ", labelHtml: "みずいろ", file: "chord_14_mizuiro_root.mp3", type: "black-root", colorClass: "mizuiro", soundKey: "mizuiro", notes: ["E♭3", "G3", "B♭3"], italian: ["エス", "ソ", "ベー"] },
 
   // 黒鍵（転回系 白色表示）
-  { name: "C#-E-A", key: "kimidori_1st", label: "チスミラ", labelHiragana: "ちすみら", labelHtml: "ちす<br>み<br>ら", file: "chord_10_kimidori_1st.mp3", type: "black-inv", colorClass: "white", soundKey: "cismila", notes: ["C#3", "E3", "A3"] },
-  { name: "E-A-C#", key: "kimidori_2nd", label: "ミラチス", labelHiragana: "みらちす", labelHtml: "み<br>ら<br>ちす", file: "chord_10_kimidori_2nd.mp3", type: "black-inv", colorClass: "white", soundKey: "milacis", notes: ["E3", "A3", "C#4"] },
+  { name: "C#-E-A", key: "kimidori_1st", label: "チスミラ", labelHiragana: "ちすみら", labelHtml: "ちすみら", file: "chord_10_kimidori_1st.mp3", type: "black-inv", colorClass: "white", soundKey: "cismila", notes: ["C#3", "E3", "A3"] },
+  { name: "E-A-C#", key: "kimidori_2nd", label: "ミラチス", labelHiragana: "みらちす", labelHtml: "みらちす", file: "chord_10_kimidori_2nd.mp3", type: "black-inv", colorClass: "white", soundKey: "milacis", notes: ["E3", "A3", "C#4"] },
 
-  { name: "F#-A-D", key: "usudai_1st", label: "フィスラレ", labelHiragana: "ふぃすられ", labelHtml: "ふぃす<br>ら<br>れ", file: "chord_11_usudai_1st.mp3", type: "black-inv", colorClass: "white", soundKey: "fisrare", notes: ["F#3", "A3", "D4"] },
-  { name: "A-D-F#", key: "usudai_2nd", label: "ラレフィス", labelHiragana: "られふぃす", labelHtml: "ら<br>れ<br>ふぃす", file: "chord_11_usudai_2nd.mp3", type: "black-inv", colorClass: "white", soundKey: "larefis", notes: ["A2", "D3", "F#3"] },
+  { name: "F#-A-D", key: "usudai_1st", label: "フィスラレ", labelHiragana: "ふぃすられ", labelHtml: "ふぃすられ", file: "chord_11_usudai_1st.mp3", type: "black-inv", colorClass: "white", soundKey: "fisrare", notes: ["F#3", "A3", "D4"] },
+  { name: "A-D-F#", key: "usudai_2nd", label: "ラレフィス", labelHiragana: "られふぃす", labelHtml: "られふぃす", file: "chord_11_usudai_2nd.mp3", type: "black-inv", colorClass: "white", soundKey: "larefis", notes: ["A2", "D3", "F#3"] },
 
-  { name: "G#-B-E", key: "fuji_1st", label: "ギスシミ", labelHiragana: "ぎすしみ", labelHtml: "ぎす<br>し<br>み", file: "chord_12_fuji_1st.mp3", type: "black-inv", colorClass: "white", soundKey: "gissemi", notes: ["G#3", "B3", "E4"] },
-  { name: "B-E-G#", key: "fuji_2nd", label: "シミギス", labelHiragana: "しみぎす", labelHtml: "し<br>み<br>ぎす", file: "chord_12_fuji_2nd.mp3", type: "black-inv", colorClass: "white", soundKey: "semigis", notes: ["B2", "E3", "G#3"] },
+  { name: "G#-B-E", key: "fuji_1st", label: "ギスシミ", labelHiragana: "ぎすしみ", labelHtml: "ぎすしみ", file: "chord_12_fuji_1st.mp3", type: "black-inv", colorClass: "white", soundKey: "gissemi", notes: ["G#3", "B3", "E4"] },
+  { name: "B-E-G#", key: "fuji_2nd", label: "シミギス", labelHiragana: "しみぎす", labelHtml: "しみぎす", file: "chord_12_fuji_2nd.mp3", type: "black-inv", colorClass: "white", soundKey: "semigis", notes: ["B2", "E3", "G#3"] },
 
-  { name: "D-F-B♭", key: "hai_1st", label: "レファベー", labelHiragana: "れふぁべー", labelHtml: "れ<br>ふぁ<br>べー", file: "chord_13_hai_1st.mp3", type: "black-inv", colorClass: "white", soundKey: "refabe", notes: ["D3", "F3", "B♭3"] },
-  { name: "F-B♭-D", key: "hai_2nd", label: "ファベーレ", labelHiragana: "ふぁべーれ", labelHtml: "ふぁ<br>べー<br>れ", file: "chord_13_hai_2nd.mp3", type: "black-inv", colorClass: "white", soundKey: "fabere", notes: ["F3", "B♭3", "D4"] },
+  { name: "D-F-B♭", key: "hai_1st", label: "レファベー", labelHiragana: "れふぁべー", labelHtml: "れふぁべー", file: "chord_13_hai_1st.mp3", type: "black-inv", colorClass: "white", soundKey: "refabe", notes: ["D3", "F3", "B♭3"] },
+  { name: "F-B♭-D", key: "hai_2nd", label: "ファベーレ", labelHiragana: "ふぁべーれ", labelHtml: "ふぁべーれ", file: "chord_13_hai_2nd.mp3", type: "black-inv", colorClass: "white", soundKey: "fabere", notes: ["F3", "B♭3", "D4"] },
 
-  { name: "G-B♭-E♭", key: "mizuiro_1st", label: "ソベーエス", labelHiragana: "そべーえす", labelHtml: "そ<br>べー<br>えす", file: "chord_14_mizuiro_1st.mp3", type: "black-inv", colorClass: "white", soundKey: "sobees", notes: ["G3", "B♭3", "E♭4"] },
-  { name: "B♭-E♭-G", key: "mizuiro_2nd", label: "ベーエスソ", labelHiragana: "べーえすそ", labelHtml: "べー<br>えす<br>そ", file: "chord_14_mizuiro_2nd.mp3", type: "black-inv", colorClass: "white", soundKey: "beesso", notes: ["B♭2", "E♭3", "G3"] }
+  { name: "G-B♭-E♭", key: "mizuiro_1st", label: "ソベーエス", labelHiragana: "そべーえす", labelHtml: "そべーえす", file: "chord_14_mizuiro_1st.mp3", type: "black-inv", colorClass: "white", soundKey: "sobees", notes: ["G3", "B♭3", "E♭4"] },
+  { name: "B♭-E♭-G", key: "mizuiro_2nd", label: "ベーエスソ", labelHiragana: "べーえすそ", labelHtml: "べーえすそ", file: "chord_14_mizuiro_2nd.mp3", type: "black-inv", colorClass: "white", soundKey: "beesso", notes: ["B♭2", "E♭3", "G3"] }
 ];
 
 // 和音解放の進行順序（色付きの14種）

--- a/style.css
+++ b/style.css
@@ -3462,6 +3462,9 @@ button#dummy-button {
   border-radius: 10px;
   box-sizing: border-box;
 }
+.square-btn-content.note-small {
+  font-size: calc(1em - 2pt) !important;
+}
 
 /* --- dynamic grid layouts --- */
 .grid-container.cols-1 { grid-template-columns: repeat(1, 1fr); max-width: 240px; }


### PR DESCRIPTION
## Summary
- display black-key inversions horizontally
- reduce note-name font size by 2pt

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687b9271c06083239603f88232d3c420