### PR TITLE
Disable email change submit until form complete

### DIFF
--- a/components/mypage.js
+++ b/components/mypage.js
@@ -222,9 +222,13 @@ export function renderMyPageScreen(user) {
       emailForm.appendChild(statusEl);
 
       function validateEmailForm() {
-        const curr = currentField.querySelector("input").value;
+        const curr = currentField.querySelector("input").value.trim();
         const newE = newField.querySelector("input").value.trim();
         const confE = confirmField.querySelector("input").value.trim();
+
+        statusEl.textContent = "";
+        statusEl.className = "form-status";
+
         let valid = !!curr && !!newE && !!confE;
         if (newE && confE && newE !== confE) {
           mismatchMsg.style.display = "block";
@@ -235,11 +239,7 @@ export function renderMyPageScreen(user) {
         submitBtn.disabled = !valid;
       }
 
-      emailForm.addEventListener("input", () => {
-        statusEl.textContent = "";
-        statusEl.className = "form-status";
-        validateEmailForm();
-      });
+      emailForm.addEventListener("input", validateEmailForm);
       validateEmailForm();
 
       emailForm.addEventListener("submit", async (e) => {


### PR DESCRIPTION
## Summary
- Ensure email change button remains disabled until current password, new email, and confirmation are filled and valid.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6895f471c0308323862660ba97aae945