### PR TITLE
Add preset load/save and temp user mode

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -1,6 +1,6 @@
 import { signOut } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 import { firebaseAuth } from "../firebase/firebase-init.js"; // ✅ これだけでOK
-import { switchScreen } from "../main.js";
+import { switchScreen, clearTempUser, getBaseUser } from "../main.js";
 import { checkRecentUnlockCriteria } from "../utils/progressStatus.js";
 import { loadGrowthFlags } from "../utils/growthStore_supabase.js";
 import { getCurrentTargetChord } from "../utils/growthUtils.js";
@@ -126,9 +126,30 @@ export function renderHeader(container, user) {
       firebaseAuth.currentUser?.email;
     if (name) {
       const icon = user?.is_premium ? "⭐ " : "";
-      userDiv.textContent = icon + name;
+      if (user?.isTemp) {
+        userDiv.textContent = `${name} (プリセット)`;
+      } else {
+        userDiv.textContent = icon + name;
+      }
       userDiv.style.display = "block";
     }
+  }
+
+  if (user && user.isTemp) {
+    const mode = document.createElement("div");
+    mode.className = "mode-indicator";
+    mode.textContent = `現在のモード：${user.name}（プリセット）`;
+    const right = header.querySelector(".header-right");
+    right.prepend(mode);
+
+    const exitBtn = document.createElement("button");
+    exitBtn.id = "exit-temp-btn";
+    exitBtn.textContent = "通常モードに戻る";
+    exitBtn.onclick = () => {
+      clearTempUser();
+      switchScreen("settings", getBaseUser());
+    };
+    dropdown.appendChild(exitBtn);
   }
 
   // ▼ 解放条件を満たした場合の通知バッジ

--- a/components/presetModal.js
+++ b/components/presetModal.js
@@ -1,0 +1,85 @@
+export function openPresetModal(currentUnlocked) {
+  let modal = document.getElementById('preset-modal');
+  if (!modal) {
+    modal = document.createElement('div');
+    modal.id = 'preset-modal';
+    modal.className = 'modal hidden';
+    modal.innerHTML = `
+      <div class="modal-box">
+        <h3 class="modal-title">出題設定の保存・読み込み</h3>
+        <div class="preset-save">
+          <input type="text" id="preset-name-input" placeholder="プリセット名" />
+          <button id="preset-save-btn">保存</button>
+        </div>
+        <div id="preset-list" class="preset-list"></div>
+        <div class="modal-buttons">
+          <button id="preset-close-btn">キャンセル</button>
+        </div>
+      </div>`;
+    document.body.appendChild(modal);
+  }
+
+  const nameInput = modal.querySelector('#preset-name-input');
+  const saveBtn = modal.querySelector('#preset-save-btn');
+  const listDiv = modal.querySelector('#preset-list');
+  const closeBtn = modal.querySelector('#preset-close-btn');
+
+  const loadPresets = () => JSON.parse(localStorage.getItem('settingPresets') || '[]');
+  const savePresets = (data) => localStorage.setItem('settingPresets', JSON.stringify(data));
+
+  function renderList() {
+    const presets = loadPresets();
+    listDiv.innerHTML = '';
+    presets.forEach((p, i) => {
+      const row = document.createElement('div');
+      row.className = 'preset-item';
+      const span = document.createElement('span');
+      span.textContent = p.name;
+      const loadBtn = document.createElement('button');
+      loadBtn.textContent = '読み込み';
+      loadBtn.onclick = () => {
+        sessionStorage.setItem('trainingMode', 'custom');
+        sessionStorage.setItem('selectedChords', JSON.stringify(p.selectedChords));
+        const tempUser = { id: 'temp', name: p.name, isTemp: true, unlockedKeys: p.unlockedKeys };
+        window.setTempUser(tempUser);
+        modal.classList.add('hidden');
+        window.switchScreen('settings', tempUser);
+      };
+      const delBtn = document.createElement('button');
+      delBtn.textContent = '削除';
+      delBtn.onclick = () => {
+        const list = loadPresets();
+        list.splice(i, 1);
+        savePresets(list);
+        renderList();
+      };
+      row.appendChild(span);
+      row.appendChild(loadBtn);
+      row.appendChild(delBtn);
+      listDiv.appendChild(row);
+    });
+  }
+
+  saveBtn.onclick = () => {
+    const name = nameInput.value.trim();
+    if (!name) return;
+    const presets = loadPresets();
+    if (presets.length >= 10) {
+      alert('最大10件まで保存できます');
+      return;
+    }
+    const stored = sessionStorage.getItem('selectedChords') || localStorage.getItem('selectedChords');
+    const selected = stored ? JSON.parse(stored) : [];
+    presets.push({ name, selectedChords: selected, unlockedKeys: currentUnlocked || [] });
+    savePresets(presets);
+    nameInput.value = '';
+    renderList();
+  };
+
+  closeBtn.onclick = () => {
+    modal.classList.add('hidden');
+  };
+
+  renderList();
+  modal.classList.remove('hidden');
+}

--- a/components/training_easy_note.js
+++ b/components/training_easy_note.js
@@ -120,15 +120,17 @@ export async function renderTrainingScreen(user) {
           nextQuestion();
         } else {
           sessionStorage.setItem("noteHistory", JSON.stringify(noteHistory));
-          await saveTrainingSession({
-            userId: user.id,
-            results: { type: 'note-easy', results: noteHistory },
-            stats: {},
-            mistakes: {},
-            correctCount: noteHistory.filter(n => n.correct).length,
-            totalCount: noteHistory.length,
-            date: new Date().toISOString()
-          });
+          if (!user.isTemp) {
+            await saveTrainingSession({
+              userId: user.id,
+              results: { type: 'note-easy', results: noteHistory },
+              stats: {},
+              mistakes: {},
+              correctCount: noteHistory.filter(n => n.correct).length,
+              totalCount: noteHistory.length,
+              date: new Date().toISOString()
+            });
+          }
           switchScreen("result_easy", user);
         }
       }, FEEDBACK_DELAY);

--- a/components/training_full.js
+++ b/components/training_full.js
@@ -118,15 +118,17 @@ export async function renderTrainingScreen(user) {
           nextQuestion();
         } else {
           sessionStorage.setItem("noteHistory", JSON.stringify(noteHistory));
-          await saveTrainingSession({
-            userId: user.id,
-            results: { type: 'note-full', results: noteHistory },
-            stats: {},
-            mistakes: {},
-            correctCount: noteHistory.filter(n => n.correct).length,
-            totalCount: noteHistory.length,
-            date: new Date().toISOString()
-          });
+          if (!user.isTemp) {
+            await saveTrainingSession({
+              userId: user.id,
+              results: { type: 'note-full', results: noteHistory },
+              stats: {},
+              mistakes: {},
+              correctCount: noteHistory.filter(n => n.correct).length,
+              totalCount: noteHistory.length,
+              date: new Date().toISOString()
+            });
+          }
           switchScreen("result_full", user);
         }
       }, FEEDBACK_DELAY);

--- a/components/training_white_keys.js
+++ b/components/training_white_keys.js
@@ -105,15 +105,17 @@ export async function renderTrainingScreen(user) {
           nextQuestion();
         } else {
           sessionStorage.setItem("noteHistory", JSON.stringify(noteHistory));
-          await saveTrainingSession({
-            userId: user.id,
-            results: { type: 'note-white', results: noteHistory },
-            stats: {},
-            mistakes: {},
-            correctCount: noteHistory.filter(n => n.correct).length,
-            totalCount: noteHistory.length,
-            date: new Date().toISOString()
-          });
+          if (!user.isTemp) {
+            await saveTrainingSession({
+              userId: user.id,
+              results: { type: 'note-white', results: noteHistory },
+              stats: {},
+              mistakes: {},
+              correctCount: noteHistory.filter(n => n.correct).length,
+              totalCount: noteHistory.length,
+              date: new Date().toISOString()
+            });
+          }
           switchScreen("result_white", user);
         }
       }, FEEDBACK_DELAY);

--- a/main.js
+++ b/main.js
@@ -116,6 +116,22 @@ window.addEventListener("error", (e) => {
 
 
 let currentUser = null;
+let baseUser = null;
+let tempUser = null;
+
+export function setTempUser(user) {
+  tempUser = user;
+  currentUser = user;
+}
+
+export function clearTempUser() {
+  tempUser = null;
+  currentUser = baseUser;
+}
+
+export function getBaseUser() {
+  return baseUser;
+}
 
 async function checkTrainingLimit(user) {
   if (!user || user.is_premium || !user.trial_active) return true;
@@ -249,6 +265,7 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
     return;
   }
 
+  baseUser = user;
   currentUser = user;
   if (!user.name || user.name === "名前未設定") {
     switchScreen("setup", user, { showWelcome: true });
@@ -273,3 +290,9 @@ if (document.readyState !== "loading") {
 }
 
 window.addEventListener("load", () => {});
+
+// expose utilities for dynamically loaded modules
+window.switchScreen = switchScreen;
+window.setTempUser = setTempUser;
+window.clearTempUser = clearTempUser;
+window.getBaseUser = getBaseUser;

--- a/style.css
+++ b/style.css
@@ -717,6 +717,32 @@ button:hover {
   background-color: #f5f5f5;
 }
 
+.mode-indicator {
+  font-size: 0.8rem;
+  margin-right: 0.5em;
+}
+
+.preset-save {
+  margin-bottom: 0.5em;
+}
+.preset-save input {
+  padding: 0.3em;
+  margin-right: 0.5em;
+}
+.preset-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.3em;
+}
+.preset-item button {
+  margin-left: 0.3em;
+}
+.preset-list {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
 /* Anchor style for static pages */
 .parent-dropdown a {
   display: block;
@@ -3187,6 +3213,7 @@ button:hover {
   .settings-card.single-card { order: 1; }
   .settings-card.mode-card { order: 2; }
   .settings-card.bulk-card { order: 3; }
+  .settings-card.preset-card { order: 4; }
 }
 
 


### PR DESCRIPTION
## Summary
- implement preset management modal
- add temp user mode to switch between preset and normal settings
- show mode indicator in header with ability to return to normal
- prevent saving records while temp user is active

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687c504aa70883239df5adec4b067eb4