### PR TITLE
Use toast notifications instead of browser alerts

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Googleログイン処理中</title>
   <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/style.css">
 </head>
 <body>
   <p>ログイン処理中です...</p>
@@ -14,6 +15,7 @@
     import { ensureSupabaseAuth } from './utils/supabaseAuthHelper.js';
     import { createInitialChordProgress } from './utils/progressUtils.js';
     import { addDebugLog, showDebugLog } from './utils/loginDebug.js';
+    import { showToast } from './utils/toast.js';
 
     (async () => {
 
@@ -40,10 +42,10 @@
       const methods = await fetchSignInMethodsForEmail(firebaseAuth, firebaseUser.email);
       if (methods.includes('password') && !methods.includes('google.com')) {
         await signOut(firebaseAuth);
-        alert('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。');
+        showToast('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。');
         addDebugLog('redirect: login exists');
         showDebugLog();
-        if (!debugMode) window.location.href = '/';
+        if (!debugMode) setTimeout(() => { window.location.href = '/'; }, 1500);
         return;
       }
 

--- a/components/initialSetup.js
+++ b/components/initialSetup.js
@@ -1,6 +1,7 @@
 import { chords } from "../data/chords.js";
 import { supabase } from "../utils/supabaseClient.js";
 import { applyStartChordIndex } from "../utils/progressUtils.js";
+import { showToast } from "../utils/toast.js";
 
 export function renderInitialSetupScreen(user, onComplete) {
   const app = document.getElementById("app");
@@ -21,7 +22,7 @@ export function renderInitialSetupScreen(user, onComplete) {
     wrapper.querySelector("#next-btn").onclick = () => {
       const value = wrapper.querySelector("#nickname").value.trim();
       if (!value) {
-        alert("おなまえをいれてね");
+        showToast("おなまえをいれてね");
         return;
       }
       nickname = value;

--- a/components/mypage.js
+++ b/components/mypage.js
@@ -11,6 +11,7 @@ import { supabase } from "../utils/supabaseClient.js";
 import { switchScreen } from "../main.js";
 import { createPlanInfoContent } from "./planInfo.js";
 import { changeEmail } from "../utils/changeEmail.js";
+import { showToast } from "../utils/toast.js";
 
 export async function renderMyPageScreen(user) {
   const app = document.getElementById("app");
@@ -134,7 +135,7 @@ export async function renderMyPageScreen(user) {
           .maybeSingle();
         if (error) throw error;
         const updated = data || { ...user, ...updates };
-        alert("プロフィールを更新しました");
+        showToast("プロフィールを更新しました");
         switchScreen("mypage", updated, { replace: true });
       } catch (err) {
         statusEl.textContent = "更新に失敗しました: " + err.message;

--- a/components/planInfo.js
+++ b/components/planInfo.js
@@ -2,6 +2,7 @@ import { renderHeader } from './header.js';
 import { supabase } from '../utils/supabaseClient.js';
 import { switchScreen } from '../main.js';
 import { showCustomConfirm } from './home.js';
+import { showToast } from '../utils/toast.js';
 
 const planMap = {
   plan1: { name: '1ヶ月プラン', monthly: 1490, total: 1490 },
@@ -91,10 +92,10 @@ async function createPlanInfoContent(user) {
             body: JSON.stringify({ userId: user.id }),
           });
           if (res.ok) {
-            alert('解約処理が完了しました');
+            showToast('解約処理が完了しました');
             switchScreen('home');
           } else {
-            alert('解約に失敗しました');
+            showToast('解約に失敗しました');
           }
         });
       };

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -22,6 +22,7 @@ import { getAudio } from "../utils/audioCache.js";
 import { updateGrowthStatusBar, countQualifiedDays } from "../utils/progressStatus.js";
 import { showCustomConfirm } from "../components/home.js";
 import { SHOW_DEBUG } from "../utils/debug.js";
+import { showToast } from "../utils/toast.js";
 
 export async function renderGrowthScreen(user) {
   const app = document.getElementById("app");
@@ -188,7 +189,7 @@ export async function renderGrowthScreen(user) {
           "本当に進捗を赤だけに戻しますか？",
           async () => {
             const success = await resetChordProgressToRed(user.id);
-            alert(success ? "進捗をリセットしました" : "リセットに失敗しました");
+            showToast(success ? "進捗をリセットしました" : "リセットに失敗しました");
           }
         );
       } else if (val === "unlock") {
@@ -198,26 +199,26 @@ export async function renderGrowthScreen(user) {
           await unlockChord(user.id, next.key);
           await applyRecommendedSelection(user.id);
           forceUnlock();
-          alert(`${next.label} を解放しました`);
+          showToast(`${next.label} を解放しました`);
         } else {
-          alert("すべての和音が解放されています");
+          showToast("すべての和音が解放されています");
         }
       } else if (val === "clearWeek") {
         showCustomConfirm(
           "今週のトレーニングデータを本当に削除しますか？",
           async () => {
             const success = await deleteTrainingDataThisWeek(user.id);
-            alert(success ? "今週のデータを削除しました" : "削除に失敗しました");
+            showToast(success ? "今週のデータを削除しました" : "削除に失敗しました");
           }
         );
       } else if (val === "mockNote") {
         await generateMockSingleNoteData(user.id);
-        alert("単音テストのダミーデータを生成しました");
+        showToast("単音テストのダミーデータを生成しました");
       } else if (val.startsWith("mock")) {
         const days = parseInt(val.replace("mock", ""), 10);
         await generateMockGrowthData(user.id, days);
         const count = await countQualifiedDays(user.id);
-        alert(`モックデータ(${days}日分)を生成しました`);
+        showToast(`モックデータ(${days}日分)を生成しました`);
       }
       await renderGrowthScreen(user);
     };

--- a/utils/stripeCheckout.js
+++ b/utils/stripeCheckout.js
@@ -1,4 +1,5 @@
 import { firebaseAuth } from '../firebase/firebase-init.js';
+import { showToast } from './toast.js';
 
 export async function startCheckout(plan) {
   // currentUser が null の瞬間を避ける
@@ -12,7 +13,7 @@ export async function startCheckout(plan) {
     });
   }
   if (!user?.email) {
-    alert('ログイン情報が確認できません。もう一度ログインしてください。');
+    showToast('ログイン情報が確認できません。もう一度ログインしてください。');
     return;
   }
   const email = user.email;
@@ -41,6 +42,6 @@ export async function startCheckout(plan) {
     }
   } catch (err) {
     console.error('Stripe checkout error', err);
-    alert('決済処理でエラーが発生しました');
+    showToast('決済処理でエラーが発生しました');
   }
 }

--- a/utils/weeklyReport.js
+++ b/utils/weeklyReport.js
@@ -1,6 +1,7 @@
 import { supabase } from './supabaseClient.js';
 import { chords, chordOrder } from '../data/chords.js';
 import { REQUIRED_DAYS } from './growthUtils.js';
+import { showToast } from './toast.js';
 
 export async function generateWeeklyReport(user, startDate, endDate) {
   const userId = typeof user === 'string' ? user : user?.id;
@@ -209,6 +210,6 @@ export async function shareReport(text) {
       console.error('❌ 共有に失敗:', err);
     }
   } else {
-    alert('このブラウザは共有機能に対応していません。\n\n' + text);
+    showToast('このブラウザは共有機能に対応していません。\n\n' + text);
   }
 }


### PR DESCRIPTION
## Summary
- Replace remaining `alert` calls with `showToast` for consistent notification styling
- Add toast styling to the login callback page and delay redirect so message is visible
- Swap checkout and sharing fallbacks to toast-based messages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6896ac1b7dec83239c245efbab06d24b