### PR TITLE
Handle Supabase OAuth callback

### DIFF
--- a/auth-callback.html
+++ b/auth-callback.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>OAuth リダイレクト処理中</title>
+  <meta name="robots" content="noindex" />
+</head>
+<body>
+  <p id="message">ログイン処理中です...</p>
+  <script type="module" src="./auth-callback.js"></script>
+</body>
+</html>

--- a/auth-callback.js
+++ b/auth-callback.js
@@ -1,0 +1,23 @@
+import { supabase } from './utils/supabaseClient.js';
+
+async function handleOAuthRedirect() {
+  const hashParams = new URLSearchParams(window.location.hash.slice(1));
+  const accessToken = hashParams.get('access_token');
+
+  if (accessToken) {
+    const { data, error } = await supabase.auth.getSession();
+    console.log('✅ Supabaseセッション取得:', data, error);
+
+    if (!error && data.session) {
+      window.location.href = '/home.html';
+      return;
+    }
+  }
+
+  const message = document.getElementById('message');
+  if (message) {
+    message.textContent = 'ログインに失敗しました。もう一度お試しください。';
+  }
+}
+
+handleOAuthRedirect();

--- a/utils/authSupabase.js
+++ b/utils/authSupabase.js
@@ -11,7 +11,7 @@ export async function signIn(email, password) {
 export async function signInWithGoogle() {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
-    options: { redirectTo: `${location.origin}/auth/callback` },
+    options: { redirectTo: `${location.origin}/auth-callback.html` },
   });
   if (error) {
     console.error('Google sign-in error:', error);


### PR DESCRIPTION
## Summary
- Add standalone OAuth callback page to finalize Supabase sessions and redirect to home
- Update Google sign-in to redirect to new callback endpoint

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_b_688f2e7fc8c48323a435d1bff395d197