### PR TITLE
Fix help-button size and centering

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -202,7 +202,7 @@
   flex-wrap: wrap;
   gap: 0.75em;
 }
-.settings-controls button,
+.settings-controls button:not(.help-button),
 .settings-controls select {
   padding: 6px 12px;
   font-size: 1em;
@@ -213,6 +213,21 @@
   margin: 0;
   display: flex;
   align-items: center;
+}
+
+.help-button {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  line-height: 1;
 }
 
 .header-title-line #total-count {

--- a/style.css
+++ b/style.css
@@ -260,21 +260,18 @@ button:hover {
 
 
 .help-button {
-  margin-left: 0.2em;
-  font-size: 0.8em;
-  cursor: pointer;
-  background: transparent;
-  color: inherit;
-  border: none;
-  padding: 0;
   width: 24px;
   height: 24px;
-  line-height: 24px;
-  display: inline-flex;
+  border-radius: 50%;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2em;
+  display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 50%;
-  outline: none;
+  padding: 0;
+  line-height: 1;
 }
 
 .help-button img {
@@ -2962,7 +2959,7 @@ button:hover {
   flex-wrap: wrap;
   gap: 0.75em;
 }
-.settings-controls button,
+.settings-controls button:not(.help-button),
 .settings-controls select {
   padding: 6px 12px;
   font-size: 1em;


### PR DESCRIPTION
## Summary
- exclude `.help-button` from generic styles for settings controls
- update `.help-button` styling to keep it centered and square

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687faeb040148323b212664bc3a1c57e