### PR TITLE
feat: add email change confirmation page

### DIFF
--- a/components/mypage.js
+++ b/components/mypage.js
@@ -267,11 +267,7 @@ export function renderMyPageScreen(user) {
             currentPassword,
             newEmail,
           });
-          const updated = { ...user, email: newEmail };
-          alert(
-            "メールを送信しました。新しいメールアドレスの受信箱で確認リンクをクリックしてください"
-          );
-          switchScreen("mypage", updated, { replace: true });
+          window.location.href = "/email-change-sent.html";
         } catch (err) {
           let msg;
           switch (err.code) {

--- a/email-change-sent.html
+++ b/email-change-sent.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>メール確認</title>
+  <meta name="robots" content="noindex" />
+  <script>
+    setTimeout(() => {
+      window.location.href = '/#mypage';
+    }, 5000);
+  </script>
+</head>
+<body style="margin:0;">
+  <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;background-color:#fff;text-align:center;padding:0 1rem;">
+    <p style="font-size:1.2rem;color:#666;margin:0;">メールを送信しました。新しいメールアドレスの受信箱で確認リンクをクリックしてください</p>
+    <p style="margin-top:1rem;color:#666;font-size:0.9rem;">5秒後にマイページに戻ります</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redirect to a dedicated confirmation screen after requesting an email change
- add email-change-sent page with consistent template design

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_b_689620a9574c8323aad7f5871a56a838