### PR TITLE
feat: sync email to supabase via backend

### DIFF
--- a/api/sync-user.js
+++ b/api/sync-user.js
@@ -1,0 +1,97 @@
+import { createClient } from '@supabase/supabase-js';
+import admin from 'firebase-admin';
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.applicationDefault(),
+  });
+}
+const auth = admin.auth();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).send('Method Not Allowed');
+  }
+
+  let body = req.body;
+  if (typeof body === 'string') {
+    try {
+      body = JSON.parse(body);
+    } catch (err) {
+      console.error('Invalid JSON body');
+      return res.status(400).json({ error: 'Invalid request' });
+    }
+  }
+
+  const { uid, email, idToken } = body || {};
+  if (!uid || !idToken) {
+    return res.status(400).json({ error: 'Missing uid or idToken' });
+  }
+
+  let decoded;
+  try {
+    decoded = await auth.verifyIdToken(idToken);
+  } catch (e) {
+    console.error('Invalid idToken', e);
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+
+  if (decoded.uid !== uid) {
+    return res.status(403).json({ error: 'UID mismatch' });
+  }
+
+  const { data: existing, error: existingError } = await supabase
+    .from('users')
+    .select('*')
+    .eq('firebase_uid', uid)
+    .maybeSingle();
+  if (existingError) {
+    console.error('❌ Existing user check error:', existingError);
+    return res.status(500).json({ error: 'Failed to fetch user' });
+  }
+
+  let isNew = false;
+  let user = existing;
+
+  if (!existing) {
+    isNew = true;
+    const trialEnd = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    const { data: inserted, error: insertError } = await supabase
+      .from('users')
+      .insert([
+        {
+          firebase_uid: uid,
+          email,
+          name: '名前未設定',
+          trial_active: true,
+          trial_end_date: trialEnd,
+        },
+      ])
+      .select()
+      .maybeSingle();
+    if (insertError || !inserted) {
+      console.error('❌ Supabase insert failed:', insertError);
+      return res.status(500).json({ error: 'Insert failed' });
+    }
+    user = inserted;
+  } else if (email && existing.email !== email) {
+    const { data: updated, error: updateError } = await supabase
+      .from('users')
+      .update({ email })
+      .eq('id', existing.id)
+      .select()
+      .maybeSingle();
+    if (updateError) {
+      console.error('❌ Supabase update failed:', updateError);
+      return res.status(500).json({ error: 'Update failed' });
+    }
+    if (updated) user = updated;
+  }
+
+  return res.status(200).json({ user, isNew });
+}

--- a/utils/supabaseUser.js
+++ b/utils/supabaseUser.js
@@ -1,59 +1,27 @@
-import { supabase } from './supabaseClient.js';
-
 export async function ensureSupabaseUser(firebaseUser) {
   if (!firebaseUser) return { user: null, isNew: false };
 
-  const email = firebaseUser.email;
+  const idToken = await firebaseUser.getIdToken();
+  try {
+    const res = await fetch('/api/sync-user', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        uid: firebaseUser.uid,
+        email: firebaseUser.email,
+        idToken,
+      }),
+    });
 
-  const { data: existingUser, error: checkError } = await supabase
-    .from('users')
-    .select('*')
-    .eq('firebase_uid', firebaseUser.uid)
-    .maybeSingle();
-  if (checkError) {
-    console.error('❌ Supabaseユーザー確認エラー:', checkError);
-    throw checkError;
-  }
-
-  if (!existingUser) {
-    const trialEnd = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
-    const { data: inserted, error: insertError } = await supabase
-      .from('users')
-      .upsert(
-        [
-          {
-            firebase_uid: firebaseUser.uid,
-            name: '名前未設定',
-            email,
-            trial_active: true,
-            trial_end_date: trialEnd,
-          },
-        ],
-        { onConflict: 'firebase_uid' }
-      )
-      .select()
-      .maybeSingle();
-
-    if (insertError || !inserted) {
-      console.error('❌ Supabaseユーザー登録失敗:', insertError);
-      throw insertError || new Error('insert failed');
+    if (!res.ok) {
+      const text = await res.text();
+      console.error('❌ Supabaseユーザー同期エラー:', text);
+      throw new Error(text);
     }
 
-    return { user: inserted, isNew: true };
-  } else {
-    let user = existingUser;
-    if (!user.email || user.email !== email) {
-      const { data: updated, error: updateError } = await supabase
-        .from('users')
-        .update({ email })
-        .eq('id', user.id)
-        .select()
-        .maybeSingle();
-      if (!updateError && updated) {
-        user = updated;
-      }
-    }
-
-    return { user, isNew: false };
+    return await res.json();
+  } catch (e) {
+    console.error('❌ Supabaseユーザー同期失敗:', e);
+    throw e;
   }
 }


### PR DESCRIPTION
## Summary
- add service-role API to upsert Firebase users and emails in Supabase
- sync user email on sign-in via backend instead of client-side updates
- remove direct Supabase calls from change-email utility for cleaner decoupling

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_6896aea2b8688323bc12268911bfa37a