### PR TITLE
Update manual mode highlights

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -204,6 +204,12 @@ function showQuiz() {
   const nextChordName = questionQueue.pop();
   currentAnswer = chords.find(c => c.name === nextChordName);
   drawQuizScreen();
+  if (manualQuestion) {
+    const correctBtn = document.querySelector(`.square-btn-content[data-name="${currentAnswer.name}"]`);
+    if (correctBtn) {
+      correctBtn.classList.add('correct-highlight');
+    }
+  }
   questionCount++;
   updateProgressUI();
 
@@ -743,10 +749,8 @@ function showSingleNoteQuiz(chord, onFinish, isLast = false) {
   }
 
   if (manualQuestion) {
-    chord.notes.forEach(n => {
-      const key = piano.querySelector(`button[data-note="${toPitchClass(n)}"]`);
-      if (key) key.classList.add('key-highlight');
-    });
+    const key = piano.querySelector(`button[data-note="${pitch}"]`);
+    if (key) key.classList.add('key-highlight');
   }
 
   setActive(false);


### PR DESCRIPTION
## Summary
- highlight the correct chord at the start of each manual-mode question
- in single note quizzes highlight only the target note

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687f8c5daf5c83238f12cb3fae9c659a