### PR TITLE
Improve preset modal UI

### DIFF
--- a/components/presetModal.js
+++ b/components/presetModal.js
@@ -8,7 +8,7 @@ export function openPresetModal(currentUnlocked) {
       <div class="modal-box">
         <h3 class="modal-title">出題設定の保存・読み込み</h3>
         <div class="preset-save">
-          <input type="text" id="preset-name-input" placeholder="プリセット名" />
+          <input type="text" id="preset-name-input" placeholder="プリセット名" maxlength="16" />
           <button id="preset-save-btn">保存</button>
         </div>
         <div id="preset-list" class="preset-list"></div>
@@ -71,7 +71,14 @@ export function openPresetModal(currentUnlocked) {
 
   saveBtn.onclick = () => {
     const name = nameInput.value.trim();
-    if (!name) return;
+    if (!name) {
+      alert('プリセット名を入力してください');
+      return;
+    }
+    if (name.length > 16) {
+      alert('プリセット名は16文字以内で入力してください');
+      return;
+    }
     const presets = loadPresets();
     if (presets.length >= 10) {
       alert('最大10件まで保存できます');

--- a/components/settings.js
+++ b/components/settings.js
@@ -234,7 +234,7 @@ export async function renderSettingsScreen(user) {
   const presetCard = document.createElement('div');
   presetCard.className = 'settings-card preset-card';
   const presetBtn = document.createElement('button');
-  presetBtn.textContent = '出題設定を保存・選択';
+  presetBtn.innerHTML = '出題設定の<br>保存・読み込み';
   presetBtn.onclick = () => openPresetModal(lastUnlockedKeys);
   presetCard.appendChild(presetBtn);
   cardRow.appendChild(presetCard);

--- a/style.css
+++ b/style.css
@@ -735,6 +735,12 @@ button:hover {
   justify-content: space-between;
   margin-bottom: 0.3em;
 }
+.preset-item span {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .preset-item button {
   margin-left: 0.3em;
 }


### PR DESCRIPTION
## Summary
- break preset card button label into two lines
- cap preset names at 16 chars and alert on invalid input
- prevent long preset names from pushing the load button around

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687c5debe2108323a9f032ec04d072a1