### PR TITLE
refactor: derive auth callback redirect from origin

### DIFF
--- a/utils/authSupabase.js
+++ b/utils/authSupabase.js
@@ -9,9 +9,12 @@ export async function signIn(email, password) {
 }
 
 export async function signInWithGoogle() {
+  const redirectUrl = `${window.location.origin}/auth-callback.html`;
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
-    options: { redirectTo: `${location.origin}/auth-callback.html` },
+    options: {
+      redirectTo: redirectUrl,
+    },
   });
   if (error) {
     console.error('Google sign-in error:', error);


### PR DESCRIPTION
## Summary
- use window.location.origin for the Google OAuth redirect to handle production and test domains automatically

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688f3a5a98bc8323b65612165a3d09a0