### PR TITLE
Show hint for Google login on invalid credentials

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -30,6 +30,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
         </div>
         <button type="submit">ログイン</button>
       </form>
+      <p class="login-error" style="display:none"></p>
 
       <div class="login-divider">または</div>
 
@@ -58,6 +59,8 @@ export function renderLoginScreen(container, onLoginSuccess) {
     msgEl.style.display = "block";
     sessionStorage.removeItem("passwordResetSuccess");
   }
+
+  const loginErrorEl = container.querySelector(".login-error");
 
 
 
@@ -118,6 +121,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
   const form = container.querySelector(".login-form");
   form.addEventListener("submit", async (e) => {
     e.preventDefault();
+    loginErrorEl.style.display = "none";
     const email = form.querySelector("#email").value.trim();
     const password = form.querySelector("#password").value.trim();
 
@@ -140,7 +144,11 @@ export function renderLoginScreen(container, onLoginSuccess) {
       await ensureUserAndProgress(user);
       onLoginSuccess();
     } catch (err) {
-      if (err.code === "auth/missing-password" || err.code === "auth/wrong-password") {
+      if (err.code === "auth/invalid-credential") {
+        loginErrorEl.textContent =
+          "ログインできませんでした。このメールアドレスは Googleアカウントで登録されている可能性があります。下の『Googleでログイン』ボタンからお試しください。";
+        loginErrorEl.style.display = "block";
+      } else if (err.code === "auth/missing-password" || err.code === "auth/wrong-password") {
         showCustomAlert("このアカウントはGoogleで登録されている可能性があります。Googleログインをお試しください。");
       } else {
         showCustomAlert("ログイン失敗：" + err.message);

--- a/style.css
+++ b/style.css
@@ -2204,6 +2204,14 @@ button:hover {
   margin-bottom: 1rem;
 }
 
+.login-error {
+  margin-top: 0.5rem;
+  color: #d93025;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  text-align: center;
+}
+
 
 .mypage-screen {
   max-width: 480px;


### PR DESCRIPTION
## Summary
- display inline guidance when Firebase returns auth/invalid-credential during login
- style login error message for visibility on mobile

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688da26699cc8323b29a34930e6a67f8