### PR TITLE
fix: handle undefined notes in result screens

### DIFF
--- a/components/result_easy.js
+++ b/components/result_easy.js
@@ -18,6 +18,9 @@ export function renderTrainingEasyResultScreen(user) {
 
   const history = JSON.parse(sessionStorage.getItem("noteHistory") || "[]");
 
+  const resultNotes = history.map(entry => entry.question);
+  console.log('resultNotes', resultNotes);
+
   const vexDiv = document.createElement("div");
   vexDiv.id = "vexflow-staff";
   vexDiv.style.margin = "2em 0";
@@ -33,6 +36,10 @@ export function renderTrainingEasyResultScreen(user) {
   });
 
   function convertForStaff(note) {
+    if (!note || typeof note !== 'string') {
+      console.warn('convertForStaff: invalid note', note);
+      return { clef: "treble", key: "c/4", accidental: null };
+    }
     const m = note.match(/^([A-G]#?)(\d)$/);
     if (!m) return { clef: "treble", key: "c/4", accidental: null };
     const [_, base, octave] = m;
@@ -48,6 +55,7 @@ export function renderTrainingEasyResultScreen(user) {
     const measures = Array.from({ length: Math.ceil(history.length / 3) }, () => ({ treble: [], bass: [] }));
 
     history.forEach((entry, idx) => {
+      console.log('processing:', entry.question);
       const conv = convertForStaff(entry.question);
       const vNote = new VF.StaveNote({ clef: conv.clef, keys: [conv.key], duration: "q" });
       if (conv.accidental) vNote.addAccidental(0, new VF.Accidental(conv.accidental));

--- a/components/result_full.js
+++ b/components/result_full.js
@@ -19,6 +19,9 @@ export function renderTrainingFullResultScreen(user) {
   const history = JSON.parse(sessionStorage.getItem("noteHistory") || "[]");
   const summary = {};
 
+  const resultNotes = history.map(entry => entry.question);
+  console.log('resultNotes', resultNotes);
+
   const validNotes = new Set([
     "A-1","A#-1",
     "A0","A#0","B-1","B0",
@@ -42,6 +45,10 @@ export function renderTrainingFullResultScreen(user) {
   const VF = (typeof Vex !== "undefined" && Vex.Flow) ? Vex.Flow : null; // use global VexFlow 3.x loaded in index.html
 
   function convertForStaff(note) {
+    if (!note || typeof note !== 'string') {
+      console.warn('convertForStaff: invalid note', note);
+      return { clef: "treble", key: "c/4", shift: 0, accidental: null };
+    }
     const m = note.match(/^([A-G]#?)(-?\d)$/);
     if (!m) return { clef: "treble", key: "c/4", shift: 0, accidental: null };
     let [_, base, octaveStr] = m;
@@ -74,6 +81,7 @@ export function renderTrainingFullResultScreen(user) {
   const measures = Array.from({ length: Math.max(1, Math.ceil(entries.length / 5)) }, () => ({ treble: [], bass: [] }));
 
   entries.forEach((entry, idx) => {
+    console.log('processing:', entry.question);
 
     if (!summary[entry.question]) summary[entry.question] = { correct: 0, total: 0 };
     summary[entry.question].total++;

--- a/components/result_white.js
+++ b/components/result_white.js
@@ -18,6 +18,9 @@ export function renderTrainingWhiteResultScreen(user) {
 
   const history = JSON.parse(sessionStorage.getItem("noteHistory") || "[]");
 
+  const resultNotes = history.map(entry => entry.question);
+  console.log('resultNotes', resultNotes);
+
   const vexDiv = document.createElement("div");
   vexDiv.id = "vexflow-staff";
   vexDiv.style.margin = "2em 0";
@@ -33,6 +36,10 @@ export function renderTrainingWhiteResultScreen(user) {
   });
 
   function convertForStaff(note) {
+    if (!note || typeof note !== 'string') {
+      console.warn('convertForStaff: invalid note', note);
+      return { clef: "treble", key: "c/4", accidental: null };
+    }
     const m = note.match(/^([A-G]#?)(\d)$/);
     if (!m) return { clef: "treble", key: "c/4", accidental: null };
     const [_, base, octave] = m;
@@ -48,6 +55,7 @@ export function renderTrainingWhiteResultScreen(user) {
     const measures = Array.from({ length: Math.ceil(history.length / 3) }, () => ({ treble: [], bass: [] }));
 
     history.forEach((entry, idx) => {
+      console.log('processing:', entry.question);
       const conv = convertForStaff(entry.question);
       const vNote = new VF.StaveNote({ clef: conv.clef, keys: [conv.key], duration: "q" });
       if (conv.accidental) vNote.addAccidental(0, new VF.Accidental(conv.accidental));


### PR DESCRIPTION
## Summary
- guard convertForStaff against undefined notes
- log note history when rendering result screens for easier debugging

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_688cdc7bdf208323a3e08ddcb98f87f6