### PR TITLE
Add blog link to info menu

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -27,6 +27,16 @@ export function renderHeader(container, user) {
           <button id="privacy-btn">プライバシーポリシー</button>
           <button id="contact-btn">お問い合わせ</button>
           <button id="help-btn">必ずお読みください</button>
+          <a
+            href="https://blog.playotoron.com/?utm_source=app&utm_medium=info_menu&utm_campaign=launch"
+            class="info-link"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-analytics="blog"
+          >
+            ブログ（外部サイト）
+            <span class="ext-icon" aria-hidden="true">↗</span>
+          </a>
           <button id="faq-btn">よくある質問</button>
           <button id="law-btn">特定商取引法に基づく表示</button>
           <button id="external-btn">外部送信ポリシー</button>

--- a/components/intro.js
+++ b/components/intro.js
@@ -42,6 +42,16 @@ export function renderIntroScreen() {
             <button id="privacy-btn">プライバシーポリシー</button>
             <button id="contact-btn">お問い合わせ</button>
             <button id="help-btn">必ずお読みください</button>
+            <a
+              href="https://blog.playotoron.com/?utm_source=app&utm_medium=info_menu&utm_campaign=launch"
+              class="info-link"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-analytics="blog"
+            >
+              ブログ（外部サイト）
+              <span class="ext-icon" aria-hidden="true">↗</span>
+            </a>
             <button id="faq-btn">よくある質問</button>
             <button id="law-btn">特定商取引法に基づく表示</button>
             <button id="external-btn">外部送信ポリシー</button>

--- a/components/introHeader.js
+++ b/components/introHeader.js
@@ -18,6 +18,16 @@ export function renderIntroHeader(container) {
           <button id="privacy-btn">プライバシーポリシー</button>
           <button id="contact-btn">お問い合わせ</button>
           <button id="help-btn">必ずお読みください</button>
+          <a
+            href="https://blog.playotoron.com/?utm_source=app&utm_medium=info_menu&utm_campaign=launch"
+            class="info-link"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-analytics="blog"
+          >
+            ブログ（外部サイト）
+            <span class="ext-icon" aria-hidden="true">↗</span>
+          </a>
           <button id="faq-btn">よくある質問</button>
           <button id="law-btn">特定商取引法に基づく表示</button>
           <button id="external-btn">外部送信ポリシー</button>

--- a/css/header.css
+++ b/css/header.css
@@ -187,6 +187,17 @@
   background-color: #f5f5f5;
 }
 
+.info-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ext-icon {
+  font-size: 0.85em;
+  opacity: 0.65;
+}
+
 /* ▼ ログアウトボタン（従来のスタイル） */
 .logout-btn {
   padding: 0.4em 1em;

--- a/style.css
+++ b/style.css
@@ -848,6 +848,17 @@ button:hover {
   background-color: #f5f5f5;
 }
 
+.info-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ext-icon {
+  font-size: 0.85em;
+  opacity: 0.65;
+}
+
 /* ▼ ログアウトボタン（従来のスタイル） */
 .logout-btn {
   padding: 0.4em 1em;


### PR DESCRIPTION
## Summary
- add "ブログ（外部サイト）" link to info menus across headers
- style external link with flex layout and arrow icon

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b0454117708323bb152a7595ab70e8