### PR TITLE
Fix header title spacing

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -176,6 +176,7 @@
 .header-title-line {
   display: flex;
   align-items: center;
+  gap: 1em;
   font-size: 1.3em;
   font-weight: bold;
   white-space: nowrap;
@@ -231,7 +232,7 @@
 }
 
 .header-title-line .help-button {
-  margin-left: 0.5em;
+  transform: translateX(-0.5em);
 }
 
 .header-title-line #total-count {

--- a/style.css
+++ b/style.css
@@ -276,7 +276,7 @@ button:hover {
 }
 
 .header-title-line .help-button {
-  margin-left: 0.5em;
+  transform: translateX(-0.5em);
 }
 
 .help-button img {
@@ -2938,6 +2938,7 @@ button:hover {
 .header-title-line {
   display: flex;
   align-items: center;
+  gap: 1em;
   font-size: 1.3em;
   font-weight: bold;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- restore 1em gap in `.header-title-line`
- shift the help button left using CSS transform

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687fbbcd16308323a81d1434910330dd