### PR TITLE
Hide broken forgot password link in production

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -46,6 +46,10 @@ export function renderLoginScreen(container, onLoginSuccess) {
 
   const pwInput = container.querySelector("#password");
   const pwToggle = container.querySelector(".toggle-password");
+  const forgotBtn = container.querySelector("#forgot-btn");
+  if (window.location.hostname === "playotoron.com") {
+    forgotBtn.style.display = "none";
+  }
   pwToggle.addEventListener("click", () => {
     const visible = pwInput.type === "text";
     pwInput.type = visible ? "password" : "text";
@@ -176,8 +180,10 @@ export function renderLoginScreen(container, onLoginSuccess) {
   });
 
   // パスワード忘れリンク
-  container.querySelector("#forgot-btn").addEventListener("click", (e) => {
-    e.preventDefault();
-    switchScreen("forgot_password");
-  });
+  if (forgotBtn) {
+    forgotBtn.addEventListener("click", (e) => {
+      e.preventDefault();
+      switchScreen("forgot_password");
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- hide "パスワードを忘れた方はこちら" on production domain
- guard event handler for hidden link

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688e242c2850832380375092bf466d7a