### PR TITLE
Switch Google auth popups to redirect flow

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -11,7 +11,7 @@
   <pre id="debug-log" style="white-space: pre-wrap; color: red; font-size: 0.9em;"></pre>
   <script type="module">
     import { firebaseAuth } from './firebase/firebase-init.js';
-    import { getRedirectResult, fetchSignInMethodsForEmail, signOut } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+    import { getRedirectResult, fetchSignInMethodsForEmail, signOut, GoogleAuthProvider, signInWithRedirect } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
     import { ensureSupabaseAuth } from './utils/supabaseAuthHelper.js';
     import { createInitialChordProgress } from './utils/progressUtils.js';
     import { addDebugLog, showDebugLog } from './utils/loginDebug.js';
@@ -31,7 +31,8 @@
       if (!result || !result.user) {
         addDebugLog('no redirect result or user');
         showDebugLog();
-        if (!debugMode) window.location.href = '/';
+        const provider = new GoogleAuthProvider();
+        await signInWithRedirect(firebaseAuth, provider);
         return;
       }
 

--- a/components/login.js
+++ b/components/login.js
@@ -1,8 +1,6 @@
 import {
   signInWithEmailAndPassword,
-  fetchSignInMethodsForEmail,
-  GoogleAuthProvider,
-  signInWithPopup
+  fetchSignInMethodsForEmail
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
 import { firebaseAuth } from "../firebase/firebase-init.js";
@@ -99,11 +97,10 @@ export function renderLoginScreen(container, onLoginSuccess) {
     }
   });
 
-  // Googleログイン処理（ポップアップ方式）
-  const googleProvider = new GoogleAuthProvider();
+  // Googleログイン処理（リダイレクト方式）
   container.querySelector("#google-login").addEventListener("click", () => {
     addDebugLog("click google-login");
-    signInWithPopup(firebaseAuth, googleProvider);
+    window.location.href = "/callback.html";
   });
 
   // 戻るボタン

--- a/components/signup.js
+++ b/components/signup.js
@@ -1,10 +1,6 @@
 import { switchScreen } from "../main.js";
 import { firebaseAuth } from "../firebase/firebase-init.js";
-import {
-  createUserWithEmailAndPassword,
-  GoogleAuthProvider,
-  signInWithPopup
-} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+import { createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 import { addDebugLog } from "../utils/loginDebug.js";
 
 import { showCustomAlert } from "./home.js";
@@ -70,12 +66,11 @@ export function renderSignUpScreen() {
     }
   });
 
-  // Googleサインアップ処理（ポップアップ方式）
+  // Googleサインアップ処理（リダイレクト方式）
   const googleBtn = container.querySelector("#google-signup");
-  const googleProvider = new GoogleAuthProvider();
   googleBtn.addEventListener("click", () => {
     addDebugLog("click google-signup");
-    signInWithPopup(firebaseAuth, googleProvider);
+    window.location.href = "/callback.html";
   });
 
   // 戻るボタン


### PR DESCRIPTION
## Summary
- Replace Google login/signup popups with redirect flow that navigates to `callback.html`
- Start redirect-based Google auth from `callback.html` using Firebase `signInWithRedirect`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68974bcd11cc8323a292009d98a02b1b