### PR TITLE
feat: add password reset flow

### DIFF
--- a/components/forgotPassword.js
+++ b/components/forgotPassword.js
@@ -1,0 +1,45 @@
+import { supabase } from "../utils/supabaseClient.js";
+import { switchScreen } from "../main.js";
+import { showCustomAlert } from "./home.js";
+
+export function renderForgotPasswordScreen() {
+  const app = document.getElementById("app");
+  app.innerHTML = "";
+
+  const container = document.createElement("div");
+  container.className = "login-wrapper";
+  container.innerHTML = `
+    <h2 class="login-title">パスワードリセット</h2>
+    <form class="login-form">
+      <input type="email" id="reset-email" placeholder="メールアドレス" required />
+      <button type="submit" class="login-button">送信</button>
+    </form>
+    <div class="login-actions">
+      <button id="back-btn" class="login-secondary">戻る</button>
+    </div>
+  `;
+  app.appendChild(container);
+
+  const form = container.querySelector(".login-form");
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const email = form.querySelector("#reset-email").value.trim();
+    if (!email) {
+      showCustomAlert("メールアドレスを入力してください");
+      return;
+    }
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${location.origin}/reset-password`,
+    });
+    if (error) {
+      showCustomAlert("メール送信に失敗しました：" + error.message);
+    } else {
+      showCustomAlert("リセット用のメールを送信しました");
+      switchScreen("login");
+    }
+  });
+
+  container.querySelector("#back-btn").addEventListener("click", () => {
+    switchScreen("login");
+  });
+}

--- a/components/login.js
+++ b/components/login.js
@@ -17,6 +17,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
   container.innerHTML = `
     <div class="login-wrapper">
       <h2 class="login-title">ログイン</h2>
+      <p class="login-success" style="display:none"></p>
       <div class="login-note">
         <p>・Googleでログインしたことがある場合は、必ず「Googleでログイン」を使ってください。</p>
         <p>・メールアドレスとパスワードは、最初にメール認証を使った場合のみ有効です。</p>
@@ -35,6 +36,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       <button id="google-login" class="google-button">Googleでログイン</button>
 
       <div class="login-actions">
+        <button id="forgot-btn" class="login-secondary">パスワードを忘れた方はこちら</button>
         <button id="back-btn" class="login-secondary">戻る</button>
         <button id="signup-btn" class="login-signup">新規登録はこちら</button>
       </div>
@@ -48,6 +50,14 @@ export function renderLoginScreen(container, onLoginSuccess) {
     pwInput.type = visible ? "password" : "text";
     pwToggle.src = visible ? "images/Visibility_off.svg" : "images/Visibility.svg";
   });
+
+  const successMsg = sessionStorage.getItem("passwordResetSuccess");
+  if (successMsg) {
+    const msgEl = container.querySelector(".login-success");
+    msgEl.textContent = "パスワードを変更しました";
+    msgEl.style.display = "block";
+    sessionStorage.removeItem("passwordResetSuccess");
+  }
 
 
 
@@ -155,5 +165,11 @@ export function renderLoginScreen(container, onLoginSuccess) {
   container.querySelector("#signup-btn").addEventListener("click", (e) => {
     e.preventDefault();
     switchScreen("signup");
+  });
+
+  // パスワード忘れリンク
+  container.querySelector("#forgot-btn").addEventListener("click", (e) => {
+    e.preventDefault();
+    switchScreen("forgot_password");
   });
 }

--- a/main.js
+++ b/main.js
@@ -35,6 +35,7 @@ import { renderFaqScreen } from "./components/info/faq.js";
 import { renderChordResetScreen } from "./components/info/chordReset.js";
 import { renderPricingScreen } from "./components/pricing.js";
 import { renderLockScreen } from "./components/lock.js";
+import { renderForgotPasswordScreen } from "./components/forgotPassword.js";
 
 
 import { firebaseAuth } from "./firebase/firebase-init.js";
@@ -201,6 +202,7 @@ export const switchScreen = async (screen, user = currentUser, options = {}) => 
     renderIntroScreen();
   }
   else if (screen === "login") renderLoginScreen(app, () => {});
+  else if (screen === "forgot_password") renderForgotPasswordScreen();
   else if (screen === "home") renderHomeScreen(user, options);
   else if (screen === "training") renderTrainingScreen(user);
   else if (screen === "training_easy") renderTrainingEasy(user);

--- a/reset-password.html
+++ b/reset-password.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>パスワード再設定</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body class="app-root">
+  <div class="login-wrapper">
+    <h2 class="login-title">新しいパスワードを入力</h2>
+    <form id="reset-form" class="login-form">
+      <input type="password" id="new-password" placeholder="新しいパスワード" required />
+      <button type="submit" class="login-button">更新</button>
+    </form>
+  </div>
+
+  <script type="module">
+    import { supabase } from './utils/supabaseClient.js';
+    import { showCustomAlert } from './components/home.js';
+
+    try {
+      await supabase.auth.getSessionFromUrl({ storeSession: true });
+    } catch (e) {
+      showCustomAlert('リンクが無効です：' + e.message);
+    }
+
+    const form = document.getElementById('reset-form');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const pw = document.getElementById('new-password').value.trim();
+      if (!pw) {
+        showCustomAlert('新しいパスワードを入力してください');
+        return;
+      }
+      const { error } = await supabase.auth.updateUser({ password: pw });
+      if (error) {
+        showCustomAlert('パスワードの更新に失敗しました：' + error.message);
+      } else {
+        sessionStorage.setItem('passwordResetSuccess', '1');
+        window.location.href = '/#login';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -2198,6 +2198,12 @@ button:hover {
   font-size: 0.9rem;
 }
 
+.login-success {
+  text-align: center;
+  color: #28a745;
+  margin-bottom: 1rem;
+}
+
 
 .mypage-screen {
   max-width: 480px;


### PR DESCRIPTION
## Summary
- add forgot password screen and link
- send reset email via supabase and add reset page
- show success notice after password update

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_688d8d50af508323bafbd9430068b6c3