### PR TITLE
Use Firebase for password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ if (signInError) {
 
 ## パスワードリセットの流れ
 
-パスワードの再設定メールは Supabase の `resetPasswordForEmail` で送信します。メール内のリンクは `/reset-password.html` にリダイレクトされ、URL ハッシュに含まれる `access_token` と `refresh_token` を用いてセッションを確立し `updateUser` で新しいパスワードを確定します。Firebase はこのフローには関与しません。
+パスワードの再設定メールは Firebase の `sendPasswordResetEmail` で送信します。メール内のリンクは `/reset-password.html` にリダイレクトされ、クエリパラメータの `oobCode` を `verifyPasswordResetCode` で検証し、`confirmPasswordReset` で新しいパスワードを確定します。Supabase の認証情報は常にダミーパスワードを使用するため更新しません。
 
 ## Supabase Configuration
 

--- a/components/forgotPassword.js
+++ b/components/forgotPassword.js
@@ -1,8 +1,10 @@
 import { switchScreen } from "../main.js";
 import { showCustomAlert } from "./home.js";
 import { firebaseAuth } from "../firebase/firebase-init.js";
-import { fetchSignInMethodsForEmail } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
-import { supabase } from "../utils/supabaseClient.js";
+import {
+  fetchSignInMethodsForEmail,
+  sendPasswordResetEmail,
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
 export function renderForgotPasswordScreen() {
   const app = document.getElementById("app");
@@ -42,13 +44,10 @@ export function renderForgotPasswordScreen() {
         return;
       }
 
-      // Supabase sends the password reset email and embeds access_token and
-      // refresh_token in the redirect URL hash. `reset-password.html` consumes
-      // these tokens to finalize the update.
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: "https://playotoron.com/reset-password.html",
+      // Firebase sends the password reset email and redirects to our reset page.
+      await sendPasswordResetEmail(firebaseAuth, email, {
+        url: "https://playotoron.com/reset-password.html",
       });
-      if (error) throw error;
       showCustomAlert(
         "リセット用のメールを送信しました。※ Googleなど外部サービスで登録されたアカウントは、パスワードの再設定はできません。" +
           "ログイン画面の『Googleでログイン』ボタンをご利用ください。",

--- a/reset-password.html
+++ b/reset-password.html
@@ -31,29 +31,27 @@
   </p>
 
   <script type="module">
-    import { supabase } from './utils/supabaseClient.js';
+    import { firebaseAuth } from './firebase/firebase-init.js';
+    import {
+      verifyPasswordResetCode,
+      confirmPasswordReset,
+    } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
 
     function showCustomAlert(message) {
       alert(message);
     }
 
-    // Supabase's password reset redirect includes `access_token` and
-    // `refresh_token` in the URL hash. Extract them and establish a session
-    // so the user can update their password.
-    const hashParams = new URLSearchParams(window.location.hash.slice(1));
-    const accessToken = hashParams.get('access_token');
-    const refreshToken = hashParams.get('refresh_token');
+    // Firebase's password reset email includes an `oobCode` query parameter.
+    // Verify it before allowing the user to enter a new password.
+    const queryParams = new URLSearchParams(window.location.search);
+    const oobCode = queryParams.get('oobCode');
     let validSession = true;
 
     try {
-      if (!accessToken || !refreshToken) {
-        throw new Error('missing token');
+      if (!oobCode) {
+        throw new Error('missing code');
       }
-      const { error: sessionError } = await supabase.auth.setSession({
-        access_token: accessToken,
-        refresh_token: refreshToken,
-      });
-      if (sessionError) throw sessionError;
+      await verifyPasswordResetCode(firebaseAuth, oobCode);
     } catch (e) {
       validSession = false;
       showCustomAlert('リンクが無効です：' + e.message);
@@ -108,14 +106,8 @@
       if (submitBtn.disabled) return;
       const pw = newPwInput.value.trim();
       try {
-        const { error } = await supabase.auth.updateUser({ password: pw });
-        if (error) throw error;
+        await confirmPasswordReset(firebaseAuth, oobCode, pw);
         sessionStorage.setItem('passwordResetSuccess', '1');
-        try {
-          await supabase.auth.signOut();
-        } catch (e) {
-          console.error('Supabase sign-out failed:', e);
-        }
         showCustomAlert('パスワードの更新が完了しました');
         window.location.href = 'https://playotoron.com/reset-password-success.html';
       } catch (error) {


### PR DESCRIPTION
## Summary
- send password reset emails through Firebase instead of Supabase
- verify and confirm password reset using Firebase SDK without updating Supabase password
- document the new Firebase-based reset flow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688e16cafa5c8323a508096882f684fa