### PR TITLE
Fix preset modal closing behavior and button style

### DIFF
--- a/components/presetModal.js
+++ b/components/presetModal.js
@@ -92,9 +92,19 @@ export function openPresetModal(currentUnlocked) {
     renderList();
   };
 
-  closeBtn.onclick = () => {
-    modal.classList.add('hidden');
+  const outsideHandler = (e) => {
+    if (e.target === modal) {
+      closeModal();
+    }
   };
+
+  const closeModal = () => {
+    modal.classList.add('hidden');
+    modal.removeEventListener('click', outsideHandler);
+  };
+
+  closeBtn.onclick = closeModal;
+  modal.addEventListener('click', outsideHandler);
 
   renderList();
   modal.classList.remove('hidden');

--- a/style.css
+++ b/style.css
@@ -3089,6 +3089,12 @@ button:hover {
   font-weight: normal;
 }
 
+/* Adjust preset button size */
+.settings-card.preset-card button {
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
 /* 表示モードトグル */
 .display-mode-toggle {
   display: flex;


### PR DESCRIPTION
## Summary
- close preset modal when clicking outside the dialog
- enlarge the preset button height so text does not overflow

## Testing
- `node -e "require('./components/presetModal.js')"`

------
https://chatgpt.com/codex/tasks/task_b_687c609632588323a114c0ac98ead6bf