### PR TITLE
Handle flats in manual mode single note keyboard

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -560,7 +560,7 @@ function chooseSingleNote(notes) {
 }
 
 function toPitchClass(note) {
-  return note.replace(/[0-9]/g, '').replace('♭', 'b');
+  return normalizeNoteName(note).replace(/[0-9]/g, '');
 }
 
 function generateNoteOptions(correct, chordNotes = null) {


### PR DESCRIPTION
## Summary
- ensure manual mode's single-note questions highlight the correct key
  by normalizing flats to sharps when determining the pitch class

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_687f91bc060c8323b122ef70efcc2fc2