### PR TITLE
Switch password reset flow to Supabase

### DIFF
--- a/components/forgotPassword.js
+++ b/components/forgotPassword.js
@@ -1,10 +1,8 @@
 import { switchScreen } from "../main.js";
 import { showCustomAlert } from "./home.js";
 import { firebaseAuth } from "../firebase/firebase-init.js";
-import {
-  fetchSignInMethodsForEmail,
-  sendPasswordResetEmail,
-} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+import { fetchSignInMethodsForEmail } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+import { supabase } from "../utils/supabaseClient.js";
 
 export function renderForgotPasswordScreen() {
   const app = document.getElementById("app");
@@ -44,10 +42,11 @@ export function renderForgotPasswordScreen() {
         return;
       }
 
-      // Firebase sends the password reset email and redirects to our reset page.
-      await sendPasswordResetEmail(firebaseAuth, email, {
-        url: "https://playotoron.com/reset-password.html",
+      // Supabase sends the password reset email and redirects to our reset page.
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: "https://playotoron.com/reset-password.html",
       });
+      if (error) throw error;
       showCustomAlert(
         "リセット用のメールを送信しました。※ Googleなど外部サービスで登録されたアカウントは、パスワードの再設定はできません。" +
           "ログイン画面の『Googleでログイン』ボタンをご利用ください。",

--- a/reset-password.html
+++ b/reset-password.html
@@ -31,27 +31,24 @@
   </p>
 
   <script type="module">
-    import { firebaseAuth } from './firebase/firebase-init.js';
-    import {
-      verifyPasswordResetCode,
-      confirmPasswordReset,
-    } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+    import { supabase } from './utils/supabaseClient.js';
 
     function showCustomAlert(message) {
       alert(message);
     }
 
-    // Firebase's password reset email includes an `oobCode` query parameter.
-    // Verify it before allowing the user to enter a new password.
+    // Supabase provides a `code` query parameter in the redirect URL.
+    // Exchange it for a session before allowing password update.
     const queryParams = new URLSearchParams(window.location.search);
-    const oobCode = queryParams.get('oobCode');
+    const code = queryParams.get('code');
     let validSession = true;
 
     try {
-      if (!oobCode) {
+      if (!code) {
         throw new Error('missing code');
       }
-      await verifyPasswordResetCode(firebaseAuth, oobCode);
+      const { error } = await supabase.auth.exchangeCodeForSession(code);
+      if (error) throw error;
     } catch (e) {
       validSession = false;
       showCustomAlert('リンクが無効です：' + e.message);
@@ -106,7 +103,9 @@
       if (submitBtn.disabled) return;
       const pw = newPwInput.value.trim();
       try {
-        await confirmPasswordReset(firebaseAuth, oobCode, pw);
+        const { error } = await supabase.auth.updateUser({ password: pw });
+        if (error) throw error;
+        await supabase.auth.signOut();
         sessionStorage.setItem('passwordResetSuccess', '1');
         showCustomAlert('パスワードの更新が完了しました');
         window.location.href = 'https://playotoron.com/reset-password-success.html';


### PR DESCRIPTION
## Summary
- send Supabase password reset emails instead of Firebase
- handle Supabase recovery code and update password in reset page

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_688e1fa22cd883239b1d23b356e01f48