### PR TITLE
Fix help button alignment CSS

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -222,11 +222,12 @@
   border: none;
   cursor: pointer;
   font-size: 1.2em;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0;
   line-height: 1;
+  vertical-align: middle;
 }
 
 .header-title-line .help-button {
@@ -382,9 +383,10 @@
 }
 
 .manual-label {
-  display: flex;
+  /* display: flex; */
   align-items: center;
   gap: 0.2em;
+  position: relative;
 }
 
 .display-mode-toggle {

--- a/style.css
+++ b/style.css
@@ -267,11 +267,12 @@ button:hover {
   border: none;
   cursor: pointer;
   font-size: 1.2em;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0;
   line-height: 1;
+  vertical-align: middle;
 }
 
 .header-title-line .help-button {
@@ -3130,15 +3131,17 @@ button:hover {
 }
 
 .manual-label {
-  display: flex;
+  /* display: flex; */
   align-items: center;
   gap: 0.2em;
+  position: relative;
 }
 
 .mode-label {
-  display: flex;
+  /* display: flex; */
   align-items: center;
   gap: 0.2em;
+  position: relative;
 }
 
 /* 表示モードトグル */


### PR DESCRIPTION
## Summary
- tune `.help-button` alignment using `inline-flex`
- ensure `.manual-label` and `.mode-label` keep alignment without flex

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687fb69c9bf88323a168159db9e318f3