### PR TITLE
Adjust settings controls button height

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -206,7 +206,7 @@
 .settings-controls select {
   padding: 6px 12px;
   font-size: 1em;
-  height: 2.2em;
+  min-height: 2.2em;
 }
 .settings-controls .toggle-wrap {
   height: 2.2em;

--- a/style.css
+++ b/style.css
@@ -2951,7 +2951,7 @@ button:hover {
 .settings-controls select {
   padding: 6px 12px;
   font-size: 1em;
-  height: 2.2em;
+  min-height: 2.2em;
 }
 .settings-controls .toggle-wrap {
   height: 2.2em;


### PR DESCRIPTION
## Summary
- allow settings screen buttons to grow beyond 2.2em using `min-height`

## Testing
- `grep -n "min-height" -R`

------
https://chatgpt.com/codex/tasks/task_b_687d17855d748323ae868d05d86c366f