### PR TITLE
Fix chord reset dropdown labels

### DIFF
--- a/components/info/chordReset.js
+++ b/components/info/chordReset.js
@@ -30,7 +30,7 @@ export function renderChordResetScreen(user) {
     const opt = document.createElement("option");
     opt.value = idx;
     let label = ch.label;
-    if (idx === 1 || idx === 2) label += "まで"; // 黄色まで・青まで
+    if (idx !== 0) label += "まで"; // 赤以外は「まで」を追加
     opt.textContent = label;
     select.appendChild(opt);
   });


### PR DESCRIPTION
## Summary
- show "まで" on all chord options except red in the chord reset dropdown

## Testing
- `npm run fix-chord-progress` *(fails: Cannot find package '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_b_687c5961233483238ac877c4b3d683ce