### PR TITLE
Fix password reset redirect for Supabase recovery link

### DIFF
--- a/components/forgotPassword.js
+++ b/components/forgotPassword.js
@@ -29,7 +29,7 @@ export function renderForgotPasswordScreen() {
       return;
     }
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${location.origin}/reset-password`,
+      redirectTo: `${location.origin}/reset-password.html`,
     });
     if (error) {
       showCustomAlert("メール送信に失敗しました：" + error.message);

--- a/main.js
+++ b/main.js
@@ -281,12 +281,17 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 });
 
 const initApp = () => {
+  const hash = location.hash;
+  if (hash.includes("type=recovery")) {
+    window.location.replace(`/reset-password.html${hash}`);
+    return;
+  }
   const initial = DEBUG_AUTO_LOGIN ? "home" : "intro";
-  const hash = location.hash.replace("#", "");
-  const startScreen = hash || initial;
-  
+  const screenHash = hash.replace("#", "");
+  const startScreen = screenHash || initial;
+
   switchScreen(startScreen, undefined, { replace: true });
-  
+
 };
 
 if (document.readyState !== "loading") {


### PR DESCRIPTION
## Summary
- redirect password reset emails to `/reset-password.html`
- handle Supabase recovery callback by forwarding to reset page with token

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688d920ff51083238344cee7a59df336