### PR TITLE
refactor: unify note history keys

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -45,8 +45,8 @@ export function createResultTable(results) {
       .map((r, i) => `
         <tr class="${r.correct ? 'correct-row' : 'wrong-row'}">
           <td>${i + 1}</td>
-          <td>${labelNote(r.noteQuestion || '')}</td>
-          <td><span class="ans-mark ${r.correct ? 'correct' : 'wrong'}">${r.correct ? '◯' : ''}</span>${labelNote(r.noteAnswer || '')}</td>
+          <td>${labelNote(r.question || '')}</td>
+          <td><span class="ans-mark ${r.correct ? 'correct' : 'wrong'}">${r.correct ? '◯' : ''}</span>${labelNote(r.answer || '')}</td>
         </tr>`)
       .join('');
     return `<table class="result-table">
@@ -83,8 +83,8 @@ export function createResultTable(results) {
               ${getLabelHiragana(r.answerName)}
             </div>
           </td>
-          ${singleNoteMode ? `<td>${noteRes ? labelNote(noteRes.noteQuestion || '') : ''}</td>` : ''}
-          ${singleNoteMode ? `<td>${noteRes ? '<span class="note-answer">' + '<span class="ans-mark ' + (noteRes.correct ? 'correct' : 'wrong') + '">' + (noteRes.correct ? '◯' : '') + '</span>' + labelNote(noteRes.noteAnswer || '') + '</span>' : ''}</td>` : ''}
+          ${singleNoteMode ? `<td>${noteRes ? labelNote(noteRes.question || '') : ''}</td>` : ''}
+          ${singleNoteMode ? `<td>${noteRes ? '<span class="note-answer">' + '<span class="ans-mark ' + (noteRes.correct ? 'correct' : 'wrong') + '">' + (noteRes.correct ? '◯' : '') + '</span>' + labelNote(noteRes.answer || '') + '</span>' : ''}</td>` : ''}
         </tr>`;
     }
     return rhtml;

--- a/components/result_easy.js
+++ b/components/result_easy.js
@@ -18,7 +18,7 @@ export function renderTrainingEasyResultScreen(user) {
 
   const history = JSON.parse(sessionStorage.getItem("noteHistory") || "[]");
 
-  const resultNotes = history.map(entry => entry.noteQuestion);
+  const resultNotes = history.map(entry => entry.question);
   console.log('resultNotes', resultNotes);
 
   const vexDiv = document.createElement("div");
@@ -30,9 +30,9 @@ export function renderTrainingEasyResultScreen(user) {
 
   const summary = {};
   history.forEach(entry => {
-    if (!summary[entry.noteQuestion]) summary[entry.noteQuestion] = { correct: 0, total: 0 };
-    summary[entry.noteQuestion].total++;
-    if (entry.correct) summary[entry.noteQuestion].correct++;
+    if (!summary[entry.question]) summary[entry.question] = { correct: 0, total: 0 };
+    summary[entry.question].total++;
+    if (entry.correct) summary[entry.question].correct++;
   });
 
   function convertForStaff(note) {
@@ -55,8 +55,8 @@ export function renderTrainingEasyResultScreen(user) {
     const measures = Array.from({ length: Math.ceil(history.length / 3) }, () => ({ treble: [], bass: [] }));
 
     history.forEach((entry, idx) => {
-      console.log('processing:', entry.noteQuestion);
-      const conv = convertForStaff(entry.noteQuestion);
+      console.log('processing:', entry.question);
+      const conv = convertForStaff(entry.question);
       const vNote = new VF.StaveNote({ clef: conv.clef, keys: [conv.key], duration: "q" });
       if (conv.accidental) vNote.addAccidental(0, new VF.Accidental(conv.accidental));
       if (!entry.correct) {

--- a/components/result_full.js
+++ b/components/result_full.js
@@ -19,7 +19,7 @@ export function renderTrainingFullResultScreen(user) {
   const history = JSON.parse(sessionStorage.getItem("noteHistory") || "[]");
   const summary = {};
 
-  const resultNotes = history.map(entry => entry.noteQuestion);
+  const resultNotes = history.map(entry => entry.question);
   console.log('resultNotes', resultNotes);
 
   const validNotes = new Set([
@@ -77,18 +77,18 @@ export function renderTrainingFullResultScreen(user) {
     return { key, accidental, shift, clef };
   }
 
-  const entries = history.slice(0, 30).filter(e => validNotes.has(e.noteQuestion));
+  const entries = history.slice(0, 30).filter(e => validNotes.has(e.question));
   const measures = Array.from({ length: Math.max(1, Math.ceil(entries.length / 5)) }, () => ({ treble: [], bass: [] }));
 
   entries.forEach((entry, idx) => {
-    console.log('processing:', entry.noteQuestion);
+    console.log('processing:', entry.question);
 
-    if (!summary[entry.noteQuestion]) summary[entry.noteQuestion] = { correct: 0, total: 0 };
-    summary[entry.noteQuestion].total++;
-    if (entry.correct) summary[entry.noteQuestion].correct++;
+    if (!summary[entry.question]) summary[entry.question] = { correct: 0, total: 0 };
+    summary[entry.question].total++;
+    if (entry.correct) summary[entry.question].correct++;
 
     if (VF) {
-      const conv = convertForStaff(entry.noteQuestion);
+      const conv = convertForStaff(entry.question);
       const vNote = new VF.StaveNote({ clef: conv.clef, keys: [conv.key], duration: "q" });
       if (typeof vNote.setStyle === "function") {
         vNote.setStyle({

--- a/components/result_white.js
+++ b/components/result_white.js
@@ -18,7 +18,7 @@ export function renderTrainingWhiteResultScreen(user) {
 
   const history = JSON.parse(sessionStorage.getItem("noteHistory") || "[]");
 
-  const resultNotes = history.map(entry => entry.noteQuestion);
+  const resultNotes = history.map(entry => entry.question);
   console.log('resultNotes', resultNotes);
 
   const vexDiv = document.createElement("div");
@@ -30,9 +30,9 @@ export function renderTrainingWhiteResultScreen(user) {
 
   const summary = {};
   history.forEach(entry => {
-    if (!summary[entry.noteQuestion]) summary[entry.noteQuestion] = { correct: 0, total: 0 };
-    summary[entry.noteQuestion].total++;
-    if (entry.correct) summary[entry.noteQuestion].correct++;
+    if (!summary[entry.question]) summary[entry.question] = { correct: 0, total: 0 };
+    summary[entry.question].total++;
+    if (entry.correct) summary[entry.question].correct++;
   });
 
   function convertForStaff(note) {
@@ -55,8 +55,8 @@ export function renderTrainingWhiteResultScreen(user) {
     const measures = Array.from({ length: Math.ceil(history.length / 3) }, () => ({ treble: [], bass: [] }));
 
     history.forEach((entry, idx) => {
-      console.log('processing:', entry.noteQuestion);
-      const conv = convertForStaff(entry.noteQuestion);
+      console.log('processing:', entry.question);
+      const conv = convertForStaff(entry.question);
       const vNote = new VF.StaveNote({ clef: conv.clef, keys: [conv.key], duration: "q" });
       if (conv.accidental) vNote.addAccidental(0, new VF.Accidental(conv.accidental));
       if (!entry.correct) {

--- a/components/training.js
+++ b/components/training.js
@@ -693,8 +693,8 @@ function showSingleNoteQuiz(chord, onFinish, isLast = false) {
     if (!recorded) {
       lastResults.push({
         chordName: chord.name,
-        noteQuestion: note,
-        noteAnswer: selection,
+        question: note,
+        answer: selection,
         correct,
         isSingleNote: true
       });

--- a/components/training_easy_note.js
+++ b/components/training_easy_note.js
@@ -100,8 +100,8 @@ export async function renderTrainingScreen(user) {
     const note = btn.dataset.note;
     const correct = note === currentNote.replace(/[0-9]/g, "");
     noteHistory.push({
-      noteQuestion: currentNote,
-      noteAnswer: note,
+      question: currentNote,
+      answer: note,
       correct,
       isSingleNote: true
     });

--- a/components/training_full.js
+++ b/components/training_full.js
@@ -98,8 +98,8 @@ export async function renderTrainingScreen(user) {
     const note = btn.dataset.note;
     const correct = note === currentNote.replace(/[0-9-]/g, "");
     noteHistory.push({
-      noteQuestion: currentNote,
-      noteAnswer: note,
+      question: currentNote,
+      answer: note,
       correct,
       isSingleNote: true
     });

--- a/components/training_white_keys.js
+++ b/components/training_white_keys.js
@@ -85,8 +85,8 @@ export async function renderTrainingScreen(user) {
     const note = btn.dataset.note;
     const correct = note === currentNote.replace(/[0-9]/g, "");
     noteHistory.push({
-      noteQuestion: currentNote,
-      noteAnswer: note,
+      question: currentNote,
+      answer: note,
       correct,
       isSingleNote: true
     });

--- a/utils/growthStore_supabase.js
+++ b/utils/growthStore_supabase.js
@@ -185,8 +185,8 @@ export async function generateMockSingleNoteData(userId) {
     for (let q = 0; q < total; q++) {
       const correct = q >= mistakeNum;
       results.push({
-        noteQuestion: 'C4',
-        noteAnswer: correct ? 'C4' : 'D4',
+        question: 'C4',
+        answer: correct ? 'C4' : 'D4',
         correct,
         isSingleNote: true
       });


### PR DESCRIPTION
## Summary
- replace `noteQuestion`/`noteAnswer` with `question`/`answer` in single-note trainings and chord training
- update result screens and mock data to consume new key names

## Testing
- `node --check components/training_white_keys.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688ce1b48b048323a72620a024c1b4de