### PR TITLE
Simplify password reset success page

### DIFF
--- a/reset-password-success.html
+++ b/reset-password-success.html
@@ -21,14 +21,9 @@
     .message {
       font-size: 1.8rem;
       font-weight: bold;
-      margin-bottom: 1rem;
-    }
-    .sub-text {
-      font-size: 1rem;
-      line-height: 1.6;
+      margin-bottom: 1.5rem;
     }
     .login-button {
-      margin-top: 1.5rem;
       padding: 1rem 2rem;
       background-color: #FF7F50;
       color: #fff;
@@ -45,13 +40,14 @@
   </style>
 </head>
 <body>
-  <div class="message">✅ パスワードの再設定が完了しました！</div>
-  <div class="sub-text">3秒後にログイン画面へ移動します。<br />または、以下のボタンを押してください。</div>
+  <div class="message">✅ パスワードの再設定が完了しました</div>
   <a href="https://playotoron.com/#login" class="login-button">ログイン画面へ戻る</a>
   <script>
-    setTimeout(() => {
+    if (sessionStorage.getItem('passwordResetSuccess') !== '1') {
       location.href = 'https://playotoron.com/#login';
-    }, 3000);
+    } else {
+      sessionStorage.removeItem('passwordResetSuccess');
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- streamline password reset success page to only show completion message and login link
- prevent direct access by checking for `passwordResetSuccess` in session storage

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68909d3d45d08323b5d539341d43880c