### PR TITLE
fix: restore Supabase project URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ if (signInError) {
 アプリが利用する標準の Supabase プロジェクトは下記の URL とキーです。誤って別の DB に切り替えた場合は `utils/supabaseClient.js` をこの設定に戻してください。
 
 ```javascript
-const supabaseUrl = 'https://xncwydeesyqvyqafbg.supabase.co';
+const supabaseUrl = 'https://xnccwydcesyvqvyqafbg.supabase.co';
 const supabaseAnonKey = '49b00ff076eae66c4dd35832cd07a1a4f6a1632e2b887d7fbf9ce10d68db4e1d';
 ```
 

--- a/utils/supabaseClient.js
+++ b/utils/supabaseClient.js
@@ -1,7 +1,7 @@
 // supabaseClient.js
 import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
 
-const supabaseUrl = 'https://xncwydeesyqvyqafbg.supabase.co';
+const supabaseUrl = 'https://xnccwydcesyvqvyqafbg.supabase.co';
 const supabaseAnonKey = '49b00ff076eae66c4dd35832cd07a1a4f6a1632e2b887d7fbf9ce10d68db4e1d';
 
 // 標準設定で Supabase クライアントを生成し、セッションの保持と更新を有効化する


### PR DESCRIPTION
## Summary
- restore full Supabase project URL so authentication points to valid domain
- document correct Supabase URL in README for reference

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688e4e1f35508323a2569b25dafd88fc