### PR TITLE
Replace question mark help buttons with icon

### DIFF
--- a/components/presetModal.js
+++ b/components/presetModal.js
@@ -11,7 +11,7 @@ export function openPresetModal(currentUnlocked) {
       <div class="modal-box">
         <h3 class="modal-title">
           出題設定の保存・読み込み
-          <button id="preset-help-btn" class="help-button">？</button>
+          <button id="preset-help-btn" class="help-button"><img src="images/icon_help.webp" alt="ヘルプ" /></button>
         </h3>
         <div class="preset-save">
           <input type="text" id="preset-name-input" placeholder="プリセット名" maxlength="16" />

--- a/components/settings.js
+++ b/components/settings.js
@@ -86,8 +86,8 @@ export async function renderSettingsScreen(user) {
 
   const helpBtn = document.createElement("div");
   helpBtn.className = "help-button";
-  helpBtn.textContent = "？";
-  helpBtn.onclick = () => openHelp('設定画面');
+  helpBtn.innerHTML = '<img src="images/icon_help.webp" alt="ヘルプ" />';
+  helpBtn.onclick = () => openHelp("設定画面");
   titleLine.appendChild(helpBtn);
 
   const totalSpan = document.createElement("span");

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -50,7 +50,7 @@ export async function renderGrowthScreen(user) {
   const helpBtn = document.createElement("button");
   helpBtn.id = "growth-help-btn";
   helpBtn.className = "help-button";
-  helpBtn.textContent = "？";
+  helpBtn.innerHTML = '<img src="images/icon_help.webp" alt="ヘルプ" />';
   helpBtn.onclick = () => openHelp("育成モード");
 
   titleRow.appendChild(title);

--- a/style.css
+++ b/style.css
@@ -272,6 +272,11 @@ button:hover {
   border-radius: 50%;
 }
 
+.help-button img {
+  width: 100%;
+  height: auto;
+}
+
 #help-modal .help-otolon {
   flex: 0 0 auto;
   width: 60px;


### PR DESCRIPTION
## Summary
- use icon_help.webp for all help buttons
- add styling so image fills button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687f8edb9ed88323aa9a88cc9c31dd25