### PR TITLE
Use Firebase ID token for Supabase auth

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -140,7 +140,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       sessionStorage.setItem("currentPassword", password);
       const user = firebaseAuth.currentUser;
       try {
-        await ensureSupabaseAuth(user, password);
+        await ensureSupabaseAuth(user);
       } catch (e) {
         console.error("❌ Supabaseサインイン処理でエラー:", e);
         return;

--- a/components/signup.js
+++ b/components/signup.js
@@ -66,7 +66,7 @@ export function renderSignUpScreen() {
 
     try {
       const cred = await createUserWithEmailAndPassword(firebaseAuth, email, password);
-      const { user } = await ensureSupabaseAuth(cred.user, password);
+      const { user } = await ensureSupabaseAuth(cred.user);
       if (user) {
         await createInitialChordProgress(user.id);
       }


### PR DESCRIPTION
## Summary
- Use Firebase ID tokens to authenticate with Supabase for any provider
- Clean up login and signup flows to call `ensureSupabaseAuth` without passwords

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68935f2bb4a883238fc3b807d39209c4