### PR TITLE
Add display mode toggle

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -5,6 +5,7 @@ import { switchScreen, openHelp } from "../main.js";
 import { supabase } from "../utils/supabaseClient.js";
 import { chords, chordOrder } from "../data/chords.js";
 import { generateRecommendedQueue } from "../utils/growthUtils.js"; // use queue util
+import { getDisplayMode, setDisplayMode } from "../utils/displayMode.js";
 import { showCustomConfirm } from "./home.js";
 
 export let selectedChords = [];
@@ -168,6 +169,30 @@ export async function renderSettingsScreen(user) {
   singleSelectWrap.appendChild(singleSelectLabel);
   singleSelectWrap.appendChild(singleSelect);
 
+  const modeWrap = document.createElement('div');
+  modeWrap.className = 'display-mode-wrap';
+  const modeLabel = document.createElement('span');
+  modeLabel.textContent = '表示モード:';
+  const noteBtn = document.createElement('button');
+  noteBtn.className = 'mode-btn';
+  noteBtn.textContent = '音名';
+  const colorBtn = document.createElement('button');
+  colorBtn.className = 'mode-btn';
+  colorBtn.textContent = '色名';
+  modeWrap.appendChild(modeLabel);
+  modeWrap.appendChild(noteBtn);
+  modeWrap.appendChild(colorBtn);
+
+  function updateModeUI(mode) {
+    noteBtn.classList.toggle('active', mode === 'note');
+    colorBtn.classList.toggle('active', mode === 'color');
+  }
+
+  let mode = getDisplayMode(unlockedKeys.length);
+  updateModeUI(mode);
+  noteBtn.onclick = () => { setDisplayMode('note'); updateModeUI('note'); };
+  colorBtn.onclick = () => { setDisplayMode('color'); updateModeUI('color'); };
+
   const controlBar = document.createElement('div');
   controlBar.className = 'settings-controls';
   controlBar.appendChild(titleLine);
@@ -179,6 +204,7 @@ export async function renderSettingsScreen(user) {
   singleCard.className = 'settings-card';
   singleCard.appendChild(singleWrap);
   singleCard.appendChild(singleSelectWrap);
+  singleCard.appendChild(modeWrap);
   cardRow.appendChild(singleCard);
 
   const bulkCard = document.createElement('div');

--- a/components/training.js
+++ b/components/training.js
@@ -12,6 +12,7 @@ import { generateRecommendedQueue } from "../utils/growthUtils.js";
 import { loadGrowthFlags } from "../utils/growthStore_supabase.js";
 import { getAudio } from "../utils/audioCache.js";
 import { kanaToHiragana, noteLabels } from "../utils/noteUtils.js";
+import { getDisplayMode } from "../utils/displayMode.js";
 import { SHOW_DEBUG } from "../utils/debug.js";
 
 let questionCount = 0;
@@ -26,6 +27,7 @@ let singleNoteMode = false;
 let singleNoteStrategy = 'top';
 let chordProgressCount = 0;
 let chordSoundOn = true;
+let displayMode = 'color';
 
 export const stats = {};
 export const mistakes = {};
@@ -79,6 +81,7 @@ export async function renderTrainingScreen(user) {
   chordSoundOn = localStorage.getItem("chordSound") !== "off";
   const flags = await loadGrowthFlags(user.id);
   chordProgressCount = Object.values(flags).filter(f => f.unlocked).length;
+  displayMode = getDisplayMode(chordProgressCount);
   resetResultFlag();
   lastResults = [];
 
@@ -321,7 +324,7 @@ function drawQuizScreen() {
       const inner = document.createElement("div");
       inner.className = `square-btn-content ${only.colorClass}`;
       let showNote = false;
-      if (chordProgressCount >= 10 && only.italian) {
+      if (displayMode === 'note' && only.italian) {
         inner.innerHTML = only.italian.map(kanaToHiragana).join("");
         showNote = true;
       } else {
@@ -365,7 +368,7 @@ function drawQuizScreen() {
       const inner = document.createElement("div");
       inner.className = `square-btn-content ${chord.colorClass}`;
       let noteFlag = false;
-      if (chordProgressCount >= 10 && chord.italian) {
+      if (displayMode === 'note' && chord.italian) {
         inner.innerHTML = chord.italian.map(kanaToHiragana).join("");
         noteFlag = true;
       } else {

--- a/css/settings.css
+++ b/css/settings.css
@@ -306,6 +306,26 @@
   padding: 6px 4px;
 }
 
+.display-mode-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0.5em 0;
+}
+
+.mode-btn {
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  background: #f5f5f5;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.mode-btn.active {
+  background: var(--color-primary);
+  color: #fff;
+}
+
 /* 縦型の設定カード */
 .settings-card-row {
   display: flex;

--- a/style.css
+++ b/style.css
@@ -3024,6 +3024,26 @@ button:hover {
   padding: 6px 4px;
 }
 
+.display-mode-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0.5em 0;
+}
+
+.mode-btn {
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  background: #f5f5f5;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.mode-btn.active {
+  background: var(--color-primary);
+  color: #fff;
+}
+
 /* 縦型の設定カード */
 .settings-card-row {
   display: flex;

--- a/utils/displayMode.js
+++ b/utils/displayMode.js
@@ -1,0 +1,14 @@
+export function getDisplayMode(unlockedCount = 0) {
+  const stored = localStorage.getItem('displayMode');
+  if (stored === 'note' || stored === 'color') return stored;
+  return unlockedCount >= 10 ? 'note' : 'color';
+}
+
+export function setDisplayMode(mode) {
+  if (mode === 'note' || mode === 'color') {
+    localStorage.setItem('displayMode', mode);
+  } else {
+    localStorage.removeItem('displayMode');
+  }
+}
+


### PR DESCRIPTION
## Summary
- add display mode utils
- add display mode toggle in settings UI
- allow choosing note names vs color names in training
- support display mode in results
- style display mode buttons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687b99ccbb24832383d48f8b7ba3f13c