### PR TITLE
Switch Google sign-in to popup flow

### DIFF
--- a/utils/authSupabase.js
+++ b/utils/authSupabase.js
@@ -14,14 +14,14 @@ export async function signInWithGoogle() {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
     options: {
-      redirectTo: window.location.origin + '/auth-callback.html',
+      flow: 'popup', // ✅ ポップアップモードに切り替え
     },
   });
   if (error) {
     addDebugLog('signInWithGoogle error', { message: error.message });
     console.error('Google sign-in error:', error);
   } else {
-    addDebugLog('signInWithGoogle redirect');
+    addDebugLog('signInWithGoogle popup opened');
   }
 }
 


### PR DESCRIPTION
## Summary
- use Supabase OAuth popup flow for Google sign-in to avoid redirects

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688f67b531a48323982754cc193fa381