### PR TITLE
Unify help button style across app

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -84,7 +84,7 @@ export async function renderSettingsScreen(user) {
   titleLine.className = "header-title-line";
   titleLine.innerHTML = `🎼 <strong>出題設定</strong>`;
 
-  const helpBtn = document.createElement("div");
+  const helpBtn = document.createElement("button");
   helpBtn.className = "help-button";
   helpBtn.innerHTML = '<img src="images/icon_help.webp" alt="ヘルプ" />';
   helpBtn.onclick = () => openHelp("設定画面");
@@ -196,8 +196,9 @@ export async function renderSettingsScreen(user) {
   const manualCard = document.createElement('div');
   manualCard.className = 'settings-card manual-card';
   const manualLabel = document.createElement('div');
+  manualLabel.className = 'manual-label';
   manualLabel.textContent = '出題モード';
-  const manualHelp = document.createElement('div');
+  const manualHelp = document.createElement('button');
   manualHelp.className = 'help-button';
   manualHelp.innerHTML = '<img src="images/icon_help.webp" alt="ヘルプ" />';
   manualHelp.onclick = () => openHelp('出題モード');

--- a/css/common.css
+++ b/css/common.css
@@ -157,6 +157,10 @@ button:hover {
 
 .modal-title {
   margin: 0 0 0.5em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3em;
 }
 
 .modal-buttons {

--- a/css/settings.css
+++ b/css/settings.css
@@ -363,6 +363,12 @@
   flex-shrink: 0;
 }
 
+.manual-label {
+  display: flex;
+  align-items: center;
+  gap: 0.2em;
+}
+
 .display-mode-toggle {
   display: flex;
   gap: 4px;

--- a/style.css
+++ b/style.css
@@ -194,6 +194,10 @@ button:hover {
 
 .modal-title {
   margin: 0 0 0.5em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3em;
 }
 
 .modal-buttons {
@@ -3123,6 +3127,12 @@ button:hover {
 .settings-card.preset-card .help-button {
   margin-left: 0.5em;
   flex-shrink: 0;
+}
+
+.manual-label {
+  display: flex;
+  align-items: center;
+  gap: 0.2em;
 }
 
 /* 表示モードトグル */


### PR DESCRIPTION
## Summary
- make help buttons use `<button>` elements in settings screen
- align help icon with labels using `.manual-label` styling
- format modal titles so help icons sit nicely beside text

## Testing
- `npm ls --depth=0` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687f9c41b82c8323b13380906283dfce