### PR TITLE
Use noteQuestion field in result displays

### DIFF
--- a/components/result_easy.js
+++ b/components/result_easy.js
@@ -18,7 +18,7 @@ export function renderTrainingEasyResultScreen(user) {
 
   const history = JSON.parse(sessionStorage.getItem("noteHistory") || "[]");
 
-  const resultNotes = history.map(entry => entry.question);
+  const resultNotes = history.map(entry => entry.noteQuestion);
   console.log('resultNotes', resultNotes);
 
   const vexDiv = document.createElement("div");
@@ -30,9 +30,9 @@ export function renderTrainingEasyResultScreen(user) {
 
   const summary = {};
   history.forEach(entry => {
-    if (!summary[entry.question]) summary[entry.question] = { correct: 0, total: 0 };
-    summary[entry.question].total++;
-    if (entry.correct) summary[entry.question].correct++;
+    if (!summary[entry.noteQuestion]) summary[entry.noteQuestion] = { correct: 0, total: 0 };
+    summary[entry.noteQuestion].total++;
+    if (entry.correct) summary[entry.noteQuestion].correct++;
   });
 
   function convertForStaff(note) {
@@ -55,8 +55,8 @@ export function renderTrainingEasyResultScreen(user) {
     const measures = Array.from({ length: Math.ceil(history.length / 3) }, () => ({ treble: [], bass: [] }));
 
     history.forEach((entry, idx) => {
-      console.log('processing:', entry.question);
-      const conv = convertForStaff(entry.question);
+      console.log('processing:', entry.noteQuestion);
+      const conv = convertForStaff(entry.noteQuestion);
       const vNote = new VF.StaveNote({ clef: conv.clef, keys: [conv.key], duration: "q" });
       if (conv.accidental) vNote.addAccidental(0, new VF.Accidental(conv.accidental));
       if (!entry.correct) {

--- a/components/result_full.js
+++ b/components/result_full.js
@@ -19,7 +19,7 @@ export function renderTrainingFullResultScreen(user) {
   const history = JSON.parse(sessionStorage.getItem("noteHistory") || "[]");
   const summary = {};
 
-  const resultNotes = history.map(entry => entry.question);
+  const resultNotes = history.map(entry => entry.noteQuestion);
   console.log('resultNotes', resultNotes);
 
   const validNotes = new Set([
@@ -77,18 +77,18 @@ export function renderTrainingFullResultScreen(user) {
     return { key, accidental, shift, clef };
   }
 
-  const entries = history.slice(0, 30).filter(e => validNotes.has(e.question));
+  const entries = history.slice(0, 30).filter(e => validNotes.has(e.noteQuestion));
   const measures = Array.from({ length: Math.max(1, Math.ceil(entries.length / 5)) }, () => ({ treble: [], bass: [] }));
 
   entries.forEach((entry, idx) => {
-    console.log('processing:', entry.question);
+    console.log('processing:', entry.noteQuestion);
 
-    if (!summary[entry.question]) summary[entry.question] = { correct: 0, total: 0 };
-    summary[entry.question].total++;
-    if (entry.correct) summary[entry.question].correct++;
+    if (!summary[entry.noteQuestion]) summary[entry.noteQuestion] = { correct: 0, total: 0 };
+    summary[entry.noteQuestion].total++;
+    if (entry.correct) summary[entry.noteQuestion].correct++;
 
     if (VF) {
-      const conv = convertForStaff(entry.question);
+      const conv = convertForStaff(entry.noteQuestion);
       const vNote = new VF.StaveNote({ clef: conv.clef, keys: [conv.key], duration: "q" });
       if (typeof vNote.setStyle === "function") {
         vNote.setStyle({

--- a/components/result_white.js
+++ b/components/result_white.js
@@ -18,7 +18,7 @@ export function renderTrainingWhiteResultScreen(user) {
 
   const history = JSON.parse(sessionStorage.getItem("noteHistory") || "[]");
 
-  const resultNotes = history.map(entry => entry.question);
+  const resultNotes = history.map(entry => entry.noteQuestion);
   console.log('resultNotes', resultNotes);
 
   const vexDiv = document.createElement("div");
@@ -30,9 +30,9 @@ export function renderTrainingWhiteResultScreen(user) {
 
   const summary = {};
   history.forEach(entry => {
-    if (!summary[entry.question]) summary[entry.question] = { correct: 0, total: 0 };
-    summary[entry.question].total++;
-    if (entry.correct) summary[entry.question].correct++;
+    if (!summary[entry.noteQuestion]) summary[entry.noteQuestion] = { correct: 0, total: 0 };
+    summary[entry.noteQuestion].total++;
+    if (entry.correct) summary[entry.noteQuestion].correct++;
   });
 
   function convertForStaff(note) {
@@ -55,8 +55,8 @@ export function renderTrainingWhiteResultScreen(user) {
     const measures = Array.from({ length: Math.ceil(history.length / 3) }, () => ({ treble: [], bass: [] }));
 
     history.forEach((entry, idx) => {
-      console.log('processing:', entry.question);
-      const conv = convertForStaff(entry.question);
+      console.log('processing:', entry.noteQuestion);
+      const conv = convertForStaff(entry.noteQuestion);
       const vNote = new VF.StaveNote({ clef: conv.clef, keys: [conv.key], duration: "q" });
       if (conv.accidental) vNote.addAccidental(0, new VF.Accidental(conv.accidental));
       if (!entry.correct) {


### PR DESCRIPTION
## Summary
- Use `noteQuestion` instead of `question` when mapping history entries in result components
- Update summaries and staff rendering to reference `noteQuestion`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688ce05eb35883239eb5d060de1362f5