### PR TITLE
feat: add password-based Supabase auth

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -47,7 +47,8 @@
         return;
       }
 
-      const { user, isNew } = await ensureSupabaseAuth(firebaseUser);
+      const DUMMY_PASSWORD = 'secure_dummy_password';
+      const { user, isNew } = await ensureSupabaseAuth(firebaseUser, DUMMY_PASSWORD);
       if (isNew) {
         await createInitialChordProgress(user.id);
         addDebugLog('redirect: register-thankyou');

--- a/components/login.js
+++ b/components/login.js
@@ -140,7 +140,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       sessionStorage.setItem("currentPassword", password);
       const user = firebaseAuth.currentUser;
       try {
-        await ensureSupabaseAuth(user);
+        await ensureSupabaseAuth(user, password);
       } catch (e) {
         console.error("❌ Supabaseサインイン処理でエラー:", e);
         return;

--- a/components/signup.js
+++ b/components/signup.js
@@ -66,7 +66,8 @@ export function renderSignUpScreen() {
 
     try {
       const cred = await createUserWithEmailAndPassword(firebaseAuth, email, password);
-      const { user } = await ensureSupabaseAuth(cred.user);
+      sessionStorage.setItem("currentPassword", password);
+      const { user } = await ensureSupabaseAuth(cred.user, password);
       if (user) {
         await createInitialChordProgress(user.id);
       }

--- a/main.js
+++ b/main.js
@@ -250,8 +250,8 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 
   let authResult;
   try {
-    await firebaseUser.getIdToken();
-    authResult = await ensureSupabaseAuth(firebaseUser);
+    const password = sessionStorage.getItem('currentPassword') || DUMMY_PASSWORD;
+    authResult = await ensureSupabaseAuth(firebaseUser, password);
   } catch (e) {
     console.error("❌ Supabase認証処理エラー:", e);
     return;

--- a/success/index.html
+++ b/success/index.html
@@ -32,7 +32,9 @@
 
     onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
       if (!firebaseUser || !plan) return;
-      const authResult = await ensureSupabaseAuth(firebaseUser);
+      const DUMMY_PASSWORD = 'secure_dummy_password';
+      const pw = sessionStorage.getItem('currentPassword') || DUMMY_PASSWORD;
+      const authResult = await ensureSupabaseAuth(firebaseUser, pw);
       const user = authResult.user;
       if (!user) return;
       const paymentDate = new Date();


### PR DESCRIPTION
## Summary
- sign into Supabase using email/password and sign up on first use
- pass Firebase password to helper and store it for later logins
- use stored or dummy password for Google sign-in flows

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689366409de08323b3173d87cf48c0ad