### PR TITLE
fix: resolve audio after playback

### DIFF
--- a/components/soundPlayer.js
+++ b/components/soundPlayer.js
@@ -19,18 +19,33 @@ export function playNote(noteName) {
   return new Promise((resolve) => {
     const encoded = encodeURIComponent(normalizeNoteName(noteName));
     const audio = getAudio(`sounds/${encoded}.mp3`);
-    audio.addEventListener("ended", resolve);
-    audio.addEventListener("error", () => {
-      console.warn(`音声再生エラー: ${noteName}`);
+
+    const cleanup = () => {
+      audio.removeEventListener("ended", handleEnded);
+      audio.removeEventListener("error", handleError);
+    };
+
+    const handleEnded = () => {
+      cleanup();
       resolve();
-    });
+    };
+
+    const handleError = () => {
+      console.warn(`音声再生エラー: ${noteName}`);
+      cleanup();
+      resolve();
+    };
+
+    audio.addEventListener("ended", handleEnded);
+    audio.addEventListener("error", handleError);
+
     (async () => {
       try {
         await audio.play();
       } catch (e) {
         console.warn(`音声再生エラー: ${noteName}`, e);
+        handleError();
       }
-      resolve();
     })();
   });
 }


### PR DESCRIPTION
## Summary
- wait for audio playback to finish before resolving
- remove audio event listeners after use to avoid buildup

## Testing
- `node <<'NODE' ...` (simulated audio playback)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_688cd253890483239d12e1ca64185876