### PR TITLE
Use start field for new user setup

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -60,12 +60,13 @@
       if (isNew) {
         addDebugLog('redirect: setup');
         showDebugLog();
-        if (!debugMode) window.location.href = '/#setup';
+        window.location.hash = '#/setup';
       } else {
         addDebugLog('redirect: home');
         showDebugLog();
-        if (!debugMode) window.location.href = '/';
+        window.location.hash = '';
       }
+      if (!debugMode) window.location.href = '/' + window.location.hash;
     } catch (e) {
       console.error('auth flow error', e);
       addDebugLog('auth flow error', e.message);

--- a/components/initialSetup.js
+++ b/components/initialSetup.js
@@ -1,6 +1,6 @@
 import { chords } from "../data/chords.js";
 import { supabase } from "../utils/supabaseClient.js";
-import { applyStartChordIndex, createInitialChordProgress } from "../utils/progressUtils.js";
+import { createInitialChordProgress, applyStartIndexToUser } from "../utils/progressUtils.js";
 import { showCustomAlert } from "./home.js";
 
 export function renderInitialSetupScreen(user, onComplete) {
@@ -51,13 +51,13 @@ export function renderInitialSetupScreen(user, onComplete) {
         .update({ name: nickname })
         .eq("id", user.id);
       await createInitialChordProgress(user.id);
-      await applyStartChordIndex(user.id, idx);
-      const { data } = await supabase
+      await applyStartIndexToUser(user.id, idx);
+      const { data: updated } = await supabase
         .from("users")
         .select("*")
         .eq("id", user.id)
         .maybeSingle();
-      onComplete(data || user);
+      onComplete(updated || user);
     };
   }
 

--- a/main.js
+++ b/main.js
@@ -254,7 +254,7 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
       avatar_url: firebaseUser.photoURL ?? null,
     });
     window.currentUser = profile;
-    if (!profile.name) {
+    if (profile.start == null) {
       switchScreen("setup", profile);
     } else {
       switchScreen("home", profile);

--- a/utils/progressUtils.js
+++ b/utils/progressUtils.js
@@ -84,6 +84,21 @@ export async function applyStartChordIndex(userId, startIndex) {
   }
 }
 
+export async function applyStartIndexToUser(userId, startIndex) {
+  await applyStartChordIndex(userId, startIndex);
+  if (!userId) {
+    console.warn("applyStartIndexToUser called without valid user ID");
+    return;
+  }
+  const { error } = await supabase
+    .from("users")
+    .update({ start: startIndex })
+    .eq("id", userId);
+  if (error) {
+    console.error("❌ applyStartIndexToUser user update failed:", error);
+  }
+}
+
 // ✅ 連続合格日数が7日に達したら、次の和音に進める
 export async function autoUnlockNextChord(user) {
   const passed = await getPassedDays(user.id);


### PR DESCRIPTION
## Summary
- Detect new users by `users.start` instead of `name` and ensure start is initialized to `null`
- Add helper to apply selected start index and update user record
- Re-fetch user after setup and route new sign-ups to setup via hash

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68a943356304832388b4387fb38102d2