### PR TITLE
Fix offline help icon

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -24,6 +24,8 @@ const STATIC_ASSETS = [
   '/css/info.css',
   '/css/pricing.css',
   '/css/setup.css',
+  '/helpData.json',
+  '/images/icon_help.webp',
   // frequently used audio files preloaded for faster playback
   '/audio/touch.mp3',
   '/audio/good1.mp3',


### PR DESCRIPTION
## Summary
- cache helpData.json and new help icon in service worker to keep the help modal working offline

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687f9152e4108323b841e3d49211b8aa