### PR TITLE
Ensure Supabase users are synced with names

### DIFF
--- a/api/sync-user.js
+++ b/api/sync-user.js
@@ -4,10 +4,11 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { uid, email } = req.body || {}
+    const { uid, email, name } = req.body || {}
     if (!uid || !email) {
       res.status(400).json({ error: 'Missing uid or email' }); return
     }
+    const _name = name || (email ? email.split('@')[0] : 'no-name')
 
     const supabaseUrl = process.env.SUPABASE_URL
     const serviceKey  = process.env.SUPABASE_SERVICE_ROLE_KEY
@@ -25,7 +26,7 @@ export default async function handler(req, res) {
         'Content-Type': 'application/json',
         'Prefer': 'resolution=merge-duplicates,return=representation'
       },
-      body: JSON.stringify([{ id: uid, email }])
+      body: JSON.stringify([{ id: uid, email, name: _name }])
     })
 
     const text = await r.text()

--- a/utils/supabaseUser.js
+++ b/utils/supabaseUser.js
@@ -1,19 +1,25 @@
 import { AuthController } from '../src/authController.js'
 
+function deriveName(user){
+  const m = user?.user_metadata || {}
+  return m.full_name || m.name || (user?.email ? user.email.split('@')[0] : 'no-name')
+}
+
 export async function ensureSupabaseUser(){
   const auth = AuthController.get()
   // セッション確定を保証（念のため）
   if (!auth.user) throw new Error('No Supabase session')
   const { id: uid, email } = auth.user
+  const name = deriveName(auth.user)
 
   const res = await fetch('/api/sync-user', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ uid, email })
+    body: JSON.stringify({ uid, email, name })
   })
   if (!res.ok) {
     const t = await res.text().catch(() => '')
-    throw new Error(t || 'sync-user failed')
+    throw new Error(t || 'A server error has occurred')
   }
   return await res.json()
 }


### PR DESCRIPTION
## Summary
- derive user name from Supabase auth metadata and send to sync endpoint
- accept name in `/api/sync-user` and include in Supabase REST upsert

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check utils/supabaseUser.js api/sync-user.js`


------
https://chatgpt.com/codex/tasks/task_b_689829b612a4832380a35f014fd46c51