### PR TITLE
feat: include profile status in user sync

### DIFF
--- a/api/sync-user.js
+++ b/api/sync-user.js
@@ -39,7 +39,7 @@ export default async function handler(req, res) {
   const { data: existing, error: selErr } = await supabase
     .from('users')
     .select(
-      'id, email, firebase_uid, is_premium, trial_active, trial_end_date'
+      'id, name, email, firebase_uid, is_premium, trial_active, trial_end_date'
     )
     .eq('firebase_uid', uid)
     .maybeSingle();
@@ -65,7 +65,7 @@ export default async function handler(req, res) {
         is_premium: false,
       })
       .select(
-        'id, email, firebase_uid, is_premium, trial_active, trial_end_date'
+        'id, name, email, firebase_uid, is_premium, trial_active, trial_end_date'
       )
       .maybeSingle();
     if (insErr) {
@@ -79,7 +79,7 @@ export default async function handler(req, res) {
       .update({ email })
       .eq('firebase_uid', uid)
       .select(
-        'id, email, firebase_uid, is_premium, trial_active, trial_end_date'
+        'id, name, email, firebase_uid, is_premium, trial_active, trial_end_date'
       )
       .maybeSingle();
     if (updErr) {
@@ -91,14 +91,22 @@ export default async function handler(req, res) {
 
   const responseUser = {
     id: user.id,
+    name: user.name ?? null,
     email: user.email,
     firebase_uid: user.firebase_uid,
-    is_premium: user.is_premium,
-    trial_active: user.trial_active,
+    is_premium: user.is_premium ?? false,
+    trial_active: user.trial_active ?? true,
     trial_end_date: user.trial_end_date,
   };
+  const needsProfile = !(
+    responseUser.name && String(responseUser.name).trim().length > 0
+  );
 
-  return res
-    .status(200)
-    .json({ user: responseUser, isNew: inserted, inserted, updated });
+  return res.status(200).json({
+    user: responseUser,
+    isNew: inserted || needsProfile,
+    needsProfile,
+    inserted,
+    updated,
+  });
 }

--- a/callback.html
+++ b/callback.html
@@ -49,14 +49,14 @@
         return;
       }
 
-      const { user, isNew } = await ensureSupabaseAuth(firebaseUser);
+      const { user, needsProfile } = await ensureSupabaseAuth(firebaseUser);
       if (!user) {
         addDebugLog('Supabase link failed');
         showDebugLog();
         if (!debugMode) window.location.href = '/';
         return;
       }
-      if (isNew) {
+      if (needsProfile ?? !(user?.name)) {
         await createInitialChordProgress(user.id);
         addDebugLog('redirect: register-thankyou');
         showDebugLog();

--- a/main.js
+++ b/main.js
@@ -253,7 +253,7 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
     console.error("❌ Supabase認証処理エラー:", e);
     return;
   }
-  const { user, isNew } = authResult;
+  const { user, needsProfile } = authResult;
   if (!user) {
     console.warn('⚠️ Firebase logged in but Supabase link failed.');
     return;
@@ -267,7 +267,7 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
     return;
   }
 
-  if (isNew) {
+  if (needsProfile ?? !(user?.name)) {
     window.location.href = "/register-thankyou.html";
     return;
   }

--- a/utils/supabaseUser.js
+++ b/utils/supabaseUser.js
@@ -1,6 +1,6 @@
 export async function ensureSupabaseUser(auth) {
   const user = auth.currentUser;
-  if (!user) return { user: null, isNew: false };
+  if (!user) return { user: null, isNew: false, needsProfile: false };
 
   const idToken = await user.getIdToken(true);
   const payload = { uid: user.uid, email: user.email, idToken };


### PR DESCRIPTION
## Summary
- return `name` and `needsProfile` from `/api/sync-user`
- drive onboarding with `needsProfile` instead of `isNew`
- provide default `needsProfile` flag when no auth user

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_6896da6ebb70832380cdec8d94106439