### PR TITLE
Adjust settings layout on mobile

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -176,19 +176,19 @@ export async function renderSettingsScreen(user) {
   cardRow.className = 'settings-card-row';
 
   const singleCard = document.createElement('div');
-  singleCard.className = 'settings-card';
+  singleCard.className = 'settings-card single-card';
   singleCard.appendChild(singleWrap);
   singleCard.appendChild(singleSelectWrap);
   cardRow.appendChild(singleCard);
 
   const bulkCard = document.createElement('div');
-  bulkCard.className = 'settings-card';
+  bulkCard.className = 'settings-card bulk-card';
   bulkCard.appendChild(resetBtn);
   bulkCard.appendChild(bulkDropdown);
   cardRow.appendChild(bulkCard);
 
   const modeCard = document.createElement('div');
-  modeCard.className = 'settings-card';
+  modeCard.className = 'settings-card mode-card';
   const modeLabel = document.createElement('div');
   modeLabel.textContent = '表示モード';
   const modeWrap = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -3177,11 +3177,16 @@ button:hover {
   }
   .settings-card-row {
     width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-start;
   }
   .settings-card {
-    flex-basis: 100%;
-    max-width: 100%;
+    flex-basis: calc(50% - 0.5em);
+    max-width: calc(50% - 0.5em);
   }
+  .settings-card.single-card { order: 1; }
+  .settings-card.mode-card { order: 2; }
+  .settings-card.bulk-card { order: 3; }
 }
 
 


### PR DESCRIPTION
## Summary
- add card-specific classes in the settings screen
- rearrange cards on small screens via CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687ba328740c83238acb7f73e5092a7d