### PR TITLE
Switch password reset flow to Firebase

### DIFF
--- a/components/forgotPassword.js
+++ b/components/forgotPassword.js
@@ -1,6 +1,7 @@
-import { supabase } from "../utils/supabaseClient.js";
 import { switchScreen } from "../main.js";
 import { showCustomAlert } from "./home.js";
+import { firebaseAuth } from "../firebase/firebase-init.js";
+import { sendPasswordResetEmail } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
 export function renderForgotPasswordScreen() {
   const app = document.getElementById("app");
@@ -28,14 +29,15 @@ export function renderForgotPasswordScreen() {
       showCustomAlert("メールアドレスを入力してください");
       return;
     }
-    const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${location.origin}/reset-password.html`,
-    });
-    if (error) {
-      showCustomAlert("メール送信に失敗しました：" + error.message);
-    } else {
+    try {
+      await sendPasswordResetEmail(firebaseAuth, email, {
+        url: `${location.origin}/reset-password.html`,
+        handleCodeInApp: true,
+      });
       showCustomAlert("リセット用のメールを送信しました");
       switchScreen("login");
+    } catch (error) {
+      showCustomAlert("メール送信に失敗しました：" + error.message);
     }
   });
 

--- a/reset-password.html
+++ b/reset-password.html
@@ -26,10 +26,13 @@
     import { supabase } from './utils/supabaseClient.js';
     import { showCustomAlert } from './components/home.js';
     import { firebaseAuth } from './firebase/firebase-init.js';
-    import { signOut } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+    import { confirmPasswordReset, verifyPasswordResetCode } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+
+    const params = new URLSearchParams(window.location.search);
+    const oobCode = params.get('oobCode');
 
     try {
-      await supabase.auth.getSessionFromUrl({ storeSession: true });
+      await verifyPasswordResetCode(firebaseAuth, oobCode);
     } catch (e) {
       showCustomAlert('リンクが無効です：' + e.message);
     }
@@ -42,22 +45,17 @@
         showCustomAlert('新しいパスワードを入力してください');
         return;
       }
-      const { error } = await supabase.auth.updateUser({ password: pw });
-      if (error) {
-        showCustomAlert('パスワードの更新に失敗しました：' + error.message);
-      } else {
+      try {
+        await confirmPasswordReset(firebaseAuth, oobCode, pw);
         sessionStorage.setItem('passwordResetSuccess', '1');
-        try {
-          await signOut(firebaseAuth);
-        } catch (e) {
-          console.error('Firebase sign-out failed:', e);
-        }
         try {
           await supabase.auth.signOut();
         } catch (e) {
           console.error('Supabase sign-out failed:', e);
         }
         window.location.href = '/reset-password-success.html';
+      } catch (error) {
+        showCustomAlert('パスワードの更新に失敗しました：' + error.message);
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- Use Firebase's sendPasswordResetEmail in the forgot password screen
- Verify reset codes and apply new password using Firebase on reset page

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_b_688da0f8dcd88323a00efda0e241cdc6