### PR TITLE
Fix auth guard in MyPage rendering

### DIFF
--- a/components/mypage.js
+++ b/components/mypage.js
@@ -27,17 +27,26 @@ export async function renderMyPageScreen(user) {
   tabHeader.className = "mypage-tabs";
 
   const firebaseUser = await new Promise((resolve) => {
-    const unsubscribe = onAuthStateChanged(firebaseAuth, (u) => {
-      unsubscribe();
+    const unsub = onAuthStateChanged(firebaseAuth, (u) => {
+      unsub();
       resolve(u);
     });
   });
+
   if (!firebaseUser) return;
-  await firebaseUser.reload();
-  const methods = await fetchSignInMethodsForEmail(
-    firebaseAuth,
-    firebaseUser.email
-  );
+
+  let methods = [];
+  try {
+    if (!firebaseUser.email) throw new Error("no-email");
+    await firebaseUser.reload();
+    methods = await fetchSignInMethodsForEmail(
+      firebaseAuth,
+      firebaseUser.email
+    );
+  } catch (e) {
+    console.error("[auth-methods]", e);
+    methods = [];
+  }
   const hasPassword = methods.includes("password");
   const googleOnly = methods.includes("google.com") && !hasPassword;
   const showEmailChange = hasPassword;


### PR DESCRIPTION
## Summary
- Correct MyPage auth guard to early-return only when no Firebase user
- Guard sign-in method lookup with email check and error handling to prevent blank page

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_6897483472f88323ba5fec240a0bb96a