### PR TITLE
Disable email update until all fields filled

### DIFF
--- a/components/mypage.js
+++ b/components/mypage.js
@@ -229,13 +229,19 @@ export function renderMyPageScreen(user) {
         statusEl.textContent = "";
         statusEl.className = "form-status";
 
-        let valid = !!curr && !!newE && !!confE;
+        let valid = true;
+
         if (newE && confE && newE !== confE) {
           mismatchMsg.style.display = "block";
           valid = false;
         } else {
           mismatchMsg.style.display = "none";
         }
+
+        if (!curr || !newE || !confE) {
+          valid = false;
+        }
+
         submitBtn.disabled = !valid;
       }
 


### PR DESCRIPTION
## Summary
- Disable email address change button until current password, new email, and confirmation fields are all filled and matching

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68960faaa81883239b4b5778d10be132