### PR TITLE
refactor sync-user API to call Supabase via REST

### DIFF
--- a/api/sync-user.js
+++ b/api/sync-user.js
@@ -1,30 +1,44 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
-    res.status(405).json({ error: 'Method not allowed' });
-    return;
+    res.status(405).json({ error: 'Method not allowed' }); return
   }
+
   try {
-    const { uid, email } = req.body || {};
+    const { uid, email } = req.body || {}
     if (!uid || !email) {
-      res.status(400).json({ error: 'Missing uid or email' });
-      return;
+      res.status(400).json({ error: 'Missing uid or email' }); return
     }
 
-    const supabaseUrl = process.env.SUPABASE_URL;
-    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-    const sb = createClient(supabaseUrl, serviceKey);
+    const supabaseUrl = process.env.SUPABASE_URL
+    const serviceKey  = process.env.SUPABASE_SERVICE_ROLE_KEY
+    if (!supabaseUrl || !serviceKey) {
+      res.status(500).json({ error: 'Server env not set' }); return
+    }
 
-    const { data, error } = await sb
-      .from('users')
-      .upsert({ id: uid, uid, email }, { onConflict: 'id' })
-      .select()
-      .single();
+    // REST upsert（on_conflict=id）
+    const endpoint = `${supabaseUrl}/rest/v1/users?on_conflict=id`
+    const r = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'apikey': serviceKey,
+        'Authorization': `Bearer ${serviceKey}`,
+        'Content-Type': 'application/json',
+        'Prefer': 'resolution=merge-duplicates,return=representation'
+      },
+      body: JSON.stringify([{ id: uid, email }])
+    })
 
-    if (error) throw error;
-    res.status(200).json({ ok: true, user: data });
+    const text = await r.text()
+    if (!r.ok) {
+      console.error('sync-user REST error', r.status, text)
+      res.status(500).json({ error: 'Supabase REST failed', status: r.status, body: text }); return
+    }
+
+    let data = null
+    try { data = JSON.parse(text) } catch { data = text }
+    res.status(200).json({ ok: true, user: Array.isArray(data) ? data[0] : data })
   } catch (e) {
-    res.status(500).json({ error: String(e?.message || e) });
+    console.error('sync-user handler error', e)
+    res.status(500).json({ error: String(e?.message || e) })
   }
 }


### PR DESCRIPTION
## Summary
- rewrite `/api/sync-user` to use native `fetch` and Supabase REST API for upsert

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689826ea061483238f4ac09cee9958b7