### PR TITLE
feat: attempt Supabase login with provided password

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -140,7 +140,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       sessionStorage.setItem("currentPassword", password);
       const user = firebaseAuth.currentUser;
       try {
-        await ensureSupabaseAuth(user);
+        await ensureSupabaseAuth(user, password);
       } catch (e) {
         console.error("❌ Supabaseサインイン処理でエラー:", e);
         return;

--- a/components/signup.js
+++ b/components/signup.js
@@ -66,7 +66,7 @@ export function renderSignUpScreen() {
 
     try {
       const cred = await createUserWithEmailAndPassword(firebaseAuth, email, password);
-      const { user } = await ensureSupabaseAuth(cred.user);
+      const { user } = await ensureSupabaseAuth(cred.user, password);
       if (user) {
         await createInitialChordProgress(user.id);
       }

--- a/utils/supabaseAuthHelper.js
+++ b/utils/supabaseAuthHelper.js
@@ -2,7 +2,7 @@ import { supabase } from './supabaseClient.js';
 
 const DUMMY_PASSWORD = 'secure_dummy_password';
 
-export async function ensureSupabaseAuth(firebaseUser) {
+export async function ensureSupabaseAuth(firebaseUser, password) {
   if (!firebaseUser) return { user: null, isNew: false };
   const email = firebaseUser.email;
   const provider = firebaseUser.providerData?.[0]?.providerId;
@@ -12,15 +12,15 @@ export async function ensureSupabaseAuth(firebaseUser) {
       : null;
 
   const ensureSessionWithPassword = async () => {
-    const signIn = async (password = DUMMY_PASSWORD) => {
+    const signIn = async (pwd = DUMMY_PASSWORD) => {
       const { error } = await supabase.auth.signInWithPassword({
         email,
-        password,
+        password: pwd,
       });
       return error;
     };
 
-    let err = await signIn();
+    let err = await signIn(password);
     if (err) {
       if (err.message.includes('Invalid login credentials')) {
         const { error: signUpError } = await supabase.auth.signUp({


### PR DESCRIPTION
## Summary
- allow ensureSupabaseAuth to accept a password and try it before fallbacks
- pass user password to Supabase auth helper from login and signup flows

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68935a79a1808323864d8ec53e9309c7