### PR TITLE
Add auth sandbox and controller for Supabase testing

### DIFF
--- a/auth-sandbox.html
+++ b/auth-sandbox.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Auth Sandbox</title>
+  <style>
+    body { font-family: system-ui, sans-serif; padding: 20px; }
+    .row { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 16px; }
+    button { padding: 10px 14px; border-radius: 10px; border: 1px solid #ccc; cursor: pointer; }
+    button[disabled] { opacity: .5; cursor: not-allowed; }
+    #stateBox { padding: 12px; background: #f6f6f6; border-radius: 8px; }
+    .mono { font-family: ui-monospace, Menlo, monospace; font-size: 12px; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <h1>Auth Sandbox</h1>
+
+  <div class="row">
+    <button id="btnGoogle">Googleログイン</button>
+    <button id="btnEmail">通常ログイン（ダミー）</button>
+    <button id="btnLogout">ログアウト</button>
+  </div>
+
+  <div id="stateBox">
+    <div>状態: <strong id="status">idle</strong></div>
+    <div>UID: <span id="uid">-</span></div>
+    <div>メール: <span id="uemail">-</span></div>
+    <div>プロバイダ: <span id="uprovider">-</span></div>
+  </div>
+
+  <h3>ログ</h3>
+  <div id="logs" class="mono"></div>
+
+  <script type="module">
+    import { AuthController, AuthState } from './src/authController.js'
+
+    const $ = (id)=>document.getElementById(id)
+    const logBox = $('logs')
+    const statusEl = $('status'), uidEl = $('uid'), uemailEl = $('uemail'), uproviderEl = $('uprovider')
+    const btnGoogle = $('btnGoogle'), btnEmail = $('btnEmail'), btnLogout = $('btnLogout')
+
+    const auth = AuthController.get()
+
+    const addLog = (tag, payload={})=>{
+      const line = `[AUTH] ${new Date().toISOString()} ${tag} ${JSON.stringify(payload)}\n`
+      console.log(line); logBox.textContent = line + logBox.textContent
+    }
+
+    const render = ({state, user})=>{
+      statusEl.textContent = state
+      uidEl.textContent = user?.id ?? '-'
+      uemailEl.textContent = user?.email ?? '-'
+      uproviderEl.textContent = user?.app_metadata?.provider ?? '-'
+      const loading = state === AuthState.Loading
+      btnGoogle.disabled = loading
+      btnEmail.disabled = loading
+      btnLogout.disabled = loading
+    }
+
+    auth.on((s)=>{ addLog('STATE', s); render(s) })
+
+    addLog('INIT_START')
+    await auth.init()
+    addLog('INIT_DONE')
+
+    btnGoogle.addEventListener('click', async ()=>{
+      addLog('CLICK_GOOGLE')
+      try { await auth.loginWithGoogle(); addLog('GOOGLE_OK') }
+      catch(e){ addLog('GOOGLE_ERR', {code:e.code, message:e.message}) }
+    })
+    btnEmail.addEventListener('click', async ()=>{
+      addLog('CLICK_EMAIL')
+      const email = prompt('メールアドレス', 'test@example.com')
+      const pass  = prompt('パスワード', 'password123')
+      try { await auth.loginWithPassword(email, pass); addLog('EMAIL_OK') }
+      catch(e){ addLog('EMAIL_ERR', {code:e.code, message:e.message}) }
+    })
+    btnLogout.addEventListener('click', async ()=>{
+      addLog('CLICK_LOGOUT')
+      try { await auth.logout(); addLog('LOGOUT_OK') }
+      catch(e){ addLog('LOGOUT_ERR', {code:e.code, message:e.message}) }
+    })
+  </script>
+</body>
+</html>

--- a/src/authController.js
+++ b/src/authController.js
@@ -1,0 +1,96 @@
+// Supabase v2
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+export const AuthState = {
+  Idle: 'idle',
+  Loading: 'loading',
+  Authed: 'authed',
+  Unauthed: 'unauthed',
+  Error: 'error',
+}
+
+export class AuthController {
+  static #instance
+  static get() { return this.#instance ??= new AuthController() }
+
+  constructor(){
+    this.state = AuthState.Idle
+    this.user = null
+    this.listeners = new Set()
+    this._inited = false
+
+    const url = window.SUPABASE_URL ?? (import.meta.env?.VITE_SUPABASE_URL)
+    const key = window.SUPABASE_ANON_KEY ?? (import.meta.env?.VITE_SUPABASE_ANON_KEY)
+    this.supabase = createClient(url, key, {
+      auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true }
+    })
+    this._unsubscribe = null
+  }
+
+  on(cb){ this.listeners.add(cb); return ()=>this.listeners.delete(cb) }
+  #emit(){ const s = {state:this.state, user:this.user}; for(const cb of this.listeners) cb(s) }
+
+  async init(){
+    if(this._inited) return
+    this._inited = true
+    this.state = AuthState.Loading; this.#emit()
+    const { data: { session } } = await this.supabase.auth.getSession()
+    if(session?.user){ this.user = session.user; this.state = AuthState.Authed }
+    else { this.user = null; this.state = AuthState.Unauthed }
+    this.#emit()
+
+    this._unsubscribe = this.supabase.auth.onAuthStateChange((_event, session)=>{
+      this.user = session?.user ?? null
+      this.state = this.user ? AuthState.Authed : AuthState.Unauthed
+      console.log('[AUTH] onAuthStateChange', _event, !!this.user)
+      this.#emit()
+    }).data.subscription
+  }
+
+  async loginWithGoogle(){
+    if(this.state === AuthState.Loading) return
+    this.state = AuthState.Loading; this.#emit()
+    try{
+      const { error } = await this.supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo: location.origin + '/auth-sandbox.html',
+          queryParams: { prompt: 'select_account' },
+          skipBrowserRedirect: false,
+        }
+      })
+      if(error) throw error
+    } catch(e){
+      this.state = AuthState.Error; this.#emit()
+      throw e
+    }
+  }
+
+  async loginWithPassword(email, password){
+    if(this.state === AuthState.Loading) return
+    this.state = AuthState.Loading; this.#emit()
+    try{
+      const { data, error } = await this.supabase.auth.signInWithPassword({ email, password })
+      if(error) throw error
+      this.user = data.user
+      this.state = AuthState.Authed; this.#emit()
+    } catch(e){
+      this.state = AuthState.Error; this.#emit()
+      throw e
+    }
+  }
+
+  async logout(){
+    if(this.state === AuthState.Loading) return
+    this.state = AuthState.Loading; this.#emit()
+    try{
+      const { error } = await this.supabase.auth.signOut()
+      if(error) throw error
+      this.user = null
+      this.state = AuthState.Unauthed; this.#emit()
+    } catch(e){
+      this.state = AuthState.Error; this.#emit()
+      throw e
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone auth-sandbox.html with UI to test Supabase auth
- add AuthController module to manage Supabase sessions and authentication flows

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68976341b31883239aa9eb2987ff368b