### PR TITLE
Handle undefined trial status in access control

### DIFF
--- a/utils/accessControl.js
+++ b/utils/accessControl.js
@@ -2,14 +2,14 @@ export function getLockType(user) {
   if (!user) return null;
   const now = new Date();
 
-  if (!user.is_premium && user.trial_active && user.trial_end_date) {
+  if (!user.is_premium && user.trial_end_date) {
     const end = new Date(user.trial_end_date);
-    if (end <= now) {
+    if (!isNaN(end.getTime()) && end <= now) {
       return "trial_expired";
     }
   }
 
-  if (!user.is_premium && !user.trial_active) {
+  if (!user.is_premium && user.trial_active === false) {
     return "premium_expired";
   }
 


### PR DESCRIPTION
## Summary
- Ensure `getLockType` treats undefined `trial_active` as an active trial and relies on `trial_end_date` to detect expiry
- Only flag `premium_expired` when `trial_active` is explicitly `false`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6896d66e213083239dd83fa59d74d92d