### PR TITLE
fix: ensure password reset page works

### DIFF
--- a/reset-password.html
+++ b/reset-password.html
@@ -32,7 +32,10 @@
 
   <script type="module">
     import { supabase } from './utils/supabaseClient.js';
-    import { showCustomAlert } from './components/home.js';
+
+    function showCustomAlert(message) {
+      alert(message);
+    }
 
     // Supabase's password reset redirect includes `access_token` and
     // `refresh_token` in the URL hash. Extract them and establish a session
@@ -105,6 +108,7 @@
         } catch (e) {
           console.error('Supabase sign-out failed:', e);
         }
+        showCustomAlert('パスワードの更新が完了しました');
         window.location.href = '/reset-password-success.html';
       } catch (error) {
         showCustomAlert('パスワードの更新に失敗しました：' + error.message);


### PR DESCRIPTION
## Summary
- define standalone showCustomAlert in reset-password page to avoid importing home.js
- show alert after password update and redirect to success page

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_688df338539883238ff31afe7e62ccac