### PR TITLE
Switch password reset to Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ if (signInError) {
 
 ## パスワードリセットの流れ
 
-パスワードの再設定メールは Firebase の `sendPasswordResetEmail` で送信します。メール内のリンクは `/reset-password.html` にリダイレクトされ、URL に含まれる `oobCode` を使って `verifyPasswordResetCode` と `confirmPasswordReset` を実行し、新しいパスワードを確定します。Supabase はこのフローには関与しません。
+パスワードの再設定メールは Supabase の `resetPasswordForEmail` で送信します。メール内のリンクは `/reset-password.html` にリダイレクトされ、URL ハッシュに含まれる `access_token` と `refresh_token` を用いてセッションを確立し `updateUser` で新しいパスワードを確定します。Firebase はこのフローには関与しません。
 
 ## Supabase Configuration
 

--- a/components/forgotPassword.js
+++ b/components/forgotPassword.js
@@ -1,10 +1,8 @@
 import { switchScreen } from "../main.js";
 import { showCustomAlert } from "./home.js";
 import { firebaseAuth } from "../firebase/firebase-init.js";
-import {
-  fetchSignInMethodsForEmail,
-  sendPasswordResetEmail,
-} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+import { fetchSignInMethodsForEmail } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+import { supabase } from "../utils/supabaseClient.js";
 
 export function renderForgotPasswordScreen() {
   const app = document.getElementById("app");
@@ -44,12 +42,13 @@ export function renderForgotPasswordScreen() {
         return;
       }
 
-      // Use Firebase to send the password reset email. The generated link
-      // includes an `oobCode` query parameter that `reset-password.html`
-      // consumes to finalize the update.
-      await sendPasswordResetEmail(firebaseAuth, email, {
-        url: "https://otoron-app.vercel.app/reset-password.html",
+      // Supabase sends the password reset email and embeds access_token and
+      // refresh_token in the redirect URL hash. `reset-password.html` consumes
+      // these tokens to finalize the update.
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: "https://otoron-app.vercel.app/reset-password.html",
       });
+      if (error) throw error;
       showCustomAlert(
         "リセット用のメールを送信しました。※ Googleなど外部サービスで登録されたアカウントは、パスワードの再設定はできません。" +
           "ログイン画面の『Googleでログイン』ボタンをご利用ください。",

--- a/reset-password.html
+++ b/reset-password.html
@@ -33,17 +33,23 @@
   <script type="module">
     import { supabase } from './utils/supabaseClient.js';
     import { showCustomAlert } from './components/home.js';
-    import { firebaseAuth } from './firebase/firebase-init.js';
-    import { confirmPasswordReset, verifyPasswordResetCode } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
 
-    // Firebase's password reset link appends an `oobCode` query parameter
-    // that represents the reset token. Parse it from the URL and verify it
-    // before allowing the user to set a new password.
-    const params = new URLSearchParams(window.location.search);
-    const oobCode = params.get('oobCode');
+    // Supabase's password reset redirect includes `access_token` and
+    // `refresh_token` in the URL hash. Extract them and establish a session
+    // so the user can update their password.
+    const hashParams = new URLSearchParams(window.location.hash.slice(1));
+    const accessToken = hashParams.get('access_token');
+    const refreshToken = hashParams.get('refresh_token');
 
     try {
-      await verifyPasswordResetCode(firebaseAuth, oobCode);
+      if (!accessToken || !refreshToken) {
+        throw new Error('missing token');
+      }
+      const { error: sessionError } = await supabase.auth.setSession({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+      });
+      if (sessionError) throw sessionError;
     } catch (e) {
       showCustomAlert('リンクが無効です：' + e.message);
     }
@@ -91,7 +97,8 @@
       if (submitBtn.disabled) return;
       const pw = newPwInput.value.trim();
       try {
-        await confirmPasswordReset(firebaseAuth, oobCode, pw);
+        const { error } = await supabase.auth.updateUser({ password: pw });
+        if (error) throw error;
         sessionStorage.setItem('passwordResetSuccess', '1');
         try {
           await supabase.auth.signOut();


### PR DESCRIPTION
## Summary
- use Supabase to send reset password emails and finalize updates
- document new Supabase-based reset flow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688de0d8fd4c832383abee2ef23c2bfa