### PR TITLE
feat: add password reset completion screen

### DIFF
--- a/reset-password-success.html
+++ b/reset-password-success.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>パスワード再設定完了</title>
+  <link rel="icon" href="/favicon.ico" />
+  <style>
+    body {
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      text-align: center;
+      background-color: #fffaf7;
+      color: #444;
+      font-family: sans-serif;
+    }
+    .message {
+      font-size: 1.8rem;
+      font-weight: bold;
+      margin-bottom: 1rem;
+    }
+    .sub-text {
+      font-size: 1rem;
+      line-height: 1.6;
+    }
+    .login-button {
+      margin-top: 1.5rem;
+      padding: 1rem 2rem;
+      background-color: #FF7F50;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      font-size: 1.2rem;
+      cursor: pointer;
+      text-decoration: none;
+      transition: background-color 0.3s;
+    }
+    .login-button:hover {
+      background-color: #e26941;
+    }
+  </style>
+</head>
+<body>
+  <div class="message">✅ パスワードの再設定が完了しました！</div>
+  <div class="sub-text">3秒後にログイン画面へ移動します。<br />または、以下のボタンを押してください。</div>
+  <a href="/login.html" class="login-button">ログイン画面へ戻る</a>
+  <script>
+    setTimeout(() => { location.href = '/login.html'; }, 3000);
+  </script>
+</body>
+</html>

--- a/reset-password.html
+++ b/reset-password.html
@@ -38,7 +38,7 @@
         showCustomAlert('パスワードの更新に失敗しました：' + error.message);
       } else {
         sessionStorage.setItem('passwordResetSuccess', '1');
-        window.location.href = '/#login';
+        window.location.href = '/reset-password-success.html';
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- show a dedicated page after resetting password with a friendly message
- auto-redirect users to login after 3 seconds or allow manual navigation via a large button
- direct reset page to new completion screen

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_688d9b98e0488323bc5b4e7631e97bb7