### PR TITLE
Remove daily training cap for testing

### DIFF
--- a/main.js
+++ b/main.js
@@ -134,14 +134,7 @@ export function getBaseUser() {
 }
 
 async function checkTrainingLimit(user) {
-  if (!user || user.is_premium || !user.trial_active) return true;
-  const today = getToday();
-  const records = await loadTrainingRecords(user.id, today);
-  const todayRecord = records[today] || { sets: 0 };
-  if (todayRecord.sets >= 2) {
-    showCustomAlert("無料ユーザーは一日のトレーニングは2回までです");
-    return false;
-  }
+  // Test mode: temporarily disable the free user daily training limit
   return true;
 }
 


### PR DESCRIPTION
## Summary
- disable free user daily training limit for testing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687f876731c083238d6f3b6739b72bf1