### PR TITLE
Add manual display mode toggle

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -187,6 +187,44 @@ export async function renderSettingsScreen(user) {
   bulkCard.appendChild(bulkDropdown);
   cardRow.appendChild(bulkCard);
 
+  const modeCard = document.createElement('div');
+  modeCard.className = 'settings-card';
+  const modeLabel = document.createElement('div');
+  modeLabel.textContent = '表示モード';
+  const modeWrap = document.createElement('div');
+  modeWrap.className = 'display-mode-toggle';
+  const noteBtn = document.createElement('button');
+  noteBtn.textContent = '音名';
+  const colorBtn = document.createElement('button');
+  colorBtn.textContent = '色名';
+  function updateModeButtons(mode) {
+    if (mode === 'note') {
+      noteBtn.classList.add('active');
+      colorBtn.classList.remove('active');
+    } else {
+      noteBtn.classList.remove('active');
+      colorBtn.classList.add('active');
+    }
+  }
+  let savedMode = localStorage.getItem('displayMode');
+  if (!savedMode) {
+    savedMode = unlockedKeys.length >= 10 ? 'note' : 'color';
+  }
+  updateModeButtons(savedMode);
+  noteBtn.onclick = () => {
+    localStorage.setItem('displayMode', 'note');
+    updateModeButtons('note');
+  };
+  colorBtn.onclick = () => {
+    localStorage.setItem('displayMode', 'color');
+    updateModeButtons('color');
+  };
+  modeWrap.appendChild(noteBtn);
+  modeWrap.appendChild(colorBtn);
+  modeCard.appendChild(modeLabel);
+  modeCard.appendChild(modeWrap);
+  cardRow.appendChild(modeCard);
+
   controlBar.appendChild(cardRow);
 
   headerBar.appendChild(controlBar);

--- a/components/training.js
+++ b/components/training.js
@@ -26,6 +26,7 @@ let singleNoteMode = false;
 let singleNoteStrategy = 'top';
 let chordProgressCount = 0;
 let chordSoundOn = true;
+let displayMode = null; // 'note' or 'color'
 
 export const stats = {};
 export const mistakes = {};
@@ -79,6 +80,10 @@ export async function renderTrainingScreen(user) {
   chordSoundOn = localStorage.getItem("chordSound") !== "off";
   const flags = await loadGrowthFlags(user.id);
   chordProgressCount = Object.values(flags).filter(f => f.unlocked).length;
+  displayMode = localStorage.getItem("displayMode");
+  if (!displayMode) {
+    displayMode = chordProgressCount >= 10 ? "note" : "color";
+  }
   resetResultFlag();
   lastResults = [];
 
@@ -321,7 +326,7 @@ function drawQuizScreen() {
       const inner = document.createElement("div");
       inner.className = `square-btn-content ${only.colorClass}`;
       let showNote = false;
-      if (chordProgressCount >= 10 && only.italian) {
+      if (displayMode === "note" && only.italian) {
         inner.innerHTML = only.italian.map(kanaToHiragana).join("");
         showNote = true;
       } else {
@@ -365,7 +370,7 @@ function drawQuizScreen() {
       const inner = document.createElement("div");
       inner.className = `square-btn-content ${chord.colorClass}`;
       let noteFlag = false;
-      if (chordProgressCount >= 10 && chord.italian) {
+      if (displayMode === "note" && chord.italian) {
         inner.innerHTML = chord.italian.map(kanaToHiragana).join("");
         noteFlag = true;
       } else {

--- a/css/settings.css
+++ b/css/settings.css
@@ -339,6 +339,25 @@
   font-weight: normal;
 }
 
+.display-mode-toggle {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+}
+.display-mode-toggle button {
+  padding: 6px 12px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #fff;
+  font-size: 0.9em;
+  cursor: pointer;
+}
+.display-mode-toggle button.active {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary-dark);
+}
+
 /* その他のトレーニング */
 .other-training {
   background: white;

--- a/style.css
+++ b/style.css
@@ -3057,6 +3057,26 @@ button:hover {
   font-weight: normal;
 }
 
+/* 表示モードトグル */
+.display-mode-toggle {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+}
+.display-mode-toggle button {
+  padding: 6px 12px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #fff;
+  font-size: 0.9em;
+  cursor: pointer;
+}
+.display-mode-toggle button.active {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary-dark);
+}
+
 /* その他のトレーニング */
 .other-training {
   background: white;


### PR DESCRIPTION
## Summary
- add displayMode variable to training logic
- allow choosing Note/Color labels in settings
- sync chosen mode to localStorage
- style display mode toggle

## Testing
- `npm run`

------
https://chatgpt.com/codex/tasks/task_b_687b9cf6b4208323b4b3d93719452a40