### PR TITLE
chore: standardize password reset with firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ if (signInError) {
 
 `main.js` では上記のサインアップ・サインイン処理を行った後、ユーザー情報の登録や画面遷移を行います。
 
+## パスワードリセットの流れ
+
+パスワードの再設定メールは Firebase の `sendPasswordResetEmail` で送信します。メール内のリンクは `/reset-password.html` にリダイレクトされ、URL に含まれる `oobCode` を使って `verifyPasswordResetCode` と `confirmPasswordReset` を実行し、新しいパスワードを確定します。Supabase はこのフローには関与しません。
+
 ## Supabase Configuration
 
 アプリが利用する標準の Supabase プロジェクトは下記の URL とキーです。誤って別の DB に切り替えた場合は `utils/supabaseClient.js` をこの設定に戻してください。

--- a/components/forgotPassword.js
+++ b/components/forgotPassword.js
@@ -1,8 +1,10 @@
 import { switchScreen } from "../main.js";
 import { showCustomAlert } from "./home.js";
 import { firebaseAuth } from "../firebase/firebase-init.js";
-import { fetchSignInMethodsForEmail } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
-import { supabase } from "../utils/supabaseClient.js";
+import {
+  fetchSignInMethodsForEmail,
+  sendPasswordResetEmail,
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
 export function renderForgotPasswordScreen() {
   const app = document.getElementById("app");
@@ -42,8 +44,11 @@ export function renderForgotPasswordScreen() {
         return;
       }
 
-      await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: "https://otoron-app.vercel.app/reset-password.html",
+      // Use Firebase to send the password reset email. The generated link
+      // includes an `oobCode` query parameter that `reset-password.html`
+      // consumes to finalize the update.
+      await sendPasswordResetEmail(firebaseAuth, email, {
+        url: "https://otoron-app.vercel.app/reset-password.html",
       });
       showCustomAlert(
         "リセット用のメールを送信しました。※ Googleなど外部サービスで登録されたアカウントは、パスワードの再設定はできません。" +

--- a/main.js
+++ b/main.js
@@ -282,10 +282,6 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 
 const initApp = () => {
   const hash = location.hash;
-  if (hash.includes("type=recovery")) {
-    window.location.replace(`/reset-password.html${hash}`);
-    return;
-  }
   const initial = DEBUG_AUTO_LOGIN ? "home" : "intro";
   const screenHash = hash.replace("#", "");
   const startScreen = screenHash || initial;

--- a/reset-password.html
+++ b/reset-password.html
@@ -36,6 +36,9 @@
     import { firebaseAuth } from './firebase/firebase-init.js';
     import { confirmPasswordReset, verifyPasswordResetCode } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
 
+    // Firebase's password reset link appends an `oobCode` query parameter
+    // that represents the reset token. Parse it from the URL and verify it
+    // before allowing the user to set a new password.
     const params = new URLSearchParams(window.location.search);
     const oobCode = params.get('oobCode');
 


### PR DESCRIPTION
## Summary
- unify password reset flow to use Firebase's `sendPasswordResetEmail`
- document the Firebase-based password reset process
- drop legacy Supabase recovery handling

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_688dd4b39f3c83239b4b03b15596e945