### PR TITLE
Use custom alerts across account and billing flows

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -15,6 +15,7 @@
     import { ensureAppUserRecord } from './utils/userStore.js';
     import { createInitialChordProgress } from './utils/progressUtils.js';
     import { addDebugLog, showDebugLog } from './utils/loginDebug.js';
+    import { showCustomAlert } from './components/home.js';
 
     (async () => {
 
@@ -41,10 +42,12 @@
       const methods = await fetchSignInMethodsForEmail(firebaseAuth, firebaseUser.email);
       if (methods.includes('password') && !methods.includes('google.com')) {
         await signOut(firebaseAuth);
-        alert('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。');
         addDebugLog('redirect: login exists');
         showDebugLog();
-        if (!debugMode) window.location.href = '/';
+        const redirect = () => {
+          if (!debugMode) window.location.href = '/';
+        };
+        showCustomAlert('このメールアドレスは既に通常のログインで使用されています。Googleログインはできません。', redirect);
         return;
       }
 

--- a/components/initialSetup.js
+++ b/components/initialSetup.js
@@ -1,6 +1,7 @@
 import { chords } from "../data/chords.js";
 import { supabase } from "../utils/supabaseClient.js";
 import { applyStartChordIndex } from "../utils/progressUtils.js";
+import { showCustomAlert } from "./home.js";
 
 export function renderInitialSetupScreen(user, onComplete) {
   const app = document.getElementById("app");
@@ -21,7 +22,7 @@ export function renderInitialSetupScreen(user, onComplete) {
     wrapper.querySelector("#next-btn").onclick = () => {
       const value = wrapper.querySelector("#nickname").value.trim();
       if (!value) {
-        alert("おなまえをいれてね");
+        showCustomAlert("おなまえをいれてね");
         return;
       }
       nickname = value;

--- a/components/mypage.js
+++ b/components/mypage.js
@@ -12,6 +12,7 @@ import { startCheckout } from "../utils/stripeCheckout.js";
 import { supabase } from "../utils/supabaseClient.js";
 import { switchScreen } from "../main.js";
 import { createPlanInfoContent } from "./planInfo.js";
+import { showCustomAlert } from "./home.js";
 
 async function changeEmailFlow(newEmail, currentPassword) {
   const user = firebaseAuth.currentUser;
@@ -24,7 +25,7 @@ async function changeEmailFlow(newEmail, currentPassword) {
 
   await verifyBeforeUpdateEmail(user, newEmail);
 
-  alert(
+  showCustomAlert(
     "確認メールを送信しました。メール内のリンクを開くとメールアドレスが更新されます。"
   );
 }
@@ -153,11 +154,11 @@ export function renderMyPageScreen(user) {
 
         const updated = data || { ...user, ...updates };
         if (!emailChanged) {
-          alert("プロフィールを更新しました");
+          showCustomAlert("プロフィールを更新しました");
         }
         switchScreen("mypage", updated, { replace: true });
       } catch (err) {
-        alert("更新に失敗しました: " + err.message);
+        showCustomAlert("更新に失敗しました: " + err.message);
       }
     });
 
@@ -284,12 +285,12 @@ export function renderMyPageScreen(user) {
         await reauthenticateWithCredential(firebaseUser, cred);
         await updatePassword(firebaseUser, newPw);
         sessionStorage.setItem("currentPassword", newPw);
-        alert("パスワードを変更しました");
+        showCustomAlert("パスワードを変更しました");
         form.reset();
         current.input.value = newPw;
         validate();
       } catch (err) {
-        alert("パスワード変更に失敗しました: " + err.message);
+        showCustomAlert("パスワード変更に失敗しました: " + err.message);
       }
     });
 

--- a/components/planInfo.js
+++ b/components/planInfo.js
@@ -1,7 +1,7 @@
 import { renderHeader } from './header.js';
 import { supabase } from '../utils/supabaseClient.js';
 import { switchScreen } from '../main.js';
-import { showCustomConfirm } from './home.js';
+import { showCustomConfirm, showCustomAlert } from './home.js';
 
 const planMap = {
   plan1: { name: '1ヶ月プラン', monthly: 1490, total: 1490 },
@@ -91,10 +91,11 @@ async function createPlanInfoContent(user) {
             body: JSON.stringify({ userId: user.id }),
           });
           if (res.ok) {
-            alert('解約処理が完了しました');
-            switchScreen('home');
+            showCustomAlert('解約処理が完了しました', () => {
+              switchScreen('home');
+            });
           } else {
-            alert('解約に失敗しました');
+            showCustomAlert('解約に失敗しました');
           }
         });
       };

--- a/logic/growth.js
+++ b/logic/growth.js
@@ -20,7 +20,7 @@ import { renderHeader } from "../components/header.js";
 import { unlockChord, resetChordProgressToRed } from "../utils/progressUtils.js";
 import { getAudio } from "../utils/audioCache.js";
 import { updateGrowthStatusBar, countQualifiedDays } from "../utils/progressStatus.js";
-import { showCustomConfirm } from "../components/home.js";
+import { showCustomConfirm, showCustomAlert } from "../components/home.js";
 import { SHOW_DEBUG } from "../utils/debug.js";
 
 export async function renderGrowthScreen(user) {
@@ -188,7 +188,9 @@ export async function renderGrowthScreen(user) {
           "本当に進捗を赤だけに戻しますか？",
           async () => {
             const success = await resetChordProgressToRed(user.id);
-            alert(success ? "進捗をリセットしました" : "リセットに失敗しました");
+            showCustomAlert(
+              success ? "進捗をリセットしました" : "リセットに失敗しました"
+            );
           }
         );
       } else if (val === "unlock") {
@@ -198,26 +200,28 @@ export async function renderGrowthScreen(user) {
           await unlockChord(user.id, next.key);
           await applyRecommendedSelection(user.id);
           forceUnlock();
-          alert(`${next.label} を解放しました`);
+          showCustomAlert(`${next.label} を解放しました`);
         } else {
-          alert("すべての和音が解放されています");
+          showCustomAlert("すべての和音が解放されています");
         }
       } else if (val === "clearWeek") {
         showCustomConfirm(
           "今週のトレーニングデータを本当に削除しますか？",
           async () => {
             const success = await deleteTrainingDataThisWeek(user.id);
-            alert(success ? "今週のデータを削除しました" : "削除に失敗しました");
+            showCustomAlert(
+              success ? "今週のデータを削除しました" : "削除に失敗しました"
+            );
           }
         );
       } else if (val === "mockNote") {
         await generateMockSingleNoteData(user.id);
-        alert("単音テストのダミーデータを生成しました");
+        showCustomAlert("単音テストのダミーデータを生成しました");
       } else if (val.startsWith("mock")) {
         const days = parseInt(val.replace("mock", ""), 10);
         await generateMockGrowthData(user.id, days);
         const count = await countQualifiedDays(user.id);
-        alert(`モックデータ(${days}日分)を生成しました`);
+        showCustomAlert(`モックデータ(${days}日分)を生成しました`);
       }
       await renderGrowthScreen(user);
     };

--- a/reset-password.html
+++ b/reset-password.html
@@ -30,6 +30,7 @@
       verifyPasswordResetCode,
       confirmPasswordReset,
     } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import { showCustomAlert } from "./components/home.js";
 
     const params = new URLSearchParams(location.search);
     const mode = params.get('mode');
@@ -49,7 +50,7 @@
       await verifyPasswordResetCode(firebaseAuth, oobCode);
     } catch (e) {
       valid = false;
-      alert("リンクが無効です：" + e.message);
+      showCustomAlert("リンクが無効です：" + e.message);
       [newPw, confPw, form.querySelector("button")].forEach(el => el.disabled = true);
     }
 
@@ -66,15 +67,17 @@
       if (form.querySelector("button").disabled) return;
       try {
         await confirmPasswordReset(firebaseAuth, oobCode, newPw.value.trim());
-        alert("パスワードを更新しました。ログインしてください。");
-        try {
-          history.replaceState(null, '', '/#login');
-          location.replace('/#login');
-        } catch (e) {
-          location.replace('/#login');
-        }
+        const goLogin = () => {
+          try {
+            history.replaceState(null, '', '/#login');
+            location.replace('/#login');
+          } catch (e) {
+            location.replace('/#login');
+          }
+        };
+        showCustomAlert("パスワードを更新しました。ログインしてください。", goLogin);
       } catch (e) {
-        alert("更新に失敗しました：" + e.message);
+        showCustomAlert("更新に失敗しました：" + e.message);
       }
     });
   </script>

--- a/utils/stripeCheckout.js
+++ b/utils/stripeCheckout.js
@@ -1,9 +1,10 @@
 import { firebaseAuth } from '../firebase/firebase-init.js';
+import { showCustomAlert } from '../components/home.js';
 
 export async function startCheckout(plan) {
   const email = firebaseAuth.currentUser?.email || '未取得';
   if (!firebaseAuth.currentUser?.email) {
-    alert('ログイン情報がありません');
+    showCustomAlert('ログイン情報がありません');
     return;
   }
 
@@ -30,6 +31,6 @@ export async function startCheckout(plan) {
     }
   } catch (err) {
     console.error('Stripe checkout error', err);
-    alert('決済処理でエラーが発生しました');
+    showCustomAlert('決済処理でエラーが発生しました');
   }
 }

--- a/utils/weeklyReport.js
+++ b/utils/weeklyReport.js
@@ -1,6 +1,7 @@
 import { supabase } from './supabaseClient.js';
 import { chords, chordOrder } from '../data/chords.js';
 import { REQUIRED_DAYS } from './growthUtils.js';
+import { showCustomAlert } from '../components/home.js';
 
 export async function generateWeeklyReport(user, startDate, endDate) {
   const userId = typeof user === 'string' ? user : user?.id;
@@ -209,6 +210,6 @@ export async function shareReport(text) {
       console.error('❌ 共有に失敗:', err);
     }
   } else {
-    alert('このブラウザは共有機能に対応していません。\n\n' + text);
+    showCustomAlert('このブラウザは共有機能に対応していません。\n\n' + text);
   }
 }


### PR DESCRIPTION
## Summary
- Replace native `alert` dialogs with `showCustomAlert` for email and password updates on My Page
- Apply the same custom alert styling to reset-password, plan info cancellation, Stripe checkout, weekly report sharing and other flows
- Ensure growth debug actions also use custom alerts instead of browser dialogs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6898c82c3c4483239ae64775a829777e