### PR TITLE
Fix help icon layout in settings preset card

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -350,13 +350,17 @@
 }
 .settings-card.preset-card button {
   display: block;
-  width: 100%;
+  flex: 1;
   white-space: normal;
   word-break: keep-all;
   text-align: center;
   line-height: 1.4;
   padding: 1em;
   font-size: 1em;
+}
+.settings-card.preset-card .help-button {
+  margin-left: 0.5em;
+  flex-shrink: 0;
 }
 
 .display-mode-toggle {

--- a/style.css
+++ b/style.css
@@ -3101,13 +3101,17 @@ button:hover {
 }
 .settings-card.preset-card button {
   display: block;
-  width: 100%;
+  flex: 1;
   white-space: normal;
   word-break: keep-all;
   text-align: center;
   line-height: 1.4;
   padding: 1em;
   font-size: 1em;
+}
+.settings-card.preset-card .help-button {
+  margin-left: 0.5em;
+  flex-shrink: 0;
 }
 
 /* 表示モードトグル */


### PR DESCRIPTION
## Summary
- ensure the preset switch button and its help icon sit side-by-side
- remove fixed button width so help icon no longer overlaps
- add margin and prevent shrinking of the help icon

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687d2412590883239d98d2e7eccd7e41