### PR TITLE
Fix password toggle visibility on reset page

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -126,6 +126,7 @@ button:hover {
   width: 24px;
   height: 24px;
   cursor: pointer;
+  z-index: 1;
 }
 
 /* Modal styles */

--- a/style.css
+++ b/style.css
@@ -163,6 +163,7 @@ button:hover {
   width: 24px;
   height: 24px;
   cursor: pointer;
+  z-index: 1;
 }
 
 /* Modal styles */


### PR DESCRIPTION
## Summary
- ensure password visibility icons sit above inputs by setting z-index

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688df5978eac8323adf8b6ebb43fce79