### PR TITLE
feat: add password confirmation field

### DIFF
--- a/reset-password.html
+++ b/reset-password.html
@@ -10,7 +10,15 @@
   <div class="login-wrapper">
     <h2 class="login-title">新しいパスワードを入力</h2>
     <form id="reset-form" class="login-form">
-      <input type="password" id="new-password" placeholder="新しいパスワード" required />
+      <div class="password-wrapper">
+        <input type="password" id="new-password" placeholder="新しいパスワード" required />
+        <img src="images/Visibility_off.svg" id="toggle-new-password" class="toggle-password" alt="絶対音感トレーニングアプリ『オトロン』パスワード表示切り替えアイコン" />
+      </div>
+      <div class="password-wrapper">
+        <input type="password" id="confirm-password" placeholder="もう一度入力してください" required />
+        <img src="images/Visibility_off.svg" id="toggle-confirm-password" class="toggle-password" alt="絶対音感トレーニングアプリ『オトロン』パスワード表示切り替えアイコン" />
+      </div>
+      <p id="password-error" class="password-error" style="display: none;">パスワードが一致しません</p>
       <button type="submit" class="login-button">更新</button>
     </form>
   </div>
@@ -38,13 +46,47 @@
     }
 
     const form = document.getElementById('reset-form');
+    const newPwInput = document.getElementById('new-password');
+    const confirmPwInput = document.getElementById('confirm-password');
+    const errorEl = document.getElementById('password-error');
+    const submitBtn = form.querySelector('button');
+    const newToggle = document.getElementById('toggle-new-password');
+    const confirmToggle = document.getElementById('toggle-confirm-password');
+
+    function toggleVisibility(input, toggle) {
+      toggle.addEventListener('click', () => {
+        const visible = input.type === 'text';
+        input.type = visible ? 'password' : 'text';
+        toggle.src = visible ? 'images/Visibility_off.svg' : 'images/Visibility.svg';
+      });
+    }
+
+    toggleVisibility(newPwInput, newToggle);
+    toggleVisibility(confirmPwInput, confirmToggle);
+
+    function checkMatch() {
+      const newPw = newPwInput.value.trim();
+      const confirmPw = confirmPwInput.value.trim();
+      const mismatch = newPw && confirmPw && newPw !== confirmPw;
+      if (mismatch) {
+        errorEl.style.display = 'block';
+      } else {
+        errorEl.style.display = 'none';
+      }
+      submitBtn.disabled = !(newPw && confirmPw) || mismatch;
+    }
+
+    newPwInput.addEventListener('input', checkMatch);
+    confirmPwInput.addEventListener('input', checkMatch);
+    newPwInput.addEventListener('blur', checkMatch);
+    confirmPwInput.addEventListener('blur', checkMatch);
+    checkMatch();
+
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
-      const pw = document.getElementById('new-password').value.trim();
-      if (!pw) {
-        showCustomAlert('新しいパスワードを入力してください');
-        return;
-      }
+      checkMatch();
+      if (submitBtn.disabled) return;
+      const pw = newPwInput.value.trim();
       try {
         await confirmPasswordReset(firebaseAuth, oobCode, pw);
         sessionStorage.setItem('passwordResetSuccess', '1');


### PR DESCRIPTION
## Summary
- add confirm password field with show/hide icon
- validate passwords match before reset

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_688da4dea2ac8323b9e164a2c882ee7d