### PR TITLE
Add preset help button and rename label

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -6,7 +6,7 @@ import { openPresetModal } from "./presetModal.js";
 import { supabase } from "../utils/supabaseClient.js";
 import { chords, chordOrder } from "../data/chords.js";
 import { generateRecommendedQueue } from "../utils/growthUtils.js"; // use queue util
-import { showCustomConfirm } from "./home.js";
+import { showCustomConfirm, showCustomAlert } from "./home.js";
 
 export let selectedChords = [];
 export let lastUnlockedKeys = [];
@@ -233,10 +233,19 @@ export async function renderSettingsScreen(user) {
 
   const presetCard = document.createElement('div');
   presetCard.className = 'settings-card preset-card';
+  const presetWrap = document.createElement('div');
+  presetWrap.className = 'preset-wrap';
   const presetBtn = document.createElement('button');
-  presetBtn.textContent = '出題設定の保存・読み込み';
+  presetBtn.textContent = 'かんたん設定切り替え';
   presetBtn.onclick = () => openPresetModal(lastUnlockedKeys);
-  presetCard.appendChild(presetBtn);
+  const presetHelp = document.createElement('div');
+  presetHelp.className = 'help-button';
+  presetHelp.textContent = '？';
+  presetHelp.onclick = () =>
+    showCustomAlert('出題設定を名前付きで保存・読み込みできます。兄弟など他の人が使うときに一時的に切り替える用途です。成績は保存されません。');
+  presetWrap.appendChild(presetBtn);
+  presetWrap.appendChild(presetHelp);
+  presetCard.appendChild(presetWrap);
   cardRow.appendChild(presetCard);
 
   controlBar.appendChild(cardRow);

--- a/css/settings.css
+++ b/css/settings.css
@@ -342,6 +342,12 @@
 .settings-card.preset-card {
   min-height: 120px;
 }
+.settings-card.preset-card .preset-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  width: 100%;
+}
 .settings-card.preset-card button {
   display: block;
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -3093,6 +3093,12 @@ button:hover {
 .settings-card.preset-card {
   min-height: 120px;
 }
+.settings-card.preset-card .preset-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  width: 100%;
+}
 .settings-card.preset-card button {
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary
- tweak Settings component import
- rename preset button to **かんたん設定切り替え** and add help button with description
- layout preset button and help icon horizontally
- style preset wrap in desktop & mobile CSS

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687d19613b5c83239a8d2fae9947daab