### PR TITLE
chore: add login debug logs

### DIFF
--- a/auth-callback.html
+++ b/auth-callback.html
@@ -6,19 +6,31 @@
   <meta name="robots" content="noindex" />
 </head>
 <body>
-  <p>ログイン処理中です...</p>
+  <p id="message">ログイン処理中です...</p>
   <script type="module">
     import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm'
+    import { addDebugLog } from './utils/loginDebug.js'
+
+    addDebugLog('auth-callback start')
 
     const supabase = createClient('https://xnccwydcesyvqvyqafbg.supabase.co', '49b00ff076eae66c4dd35832cd07a1a4f6a1632e2b887d7fbf9ce10d68db4e1d')
 
-    const { data, error } = await supabase.auth.exchangeCodeForSession()
-    if (error) {
-      console.error('認証エラー:', error)
-      document.body.innerHTML = 'ログインに失敗しました。'
-    } else {
-      console.log('ログイン成功:', data)
-      window.location.href = '/home.html'
+    try {
+      const { data, error } = await supabase.auth.exchangeCodeForSession()
+      addDebugLog('auth-callback exchange result', { hasError: !!error })
+      if (error) {
+        addDebugLog('auth-callback exchange error', { message: error.message })
+        console.error('認証エラー:', error)
+        document.getElementById('message').textContent = 'ログインに失敗しました。'
+      } else {
+        addDebugLog('auth-callback exchange success', { user: data.user })
+        console.log('ログイン成功:', data)
+        window.location.href = '/home.html'
+      }
+    } catch (err) {
+      addDebugLog('auth-callback exchange exception', { message: err.message })
+      console.error('認証エラー:', err)
+      document.getElementById('message').textContent = 'ログインに失敗しました。'
     }
   </script>
 </body>

--- a/main.js
+++ b/main.js
@@ -36,6 +36,7 @@ import { renderChordResetScreen } from "./components/info/chordReset.js";
 import { renderPricingScreen } from "./components/pricing.js";
 import { renderLockScreen } from "./components/lock.js";
 import { renderForgotPasswordScreen } from "./components/forgotPassword.js";
+import { addDebugLog } from "./utils/loginDebug.js";
 
 
 // Firebase 認証を排除し、Supabase での認証管理に一本化
@@ -145,6 +146,8 @@ async function checkTrainingLimit(user) {
 export const switchScreen = async (screen, user = currentUser, options = {}) => {
   const { replace = false } = options;
 
+  addDebugLog('switchScreen', { screen, hasUser: !!user });
+
   if (currentUser && currentUser.isTemp && screen !== "settings") {
     clearTempUser();
     user = currentUser;
@@ -239,7 +242,9 @@ window.addEventListener("popstate", (e) => {
 });
 
 onAuthStateChanged(async (authUser) => {
+  addDebugLog('onAuthStateChanged callback', { hasUser: !!authUser });
   if (!authUser) {
+    addDebugLog('onAuthStateChanged no user');
     return;
   }
 

--- a/utils/authSupabase.js
+++ b/utils/authSupabase.js
@@ -30,7 +30,8 @@ export async function signOut() {
 }
 
 export function onAuthStateChanged(callback) {
-  const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+  const { data } = supabase.auth.onAuthStateChange((event, session) => {
+    addDebugLog('supabase onAuthStateChange', { event, hasSession: !!session });
     callback(session?.user ?? null);
   });
   return () => {


### PR DESCRIPTION
## Summary
- add exchangeCodeForSession result logging in auth callback
- track screen switches and auth state changes
- log Supabase auth state change events

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688f614a206483239bb1ff0da5cc5dbd