### PR TITLE
Unify help button icon size

### DIFF
--- a/style.css
+++ b/style.css
@@ -267,9 +267,9 @@ button:hover {
   color: inherit;
   border: none;
   padding: 0;
-  width: 1.6em;
-  height: 1.6em;
-  line-height: 1.6em;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- standardize help-button size to 20×20 for consistent look

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_687f9edbe9e88323842e9a0cecacd43d