### PR TITLE
Remove users.start usage and refresh service worker cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,7 @@
-const CACHE_NAME = 'otoron-cache-v1';
+const CACHE_NAME = 'otoron-cache-v2';
+
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', e => { e.waitUntil(clients.claim()); });
 const STATIC_ASSETS = [
   '/',
   '/index.html',
@@ -48,7 +51,6 @@ self.addEventListener('install', event => {
       )
     )
   );
-  self.skipWaiting();
 });
 
 self.addEventListener('activate', event => {
@@ -57,7 +59,6 @@ self.addEventListener('activate', event => {
       Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
     )
   );
-  self.clients.claim();
 });
 
 self.addEventListener('fetch', event => {

--- a/utils/progressUtils.js
+++ b/utils/progressUtils.js
@@ -84,21 +84,6 @@ export async function applyStartChordIndex(userId, startIndex) {
   }
 }
 
-export async function applyStartIndexToUser(userId, startIndex) {
-  await applyStartChordIndex(userId, startIndex);
-  if (!userId) {
-    console.warn("applyStartIndexToUser called without valid user ID");
-    return;
-  }
-  const { error } = await supabase
-    .from("users")
-    .update({ start: startIndex })
-    .eq("id", userId);
-  if (error) {
-    console.error("❌ applyStartIndexToUser user update failed:", error);
-  }
-}
-
 // ✅ 連続合格日数が7日に達したら、次の和音に進める
 export async function autoUnlockNextChord(user) {
   const passed = await getPassedDays(user.id);

--- a/utils/userStore.js
+++ b/utils/userStore.js
@@ -13,7 +13,7 @@ export async function ensureAppUserRecord({ uid, email, name: displayName, avata
   try {
     const { data: ex } = await supabase
       .from("users")
-      .select("id,name,start")
+      .select("*")
       .eq("firebase_uid", uid)
       .single();
     existingUser = ex ?? null;
@@ -26,7 +26,6 @@ export async function ensureAppUserRecord({ uid, email, name: displayName, avata
   });
 
   const insert = { firebase_uid: uid, email, name, avatar_url };
-  if (!existingUser) insert.start = null;
 
   const { data, error } = await supabase
     .from("users")


### PR DESCRIPTION
## Summary
- Drop `users.start` references from user and progress utilities
- Bump service worker cache version and ensure immediate activation

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_68a965806a308323a56bedb431b60c51