### PR TITLE
Parse JSON body in create-checkout-session

### DIFF
--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -15,7 +15,17 @@ function ensureAdmin() {
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method Not Allowed' });
 
-  const { uid, email, idToken, priceId } = req.body || {};
+  let body = req.body;
+  if (typeof body === 'string') {
+    try {
+      body = JSON.parse(body);
+    } catch (e) {
+      console.error('Invalid JSON body', e);
+      return res.status(400).json({ error: 'Invalid request' });
+    }
+  }
+
+  const { uid, email, idToken, priceId } = body || {};
   if (!uid || !idToken || !priceId) return res.status(400).json({ error: 'Missing params' });
 
   try {


### PR DESCRIPTION
## Summary
- ensure create-checkout-session handler parses stringified JSON bodies before accessing parameters

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68973021e3dc83239552219e1e47f384