### PR TITLE
Handle duplicate email early in changeEmail

### DIFF
--- a/components/mypage.js
+++ b/components/mypage.js
@@ -281,7 +281,7 @@ export function renderMyPageScreen(user) {
             case "auth/invalid-email":
               msg = "メールアドレスの形式が正しくありません。";
               break;
-            case "auth/email-already-in-use":
+            case "auth/email-already-in-use": // duplicate email
               msg = "そのメールアドレスは既に使用されています。";
               break;
             case "auth/operation-not-allowed":

--- a/utils/changeEmail.js
+++ b/utils/changeEmail.js
@@ -15,6 +15,12 @@ export async function changeEmail({ auth, currentPassword, newEmail }) {
   const user = auth.currentUser;
   if (!user) throw new Error("Not signed in.");
 
+  if (newEmail === user.email) {
+    throw Object.assign(new Error("Email already in use"), {
+      code: "auth/email-already-in-use",
+    });
+  }
+
   // provider確認（UI側でも分岐しているが、保険で）
   const providerId = user.providerData?.[0]?.providerId;
   if (providerId !== "password") {
@@ -28,12 +34,6 @@ export async function changeEmail({ auth, currentPassword, newEmail }) {
   await reauthenticateWithCredential(user, credential);
 
   // --- 2) 既存メール確認 & メール更新 ---
-  if (newEmail === user.email) {
-    throw Object.assign(new Error("Email already in use"), {
-      code: "auth/email-already-in-use",
-    });
-  }
-
   const methods = await fetchSignInMethodsForEmail(auth, newEmail);
   if (methods.length > 0) {
     throw Object.assign(new Error("Email already in use"), {


### PR DESCRIPTION
## Summary
- Prevent unnecessary reauthentication by rejecting when the new email matches the current one
- Document duplicate email error mapping in MyPage UI

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689613cc7d2083239b73a87bf6e68fa2