### PR TITLE
fix: handle Supabase recovery links

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,13 @@
 
     gtag('config', 'G-QCRGGLGDER');
   </script>
+  <script>
+    // Supabaseのパスワードリカバリーリンクでアクセスされた場合、
+    // 専用のパスワード再設定ページへ転送する
+    if (location.hash.includes('type=recovery')) {
+      window.location.replace('/reset-password.html' + location.hash);
+    }
+  </script>
   <script type="module">
     import { showDebugLog } from './utils/loginDebug.js';
     const debugMode = new URLSearchParams(window.location.search).get('debug') === '1';


### PR DESCRIPTION
## Summary
- redirect password recovery links to dedicated reset page so users can update their password

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_688e0c2f6f988323b36c31034e2c12d4