### PR TITLE
chore: remove unused resetPassword helper

### DIFF
--- a/utils/authSupabase.js
+++ b/utils/authSupabase.js
@@ -44,12 +44,6 @@ export async function getCurrentUser() {
   return data.user ?? null;
 }
 
-export async function resetPassword(email) {
-  return supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${location.origin}/reset-password.html`,
-  });
-}
-
 export async function updateUser(attributes) {
   return supabase.auth.updateUser(attributes);
 }


### PR DESCRIPTION
## Summary
- remove resetPassword from Supabase auth utilities
- no remaining resetPassword imports

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68909dc4f8448323aa4f708efb542b3e