### PR TITLE
Fix preset button overflow

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -339,6 +339,15 @@
   font-weight: normal;
 }
 
+.settings-card.preset-card {
+  min-height: 120px;
+}
+.settings-card.preset-card button {
+  font-size: 1.2em;
+  padding: 1em;
+  text-align: center;
+}
+
 .display-mode-toggle {
   display: flex;
   gap: 4px;

--- a/style.css
+++ b/style.css
@@ -3090,9 +3090,13 @@ button:hover {
 }
 
 /* Adjust preset button size */
+.settings-card.preset-card {
+  min-height: 120px;
+}
 .settings-card.preset-card button {
-  padding-top: 12px;
-  padding-bottom: 12px;
+  font-size: 1.2em;
+  padding: 1em;
+  text-align: center;
 }
 
 /* 表示モードトグル */


### PR DESCRIPTION
## Summary
- adjust style for the preset save/load button so it doesn't overflow
- enlarge and center the button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687cca8d63bc8323835fb99c34a9a155