### PR TITLE
Handle Supabase OAuth callback without Firebase

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -8,7 +8,11 @@
 <body>
   <p id="message">ログイン処理中です...</p>
   <script type="module">
-    import { supabase } from './utils/supabaseClient.js';
+    import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+
+    const supabaseUrl = 'https://xnccwydcesyvqvyqafbg.supabase.co';
+    const supabaseAnonKey = '49b00ff076eae66c4dd35832cd07a1a4f6a1632e2b887d7fbf9ce10d68db4e1d';
+    const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
     const message = document.getElementById('message');
 


### PR DESCRIPTION
## Summary
- create Supabase client in callback.html and process OAuth tokens via getSessionFromUrl
- ensure OAuth login redirects back to callback.html for token processing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688f027ae3d883239a45b39e016e3a4b