### PR TITLE
fix: update password reset redirects

### DIFF
--- a/components/forgotPassword.js
+++ b/components/forgotPassword.js
@@ -46,7 +46,7 @@ export function renderForgotPasswordScreen() {
       // refresh_token in the redirect URL hash. `reset-password.html` consumes
       // these tokens to finalize the update.
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: "https://otoron-app.vercel.app/reset-password.html",
+        redirectTo: "https://playotoron.com/reset-password.html",
       });
       if (error) throw error;
       showCustomAlert(

--- a/reset-password-success.html
+++ b/reset-password-success.html
@@ -47,9 +47,11 @@
 <body>
   <div class="message">✅ パスワードの再設定が完了しました！</div>
   <div class="sub-text">3秒後にログイン画面へ移動します。<br />または、以下のボタンを押してください。</div>
-  <a href="/#login" class="login-button">ログイン画面へ戻る</a>
+  <a href="https://playotoron.com/#login" class="login-button">ログイン画面へ戻る</a>
   <script>
-    setTimeout(() => { location.href = '/#login'; }, 3000);
+    setTimeout(() => {
+      location.href = 'https://playotoron.com/#login';
+    }, 3000);
   </script>
 </body>
 </html>

--- a/reset-password.html
+++ b/reset-password.html
@@ -24,7 +24,7 @@
   </div>
 
   <p style="margin-top: 20px; text-align: center;">
-    <a href="/#login"
+    <a href="https://playotoron.com/#login"
        style="display: inline-block; padding: 10px 20px; background-color: #FF7F50; color: white; text-decoration: none; border-radius: 6px;">
       ログイン画面に戻る
     </a>
@@ -43,6 +43,7 @@
     const hashParams = new URLSearchParams(window.location.hash.slice(1));
     const accessToken = hashParams.get('access_token');
     const refreshToken = hashParams.get('refresh_token');
+    let validSession = true;
 
     try {
       if (!accessToken || !refreshToken) {
@@ -54,6 +55,7 @@
       });
       if (sessionError) throw sessionError;
     } catch (e) {
+      validSession = false;
       showCustomAlert('リンクが無効です：' + e.message);
     }
 
@@ -64,6 +66,12 @@
     const submitBtn = form.querySelector('button');
     const newToggle = document.getElementById('toggle-new-password');
     const confirmToggle = document.getElementById('toggle-confirm-password');
+
+    if (!validSession) {
+      newPwInput.disabled = true;
+      confirmPwInput.disabled = true;
+      submitBtn.disabled = true;
+    }
 
     function toggleVisibility(input, toggle) {
       toggle.addEventListener('click', () => {
@@ -109,7 +117,7 @@
           console.error('Supabase sign-out failed:', e);
         }
         showCustomAlert('パスワードの更新が完了しました');
-        window.location.href = '/reset-password-success.html';
+        window.location.href = 'https://playotoron.com/reset-password-success.html';
       } catch (error) {
         showCustomAlert('パスワードの更新に失敗しました：' + error.message);
       }


### PR DESCRIPTION
## Summary
- redirect reset password flow to playotoron.com login
- disable reset form when link token invalid

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_688e0776d6f08323974d1f94cbe019ee