### PR TITLE
Ensure password reset signs out user

### DIFF
--- a/reset-password.html
+++ b/reset-password.html
@@ -25,6 +25,8 @@
   <script type="module">
     import { supabase } from './utils/supabaseClient.js';
     import { showCustomAlert } from './components/home.js';
+    import { firebaseAuth } from './firebase/firebase-init.js';
+    import { signOut } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
 
     try {
       await supabase.auth.getSessionFromUrl({ storeSession: true });
@@ -45,6 +47,16 @@
         showCustomAlert('パスワードの更新に失敗しました：' + error.message);
       } else {
         sessionStorage.setItem('passwordResetSuccess', '1');
+        try {
+          await signOut(firebaseAuth);
+        } catch (e) {
+          console.error('Firebase sign-out failed:', e);
+        }
+        try {
+          await supabase.auth.signOut();
+        } catch (e) {
+          console.error('Supabase sign-out failed:', e);
+        }
         window.location.href = '/reset-password-success.html';
       }
     });


### PR DESCRIPTION
## Summary
- Sign out from Firebase and Supabase after password reset to avoid redirecting locked users back to #lock

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_688d9ff8d0208323b78452b4e95f3479