### PR TITLE
Gracefully handle Supabase auth failures

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -13,7 +13,7 @@ import { ensureSupabaseAuth } from "../utils/supabaseAuthHelper.js";
 import { ensureChordProgress } from "../utils/progressUtils.js";
 import { showCustomAlert } from "./home.js";
 
-export function renderLoginScreen(container, onLoginSuccess) {
+export function renderLoginScreen(container) {
   container.innerHTML = `
     <div class="login-wrapper">
       <h2 class="login-title">ログイン</h2>
@@ -140,13 +140,16 @@ export function renderLoginScreen(container, onLoginSuccess) {
       sessionStorage.setItem("currentPassword", password);
       const user = firebaseAuth.currentUser;
       try {
-        await ensureSupabaseAuth(user);
+        await ensureSupabaseAuth(user.email);
       } catch (e) {
-        console.error("❌ Supabaseサインイン処理でエラー:", e);
-        return;
+        console.warn("Supabase session init failed:", e);
       }
-      await ensureUserAndProgress(user);
-      onLoginSuccess();
+      try {
+        await ensureUserAndProgress(user);
+      } catch (e) {
+        console.warn("Supabase user/progress init failed:", e);
+      }
+      switchScreen("home");
     } catch (err) {
       if (err.code === "auth/invalid-credential") {
         loginErrorEl.textContent =

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     gtag('config', 'G-QCRGGLGDER');
   </script>
   <script>
-    // Firebaseリセットリンクを検出して専用ページへ転送
+    // Firebase の reset リンクだけを捕捉
     const p = new URLSearchParams(location.search);
     if (p.get('mode') === 'resetPassword' && p.get('oobCode')) {
       location.replace('/reset-password.html?' + p.toString());

--- a/utils/supabaseAuthHelper.js
+++ b/utils/supabaseAuthHelper.js
@@ -1,108 +1,26 @@
 import { supabase } from './supabaseClient.js';
 
-const DUMMY_PASSWORD = 'secure_dummy_password';
+const DUMMY = 'secure_dummy_password';
 
-export async function ensureSupabaseAuth(firebaseUser) {
-  if (!firebaseUser) return { user: null, isNew: false };
-  const email = firebaseUser.email;
+export async function ensureSupabaseAuth(emailOrUser) {
+  const email = typeof emailOrUser === 'string' ? emailOrUser : emailOrUser?.email;
+  if (!email) return;
 
-  // Check our users table
-  const { data: existingUser, error: checkError } = await supabase
-    .from('users')
-    .select('*')
-    .eq('firebase_uid', firebaseUser.uid)
-    .maybeSingle();
-  if (checkError) {
-    console.error('❌ Supabaseユーザー確認エラー:', checkError);
-    throw checkError;
-  }
+  let { data, error } = await supabase.auth.signInWithPassword({ email, password: DUMMY });
+  if (!error) return data;
 
-  const signIn = async () => {
-    const { error } = await supabase.auth.signInWithPassword({
+  if (/invalid login/i.test(error.message)) {
+    const { error: upErr } = await supabase.auth.signUp({
       email,
-      password: DUMMY_PASSWORD,
+      password: DUMMY,
+      options: { emailRedirectTo: undefined }
     });
-    return error;
-  };
+    if (upErr && !/already registered/i.test(upErr.message)) throw upErr;
 
-  if (!existingUser) {
-    let signInError = await signIn();
-    if (signInError) {
-      if (signInError.message.includes('Invalid login credentials')) {
-        const { error: signUpError } = await supabase.auth.signUp({
-          email,
-          password: DUMMY_PASSWORD,
-        });
-        if (signUpError && !signUpError.message.includes('User already registered')) {
-          console.error('❌ Supabaseユーザー作成失敗:', signUpError.message);
-          throw signUpError;
-        }
-        signInError = await signIn();
-      }
-      if (signInError) {
-        console.error('❌ Supabaseログイン失敗:', signInError.message);
-        throw signInError;
-      }
-    }
-
-    const trialEnd = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
-    const { data: inserted, error: insertError } = await supabase
-      .from('users')
-      .upsert(
-        [
-          {
-            firebase_uid: firebaseUser.uid,
-            name: '名前未設定',
-            email,
-            trial_active: true,
-            trial_end_date: trialEnd,
-          },
-        ],
-        { onConflict: 'firebase_uid' }
-      )
-      .select()
-      .maybeSingle();
-
-    if (insertError || !inserted) {
-      console.error('❌ Supabaseユーザー登録失敗:', insertError);
-      throw insertError || new Error('insert failed');
-    }
-
-    return { user: inserted, isNew: true };
-  } else {
-    let signInError = await signIn();
-    if (signInError) {
-      // If credentials mismatch, attempt sign up once
-      if (signInError.message.includes('Invalid login credentials')) {
-        const { error: signUpError } = await supabase.auth.signUp({
-          email,
-          password: DUMMY_PASSWORD,
-        });
-        if (signUpError && !signUpError.message.includes('User already registered')) {
-          console.error('❌ Supabaseユーザー作成失敗:', signUpError.message);
-          throw signUpError;
-        }
-        signInError = await signIn();
-      }
-      if (signInError) {
-        console.error('❌ Supabaseログイン失敗:', signInError.message);
-        throw signInError;
-      }
-    }
-
-    let user = existingUser;
-    if (!user.email || user.email !== email) {
-      const { data: updated, error: updateError } = await supabase
-        .from('users')
-        .update({ email })
-        .eq('id', user.id)
-        .select()
-        .maybeSingle();
-      if (!updateError && updated) {
-        user = updated;
-      }
-    }
-
-    return { user, isNew: false };
+    const { error: siErr } = await supabase.auth.signInWithPassword({ email, password: DUMMY });
+    if (siErr) throw siErr;
+    return;
   }
+
+  throw error;
 }


### PR DESCRIPTION
## Summary
- Proceed to home screen after Firebase sign-in even if Supabase auth fails
- Add retry-only Supabase session helper using a dummy password
- Simplify auth state change handling and unify reset-password redirect

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68988d532900832394ffc1f4bd4ae9e1