### PR TITLE
Update preset handling and label

### DIFF
--- a/components/presetModal.js
+++ b/components/presetModal.js
@@ -40,7 +40,16 @@ export function openPresetModal(currentUnlocked) {
       loadBtn.onclick = () => {
         sessionStorage.setItem('trainingMode', 'custom');
         sessionStorage.setItem('selectedChords', JSON.stringify(p.selectedChords));
-        const tempUser = { id: 'temp', name: p.name, isTemp: true, unlockedKeys: p.unlockedKeys };
+        const base = window.getBaseUser?.() || {};
+        const tempUser = {
+          id: 'temp',
+          name: p.name,
+          isTemp: true,
+          unlockedKeys: p.unlockedKeys,
+          is_premium: base.is_premium,
+          trial_active: base.trial_active,
+          trial_end_date: base.trial_end_date,
+        };
         window.setTempUser(tempUser);
         modal.classList.add('hidden');
         window.switchScreen('settings', tempUser);

--- a/components/settings.js
+++ b/components/settings.js
@@ -234,7 +234,7 @@ export async function renderSettingsScreen(user) {
   const presetCard = document.createElement('div');
   presetCard.className = 'settings-card preset-card';
   const presetBtn = document.createElement('button');
-  presetBtn.textContent = 'プリセット';
+  presetBtn.textContent = '出題設定を保存・選択';
   presetBtn.onclick = () => openPresetModal(lastUnlockedKeys);
   presetCard.appendChild(presetBtn);
   cardRow.appendChild(presetCard);

--- a/main.js
+++ b/main.js
@@ -148,6 +148,11 @@ async function checkTrainingLimit(user) {
 export const switchScreen = async (screen, user = currentUser, options = {}) => {
   const { replace = false } = options;
 
+  if (currentUser && currentUser.isTemp && screen !== "settings") {
+    clearTempUser();
+    user = currentUser;
+  }
+
   // If the user is locked (trial or premium expired),
   // always redirect to the lock screen except for a few allowed pages.
   const lockType = getLockType(user);


### PR DESCRIPTION
## Summary
- avoid lock screen when loading a preset by inheriting base user status
- automatically return to main user when leaving settings
- rename preset button to "出題設定を保存・選択"

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687c56af85a48323baf3ae37a975e659