### PR TITLE
Handle Stripe config fetch errors and prevent double checkout

### DIFF
--- a/components/mypage.js
+++ b/components/mypage.js
@@ -372,7 +372,7 @@ export function renderMyPageScreen(user) {
       const btn = document.createElement("button");
       btn.className = "choose-plan";
       btn.textContent = "このプランを選ぶ";
-      btn.onclick = () => startCheckout(p.key);
+      btn.onclick = () => startCheckout(p.key, btn);
       card.appendChild(btn);
 
       wrap.appendChild(card);

--- a/components/pricing.js
+++ b/components/pricing.js
@@ -78,7 +78,7 @@ export function renderPricingScreen(user) {
     const btn = document.createElement('button');
     btn.className = 'choose-plan';
     btn.textContent = 'このプランを選ぶ';
-    btn.onclick = () => startCheckout(p.key);
+    btn.onclick = () => startCheckout(p.key, btn);
     card.appendChild(btn);
 
     main.appendChild(card);


### PR DESCRIPTION
## Summary
- guard Stripe config fetch against network failures and missing keys
- disable checkout button during processing to avoid double submissions

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_6899aa1d142c83238ced0644ed30b0b6