### PR TITLE
fix: defer debug log insertion until DOM ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,13 +43,15 @@
     import { showDebugLog } from './utils/loginDebug.js';
     const debugMode = new URLSearchParams(window.location.search).get('debug') === '1';
     if (debugMode) {
-      const pre = document.createElement('pre');
-      pre.id = 'debug-log';
-      pre.style.whiteSpace = 'pre-wrap';
-      pre.style.color = 'red';
-      pre.style.fontSize = '0.9em';
-      document.body.prepend(pre);
-      showDebugLog();
+      window.addEventListener('DOMContentLoaded', () => {
+        const pre = document.createElement('pre');
+        pre.id = 'debug-log';
+        pre.style.whiteSpace = 'pre-wrap';
+        pre.style.color = 'red';
+        pre.style.fontSize = '0.9em';
+        document.body.prepend(pre);
+        showDebugLog();
+      });
     }
   </script>
 <!-- Google Ads Conversion Tracking -->


### PR DESCRIPTION
## Summary
- prevent intro page from breaking when debug mode is enabled by waiting for DOMContentLoaded before injecting debug log element

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_689203db16448323ac38c260a8e8d1cd