### PR TITLE
feat: handle firebase password reset

### DIFF
--- a/reset-password.html
+++ b/reset-password.html
@@ -31,27 +31,26 @@
   </p>
 
   <script type="module">
-    import { supabase } from './utils/supabaseClient.js';
+    import { getAuth, verifyPasswordResetCode, confirmPasswordReset } from "firebase/auth";
 
     function showCustomAlert(message) {
       alert(message);
     }
 
-    // Supabase provides a `code` query parameter in the redirect URL.
-    // Exchange it for a session before allowing password update.
+    const auth = getAuth();
+
     const queryParams = new URLSearchParams(window.location.search);
-    const code = queryParams.get('code');
-    let validSession = true;
+    const oobCode = queryParams.get("oobCode");
+    let validCode = true;
 
     try {
-      if (!code) {
-        throw new Error('missing code');
+      if (!oobCode) {
+        throw new Error("missing code");
       }
-      const { error } = await supabase.auth.exchangeCodeForSession(code);
-      if (error) throw error;
+      await verifyPasswordResetCode(auth, oobCode);
     } catch (e) {
-      validSession = false;
-      showCustomAlert('リンクが無効です：' + e.message);
+      validCode = false;
+      showCustomAlert("リンクが無効です：" + e.message);
     }
 
     const form = document.getElementById('reset-form');
@@ -62,7 +61,7 @@
     const newToggle = document.getElementById('toggle-new-password');
     const confirmToggle = document.getElementById('toggle-confirm-password');
 
-    if (!validSession) {
+    if (!validCode) {
       newPwInput.disabled = true;
       confirmPwInput.disabled = true;
       submitBtn.disabled = true;
@@ -103,9 +102,7 @@
       if (submitBtn.disabled) return;
       const pw = newPwInput.value.trim();
       try {
-        const { error } = await supabase.auth.updateUser({ password: pw });
-        if (error) throw error;
-        await supabase.auth.signOut();
+        await confirmPasswordReset(auth, oobCode, pw);
         sessionStorage.setItem('passwordResetSuccess', '1');
         showCustomAlert('パスワードの更新が完了しました');
         window.location.href = 'https://playotoron.com/reset-password-success.html';


### PR DESCRIPTION
## Summary
- use Firebase auth to validate password reset link
- confirm new password and redirect to success page

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_68909bceedd883238aa595f50dc5b2be