### PR TITLE
Add noindex meta tags

### DIFF
--- a/cancel/index.html
+++ b/cancel/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+  <meta name="robots" content="noindex" />
   <title>決済キャンセル</title>
   <link rel="icon" href="/favicon.ico" />
   <script type="module">

--- a/success/index.html
+++ b/success/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+  <meta name="robots" content="noindex" />
   <title>決済完了</title>
   <link rel="icon" href="/favicon.ico" />
 </head>


### PR DESCRIPTION
## Summary
- prevent search engine indexing on cancel and success pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687dc2200b7c832395adee1ec30d7d00