### PR TITLE
feat: enable magic link login and password reset

### DIFF
--- a/reset.html
+++ b/reset.html
@@ -1,0 +1,28 @@
+<!doctype html><html lang="ja"><meta charset="utf-8">
+<title>パスワード再設定</title>
+<style>body{font-family:system-ui;padding:20px}input{padding:8px;margin:4px 0;width:260px}</style>
+<h1>パスワード再設定</h1>
+<p>新しいパスワードを入力してください。</p>
+<input id="pw1" type="password" placeholder="新しいパスワード">
+<input id="pw2" type="password" placeholder="もう一度入力">
+<button id="btn">更新</button>
+<div id="msg"></div>
+<script type="module">
+  import { AuthController } from './src/authController.js'
+  const msg = (t)=>document.getElementById('msg').textContent = t
+  const btn = document.getElementById('btn')
+  btn.onclick = async ()=>{
+    const p1 = document.getElementById('pw1').value
+    const p2 = document.getElementById('pw2').value
+    if(!p1 || p1!==p2){ msg('パスワードが未入力、または一致しません'); return }
+    try{
+      const auth = AuthController.get()
+      await auth.init()
+      const { data, error } = await auth.supabase.auth.updateUser({ password: p1 })
+      if(error) throw error
+      msg('更新しました。トップに戻ります...')
+      setTimeout(()=> location.href = '/index.html', 800)
+    }catch(e){ msg('エラー: ' + (e?.message||e)) }
+  }
+</script>
+</html>

--- a/src/authController.js
+++ b/src/authController.js
@@ -104,5 +104,35 @@ export class AuthController {
       throw e
     }
   }
+
+  async signInWithOtp(email){
+    if(this.state === AuthState.Loading) return
+    this.state = AuthState.Loading; this.#emit()
+    try{
+      const { error } = await this.supabase.auth.signInWithOtp({
+        email,
+        options: {
+          emailRedirectTo: location.origin + '/index.html'
+        }
+      })
+      if(error) throw error
+      this.state = AuthState.Unauthed; this.#emit()
+    }catch(e){
+      this.state = AuthState.Error; this.#emit()
+      throw e
+    }
+  }
+
+  async sendResetPassword(email){
+    try{
+      const { error } = await this.supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: location.origin + '/reset.html'
+      })
+      if(error) throw error
+      return true
+    }catch(e){
+      throw e
+    }
+  }
 }
 


### PR DESCRIPTION
## Summary
- allow passwordless access via Supabase magic link
- add password reset workflow and dedicated reset page
- enhance login screen with actions for magic link and password reset

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68982ce80f048323abe62dc14ae51177