### PR TITLE
fix: use production domain for auth redirects

### DIFF
--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -33,7 +33,7 @@ export default async function handler(req, res) {
 
   try {
     const origin = req.headers.origin;
-    const baseUrl = (process.env.BASE_URL || origin || 'https://otoron-app.vercel.app').replace(/\/$/, '');
+    const baseUrl = (process.env.BASE_URL || origin || 'https://playotoron.com').replace(/\/$/, '');
 
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',


### PR DESCRIPTION
## Summary
- use playotoron.com as default base URL for server-side redirects

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_688e10806dcc83238ca178e8b95ed0a2