### PR TITLE
Redirect new users to setup screen and defer progress creation

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -13,7 +13,6 @@
     import { getRedirectResult, fetchSignInMethodsForEmail, signOut } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
     import { ensureSupabaseAuth } from './utils/supabaseClient.js';
     import { ensureAppUserRecord } from './utils/userStore.js';
-    import { createInitialChordProgress } from './utils/progressUtils.js';
     import { addDebugLog, showDebugLog } from './utils/loginDebug.js';
     import { showCustomAlert } from './components/home.js';
 
@@ -59,10 +58,9 @@
         avatar_url: firebaseUser.photoURL ?? null,
       });
       if (isNew) {
-        await createInitialChordProgress(profile.id);
-        addDebugLog('redirect: register-thankyou');
+        addDebugLog('redirect: setup');
         showDebugLog();
-        if (!debugMode) window.location.href = '/register-thankyou.html';
+        if (!debugMode) window.location.href = '/#setup';
       } else {
         addDebugLog('redirect: home');
         showDebugLog();

--- a/components/initialSetup.js
+++ b/components/initialSetup.js
@@ -1,6 +1,6 @@
 import { chords } from "../data/chords.js";
 import { supabase } from "../utils/supabaseClient.js";
-import { applyStartChordIndex } from "../utils/progressUtils.js";
+import { applyStartChordIndex, createInitialChordProgress } from "../utils/progressUtils.js";
 import { showCustomAlert } from "./home.js";
 
 export function renderInitialSetupScreen(user, onComplete) {
@@ -50,6 +50,7 @@ export function renderInitialSetupScreen(user, onComplete) {
         .from("users")
         .update({ name: nickname })
         .eq("id", user.id);
+      await createInitialChordProgress(user.id);
       await applyStartChordIndex(user.id, idx);
       const { data } = await supabase
         .from("users")

--- a/components/signup.js
+++ b/components/signup.js
@@ -7,7 +7,6 @@ import {
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 import { ensureSupabaseAuth } from "../utils/supabaseClient.js";
 import { ensureAppUserRecord } from "../utils/userStore.js";
-import { createInitialChordProgress } from "../utils/progressUtils.js";
 import { addDebugLog } from "../utils/loginDebug.js";
 
 import { showCustomAlert } from "./home.js";
@@ -75,9 +74,8 @@ export function renderSignUpScreen() {
           name: cred.user.displayName ?? null,
           avatar_url: cred.user.photoURL ?? null,
         });
-        await createInitialChordProgress(profile.id);
+        switchScreen("setup", profile);
       }
-      window.location.href = "/register-thankyou.html";
     } catch (e) {
       showCustomAlert("登録エラー：" + e.message);
     }

--- a/main.js
+++ b/main.js
@@ -254,7 +254,11 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
       avatar_url: firebaseUser.photoURL ?? null,
     });
     window.currentUser = profile;
-    switchScreen("home", profile);
+    if (!profile.name) {
+      switchScreen("setup", profile);
+    } else {
+      switchScreen("home", profile);
+    }
   } catch (e) {
     console.warn("Supabase user init failed:", e);
   }


### PR DESCRIPTION
## Summary
- Send new accounts directly to initial setup instead of thank-you page.
- Move initial chord progress creation into setup flow and apply selected chord afterward.
- Route logged-in users without a name to setup screen.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a9391172a8832397c10bf79d9089f8