### PR TITLE
Fix preset button layout

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -234,7 +234,7 @@ export async function renderSettingsScreen(user) {
   const presetCard = document.createElement('div');
   presetCard.className = 'settings-card preset-card';
   const presetBtn = document.createElement('button');
-  presetBtn.innerHTML = '出題設定の<br>保存・読み込み';
+  presetBtn.textContent = '出題設定の保存・読み込み';
   presetBtn.onclick = () => openPresetModal(lastUnlockedKeys);
   presetCard.appendChild(presetBtn);
   cardRow.appendChild(presetCard);

--- a/css/settings.css
+++ b/css/settings.css
@@ -343,9 +343,14 @@
   min-height: 120px;
 }
 .settings-card.preset-card button {
-  font-size: 1.2em;
-  padding: 1em;
+  display: block;
+  width: 100%;
+  white-space: normal;
+  word-break: keep-all;
   text-align: center;
+  line-height: 1.4;
+  padding: 1em;
+  font-size: 1em;
 }
 
 .display-mode-toggle {

--- a/style.css
+++ b/style.css
@@ -3094,9 +3094,14 @@ button:hover {
   min-height: 120px;
 }
 .settings-card.preset-card button {
-  font-size: 1.2em;
-  padding: 1em;
+  display: block;
+  width: 100%;
+  white-space: normal;
+  word-break: keep-all;
   text-align: center;
+  line-height: 1.4;
+  padding: 1em;
+  font-size: 1em;
 }
 
 /* 表示モードトグル */


### PR DESCRIPTION
## Summary
- remove manual `<br>` from preset button label
- adjust preset card button layout to prevent text overflow on mobile

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687cdda1a62c8323a250eadd11e9db45