### PR TITLE
chore: update reset password redirect

### DIFF
--- a/components/forgotPassword.js
+++ b/components/forgotPassword.js
@@ -43,7 +43,7 @@ export function renderForgotPasswordScreen() {
       }
 
       await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: "https://otoron-app.vercel.app/reset-password",
+        redirectTo: "https://otoron-app.vercel.app/reset-password.html",
       });
       showCustomAlert(
         "リセット用のメールを送信しました。※ Googleなど外部サービスで登録されたアカウントは、パスワードの再設定はできません。" +

--- a/vercel.json
+++ b/vercel.json
@@ -9,5 +9,8 @@
         }
       ]
     }
+  ],
+  "rewrites": [
+    { "source": "/reset-password", "destination": "/reset-password.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- fix password reset link to target reset-password.html
- add vercel rewrite for /reset-password route

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688dd3a9dcf88323ad9afeb27760f9b6