### PR TITLE
fix: handle auth provider order variability

### DIFF
--- a/components/mypage.js
+++ b/components/mypage.js
@@ -24,13 +24,12 @@ export async function renderMyPageScreen(user) {
   tabHeader.className = "mypage-tabs";
 
   const firebaseUser = firebaseAuth.currentUser;
-  // 判定前に最新化（auth直後やオートフィル後の揺らぎ対策）
-  await firebaseUser?.reload?.();
-  const providers = new Set(firebaseUser?.providerData?.map(p => p.providerId) || []);
+  await firebaseUser?.reload?.(); // 最新化
+  const providers = new Set(
+    firebaseUser?.providerData?.map((p) => p.providerId) || []
+  );
   const hasPassword = providers.has("password");
-  // Google が紐づいていて、かつ password を持っていない場合のみ「Google専用UI」
   const googleOnly = providers.has("google.com") && !hasPassword;
-  // パスワードを持っている＝メール変更/パスワード変更UIを出す
   const showEmailChange = hasPassword;
 
   const tabs = [

--- a/utils/changeEmail.js
+++ b/utils/changeEmail.js
@@ -21,8 +21,8 @@ export async function changeEmail({ auth, currentPassword, newEmail }) {
   }
 
   // provider確認（UI側でも分岐しているが、保険で）
-  const providerId = user.providerData?.[0]?.providerId;
-  if (providerId !== "password") {
+  const providers = new Set(user.providerData?.map((p) => p.providerId) || []);
+  if (!providers.has("password")) {
     throw new Error(
       "This account uses a social provider. Email change is not allowed here."
     );


### PR DESCRIPTION
## Summary
- Ensure My Page determines auth provider without relying on array order
- Guard email-change flow with provider set to avoid social account edge cases

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6896a06bf2e08323bf2b0069c22032dd