### PR TITLE
Enable single note mode in auto question mode

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -844,7 +844,7 @@ function checkAnswer(selected) {
 
     const isLast = questionQueue.length === 0;
     if (isLast) {
-      if (singleNoteMode && manualQuestion) {
+      if (singleNoteMode) {
         showSingleNoteQuiz(currentAnswer, proceed, true);
       } else {
         proceed();
@@ -853,7 +853,7 @@ function checkAnswer(selected) {
       const voices = ["good1", "good2"];
       showFeedback("いいね", "good");
       playSoundThen(voices[Math.floor(Math.random() * voices.length)], () => {
-        if (singleNoteMode && manualQuestion) {
+        if (singleNoteMode) {
           showSingleNoteQuiz(currentAnswer, proceed, false);
         } else {
           proceed();


### PR DESCRIPTION
## Summary
- ensure single note quiz runs whenever single note mode is enabled, not just in manual mode

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_688cdb75f4e48323b9fcd0e4027b022c