### PR TITLE
Remove audio event listeners after playback

### DIFF
--- a/components/soundPlayer.js
+++ b/components/soundPlayer.js
@@ -19,15 +19,31 @@ export function playNote(noteName) {
   return new Promise((resolve) => {
     const encoded = encodeURIComponent(normalizeNoteName(noteName));
     const audio = getAudio(`sounds/${encoded}.mp3`);
-    audio.addEventListener("ended", resolve);
-    audio.addEventListener("error", () => {
+
+    const cleanup = () => {
+      audio.removeEventListener("ended", onEnded);
+      audio.removeEventListener("error", onError);
+    };
+
+    const onEnded = () => {
+      cleanup();
+      resolve();
+    };
+
+    const onError = () => {
+      cleanup();
       console.warn(`音声再生エラー: ${noteName}`);
       resolve();
-    });
+    };
+
+    audio.addEventListener("ended", onEnded);
+    audio.addEventListener("error", onError);
+
     (async () => {
       try {
         await audio.play();
       } catch (e) {
+        onError();
         console.warn(`音声再生エラー: ${noteName}`, e);
       }
       resolve();


### PR DESCRIPTION
## Summary
- clean up `ended` and `error` listeners added to cached audio elements

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node test-playNote.mjs`

------
https://chatgpt.com/codex/tasks/task_b_688cd26250cc8323b6762225071353cf