### PR TITLE
Start first training question on user action

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -150,11 +150,9 @@ export async function renderTrainingScreen(user) {
   if (!questionQueue.length) {
     questionQueue = createQuestionQueue();
   }
-  // 初回は1秒待ってから出題を開始
+  // 初回はユーザー操作内で直接出題を開始
+  nextQuestion(); // ✅ 出題開始！
   showFeedback("はじめるよ", "good");
-  setTimeout(() => {
-    nextQuestion(); // ✅ 出題開始！
-  }, 1000);
 }
 
 async function nextQuestion() {


### PR DESCRIPTION
## Summary
- Call `nextQuestion()` directly from the user interaction to allow immediate audio playback

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_688cd25cd06083238ebb583a0f21b0b0