### PR TITLE
feat: handle Supabase OAuth callback

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -6,20 +6,20 @@
   <meta name="robots" content="noindex" />
 </head>
 <body>
-  <p>ログイン処理中です...</p>
+  <p id="message">ログイン処理中です...</p>
   <script type="module">
     import { supabase } from './utils/supabaseClient.js';
 
-    (async () => {
-      try {
-        const { error } = await supabase.auth.getSessionFromUrl({ storeSession: true });
-        if (error) throw error;
-      } catch (err) {
-        console.error('OAuth callback error:', err);
-      } finally {
-        window.location.replace('/');
-      }
-    })();
+    const message = document.getElementById('message');
+
+    try {
+      const { error } = await supabase.auth.getSessionFromUrl({ storeSession: true });
+      if (error) throw error;
+      window.location.replace('/');
+    } catch (err) {
+      console.error('OAuth callback error:', err);
+      message.textContent = `ログインに失敗しました: ${err.message}`;
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redirect to `/` after obtaining Supabase session via `getSessionFromUrl`
- show error message on callback failure

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688f008ea9348323a5e5fa28e0467eb5