### PR TITLE
Fix blog link overflow in info dropdown

### DIFF
--- a/style.css
+++ b/style.css
@@ -827,6 +827,7 @@ button:hover {
   pointer-events: auto;
 }
 
+
 .info-dropdown button,
 .info-dropdown a {
   display: block;
@@ -839,8 +840,16 @@ button:hover {
   font-size: 1rem;
   text-align: left;
   cursor: pointer;
-  white-space: nowrap;
   transition: background 0.2s ease;
+  box-sizing: border-box;
+}
+
+.info-dropdown button {
+  white-space: nowrap;
+}
+
+.info-dropdown a {
+  white-space: normal;
 }
 
 .info-dropdown button:hover,
@@ -852,6 +861,7 @@ button:hover {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .ext-icon {


### PR DESCRIPTION
## Summary
- prevent external blog link from expanding info dropdown
- allow info link text to wrap and size correctly

## Testing
- `npm test` *(fails: missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_68b04bfb89f0832381c5bb478dea1b17