### PR TITLE
feat: sync Firebase and Supabase auth with ID token fallback

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -47,8 +47,13 @@
         return;
       }
 
-      const DUMMY_PASSWORD = 'secure_dummy_password';
-      const { user, isNew } = await ensureSupabaseAuth(firebaseUser, DUMMY_PASSWORD);
+      const { user, isNew } = await ensureSupabaseAuth(firebaseUser);
+      if (!user) {
+        addDebugLog('Supabase link failed');
+        showDebugLog();
+        if (!debugMode) window.location.href = '/';
+        return;
+      }
       if (isNew) {
         await createInitialChordProgress(user.id);
         addDebugLog('redirect: register-thankyou');

--- a/components/login.js
+++ b/components/login.js
@@ -140,7 +140,7 @@ export function renderLoginScreen(container, onLoginSuccess) {
       sessionStorage.setItem("currentPassword", password);
       const user = firebaseAuth.currentUser;
       try {
-        await ensureSupabaseAuth(user, password);
+        await ensureSupabaseAuth(user);
       } catch (e) {
         console.error("❌ Supabaseサインイン処理でエラー:", e);
         return;

--- a/components/signup.js
+++ b/components/signup.js
@@ -67,7 +67,7 @@ export function renderSignUpScreen() {
     try {
       const cred = await createUserWithEmailAndPassword(firebaseAuth, email, password);
       sessionStorage.setItem("currentPassword", password);
-      const { user } = await ensureSupabaseAuth(cred.user, password);
+      const { user } = await ensureSupabaseAuth(cred.user);
       if (user) {
         await createInitialChordProgress(user.id);
       }

--- a/main.js
+++ b/main.js
@@ -41,7 +41,6 @@ import { renderForgotPasswordScreen } from "./components/forgotPassword.js";
 import { firebaseAuth } from "./firebase/firebase-init.js";
 import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
-const DUMMY_PASSWORD = "secure_dummy_password";
 
 const INFO_SCREENS = [
   "terms",
@@ -250,13 +249,16 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 
   let authResult;
   try {
-    const password = sessionStorage.getItem('currentPassword') || DUMMY_PASSWORD;
-    authResult = await ensureSupabaseAuth(firebaseUser, password);
+    authResult = await ensureSupabaseAuth(firebaseUser);
   } catch (e) {
     console.error("❌ Supabase認証処理エラー:", e);
     return;
   }
   const { user, isNew } = authResult;
+  if (!user) {
+    console.warn('⚠️ Firebase logged in but Supabase link failed.');
+    return;
+  }
 
   await ensureChordProgress(user.id);
 

--- a/success/index.html
+++ b/success/index.html
@@ -32,9 +32,7 @@
 
     onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
       if (!firebaseUser || !plan) return;
-      const DUMMY_PASSWORD = 'secure_dummy_password';
-      const pw = sessionStorage.getItem('currentPassword') || DUMMY_PASSWORD;
-      const authResult = await ensureSupabaseAuth(firebaseUser, pw);
+      const authResult = await ensureSupabaseAuth(firebaseUser);
       const user = authResult.user;
       if (!user) return;
       const paymentDate = new Date();


### PR DESCRIPTION
## Summary
- try Supabase sign-in with Firebase ID token first
- fall back to dummy password sign-up/login with clear logs
- warn when Firebase auth succeeds but Supabase link fails

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68936d6b4e3c8323a56ec3960bc04fd5