### PR TITLE
Remove production check hiding forgot password button

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -46,9 +46,6 @@ export function renderLoginScreen(container) {
   const pwInput = container.querySelector("#password");
   const pwToggle = container.querySelector(".toggle-password");
   const forgotBtn = container.querySelector("#forgot-btn");
-  if (window.location.hostname === "playotoron.com") {
-    forgotBtn.style.display = "none";
-  }
   pwToggle.addEventListener("click", () => {
     const visible = pwInput.type === "text";
     pwInput.type = visible ? "password" : "text";


### PR DESCRIPTION
## Summary
- Remove hostname check that hid the "forgot password" button in production so it is visible in all environments

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6898a35fd5888323ab72d565846c50f3