### PR TITLE
Add temporary debug logs for Google sign-in

### DIFF
--- a/public/auth-callback.js
+++ b/public/auth-callback.js
@@ -1,8 +1,13 @@
 import { supabase } from '/scripts/supabaseClient.js'; // パスは環境に応じて調整
+import { addDebugLog } from '/utils/loginDebug.js';
+
+addDebugLog('auth-callback start');
 
 // URLフラグメントからトークンをSupabaseに渡す
 supabase.auth.onAuthStateChange((event, session) => {
+  addDebugLog('auth-callback onAuthStateChange', { event, hasSession: !!session });
   if (event === 'SIGNED_IN' && session) {
+    addDebugLog('auth-callback signed in');
     // 正常にログイン完了 → ホームへリダイレクト
     window.location.href = '/';
   }
@@ -10,13 +15,16 @@ supabase.auth.onAuthStateChange((event, session) => {
 
 // 上記が反応しないケースに備えて、一度URLパラメータから復元処理
 supabase.auth.getSession().then(({ data }) => {
+  addDebugLog('auth-callback getSession', { hasSession: !!data?.session });
   if (!data?.session) {
     // フラグメントをクエリとして処理
     supabase.auth.exchangeCodeForSession(window.location.hash)
       .then(() => {
+        addDebugLog('auth-callback exchange success');
         window.location.href = '/';
       })
       .catch((err) => {
+        addDebugLog('auth-callback exchange error', { message: err.message });
         console.error('ログイン処理エラー:', err);
         document.getElementById('message').textContent = 'ログイン処理に失敗しました。';
       });

--- a/utils/authSupabase.js
+++ b/utils/authSupabase.js
@@ -1,4 +1,5 @@
 import { supabase } from './supabaseClient.js';
+import { addDebugLog } from './loginDebug.js';
 
 export async function signUp(email, password) {
   return supabase.auth.signUp({ email, password });
@@ -9,6 +10,7 @@ export async function signIn(email, password) {
 }
 
 export async function signInWithGoogle() {
+  addDebugLog('signInWithGoogle start');
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
     options: {
@@ -16,7 +18,10 @@ export async function signInWithGoogle() {
     },
   });
   if (error) {
+    addDebugLog('signInWithGoogle error', { message: error.message });
     console.error('Google sign-in error:', error);
+  } else {
+    addDebugLog('signInWithGoogle redirect');
   }
 }
 


### PR DESCRIPTION
## Summary
- log start, redirect, and error events for Google OAuth sign-in
- capture auth callback flow with detailed debug logging

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_688f409a9bec8323b6c0a64e7111d804