### PR TITLE
Fix help modal and styling

### DIFF
--- a/main.js
+++ b/main.js
@@ -61,9 +61,15 @@ let helpOutsideHandler = null;
 let helpKeyHandler = null;
 
 export async function openHelp(topic) {
-  const res = await fetch('helpData.json');
-  const data = await res.json();
-  const help = data[topic];
+  let help;
+  try {
+    const res = await fetch('helpData.json');
+    const data = await res.json();
+    help = data[topic];
+  } catch (e) {
+    console.error('Failed to load help data', e);
+    return;
+  }
   if (!help) return;
 
   document.getElementById('help-title').innerText = help.title;

--- a/style.css
+++ b/style.css
@@ -259,8 +259,8 @@ button:hover {
   margin-left: 0.2em;
   font-size: 0.8em;
   cursor: pointer;
-  background: var(--color-accent);
-  color: #fff;
+  background: transparent;
+  color: inherit;
   border: none;
   padding: 0;
   width: 1.6em;
@@ -270,6 +270,7 @@ button:hover {
   align-items: center;
   justify-content: center;
   border-radius: 50%;
+  outline: none;
 }
 
 .help-button img {


### PR DESCRIPTION
## Summary
- tweak help button style so no yellow background shows
- handle errors when loading help modal content

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687f964ca5188323920c6b65e3b104a9