### PR TITLE
Load Supabase config at runtime

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,3 @@
+// Supabase ランタイム設定（公開可：anon key）
+window.SUPABASE_URL = 'https://xnccwydcesyvqvyqafbg.supabase.co';
+window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhuY2N3eWRjZXN5dnF2eXFhZmJnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY4MDExMTEsImV4cCI6MjA2MjM3NzExMX0.84ELOFGZFJaBNaiHM4roAVmw4o4JMEj4mHnxox1k7Gs'; // anon public

--- a/index.html
+++ b/index.html
@@ -107,6 +107,9 @@
     window.PRICE_ID_12M = '';
   </script>
 
+  <!-- Supabase ランタイム設定（main.js より前に配置） -->
+  <script src="./config.js"></script>
+
   <!-- ✅ 最後に main.js をモジュールとして読み込む -->
   <script type="module" src="main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- expose Supabase URL and anon key through new `config.js`
- load runtime config before `main.js` to remove initialization error

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68981da4075c8323970bbae198e0591c