### PR TITLE
feat: quiet optional Supabase auth

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -8,7 +8,7 @@ import {
 import { firebaseAuth } from "../firebase/firebase-init.js";
 import { switchScreen } from "../main.js";
 import { addDebugLog } from "../utils/loginDebug.js";
-import { ensureSupabaseAuth } from "../utils/supabaseClient.js";
+import { ensureSupabaseAuth } from "../utils/supabaseOptionalAuth.js";
 import { ensureAppUserRecord } from "../utils/userStore.js";
 import { showCustomAlert } from "./home.js";
 
@@ -65,10 +65,8 @@ export function renderLoginScreen(container) {
   async function onFirebaseLoginSuccess(firebaseUser) {
     const email = firebaseUser.email;
     try {
-      await ensureSupabaseAuth(email);
-    } catch (e) {
-      console.warn("Supabase session init failed:", e);
-    }
+      await ensureSupabaseAuth(email, { quiet: true });
+    } catch (_) {}
     const profile = await ensureAppUserRecord({
       uid: firebaseUser.uid,
       email,

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ import { renderLoginScreen } from "./components/login.js";
 import { renderIntroScreen } from "./components/intro.js";
 import { renderSignUpScreen } from "./components/signup.js";
 import { renderInitialSetupScreen } from "./components/initialSetup.js";
-import { ensureSupabaseAuth } from "./utils/supabaseClient.js";
+import { ensureSupabaseAuth } from "./utils/supabaseOptionalAuth.js";
 import { ensureAppUserRecord } from "./utils/userStore.js";
 import { getLockType } from "./utils/accessControl.js";
 import { loadTrainingRecords } from "./utils/recordStore_supabase.js";
@@ -243,10 +243,8 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 
   try {
     await firebaseUser.getIdToken();
-    await ensureSupabaseAuth(firebaseUser.email);
-  } catch (e) {
-    console.warn("Supabase session init failed:", e);
-  }
+    await ensureSupabaseAuth(firebaseUser.email, { quiet: true });
+  } catch (_) {}
 
   try {
     const profile = await ensureAppUserRecord({

--- a/utils/supabaseOptionalAuth.js
+++ b/utils/supabaseOptionalAuth.js
@@ -1,0 +1,33 @@
+import { supabase } from './supabaseClient.js';
+const DUMMY = 'secure_dummy_password';
+
+let triedSupabaseAuth = false;
+
+export async function ensureSupabaseAuth(email, { quiet = true } = {}) {
+  if (triedSupabaseAuth) return false;
+  triedSupabaseAuth = true;
+
+  try {
+    const { data } = await supabase.auth.getSession();
+    if (data?.session) return true;
+  } catch (_) {}
+
+  try {
+    await supabase.auth.signInWithPassword({ email, password: DUMMY });
+    return true;
+  } catch (e) {
+    try {
+      const { error: upErr } = await supabase.auth.signUp({ email, password: DUMMY });
+      if (!upErr || upErr?.status === 422) {
+        try {
+          await supabase.auth.signInWithPassword({ email, password: DUMMY });
+          return true;
+        } catch {}
+      }
+    } catch {}
+
+    if (!quiet) console.warn('[supabase-init] optional init failed:', e);
+    else console.debug('[supabase-init] optional init failed');
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add optional Supabase session helper that suppresses repeated 400/422 errors
- use new optional helper in login flow and global auth change handler

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_6898cb5f1ac88323b11c7ea203aa1460