### PR TITLE
Add English UI and JPY price localization

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -1,4 +1,4 @@
-import { switchScreen } from "../main.js";
+import { switchScreen, t } from "../main.js";
 import { loadTrainingRecords } from "../utils/recordStore_supabase.js";
 import { getToday } from "../utils/growthUtils.js";
 import { renderHeader } from "./header.js";
@@ -45,7 +45,7 @@ export async function renderHomeScreen(user, options = {}) {
 
   const info = document.createElement("p");
   info.className = "today-count";
-  info.innerHTML = `🎯 きょう の がんばり：<strong>${todayRecord.sets}</strong>かい`;
+  info.innerHTML = `${t('label_today_count')}：<strong>${todayRecord.sets}</strong>`;
   container.appendChild(info);
 
   // Create trial info element ahead of time to preserve layout

--- a/components/training.js
+++ b/components/training.js
@@ -1,7 +1,7 @@
 // 修正済み training.js（黒鍵転回形も正しく表示）
 import { chords } from "../data/chords.js";
 import { selectedChords } from "./settings.js";
-import { switchScreen } from "../main.js";
+import { switchScreen, t } from "../main.js";
 import { showCustomConfirm } from "./home.js";
 import { resetResultFlag } from "./result.js";
 import { saveSessionToHistory } from "./summary.js";
@@ -471,7 +471,7 @@ if (correctBtn) {
   correctBtn.classList.add("correct-highlight");
 }
 
-    showFeedback("もういちど", "bad");
+    showFeedback(t("btn_retry"), "bad");
     const soundKey = currentAnswer.soundKey || currentAnswer.colorClass;
     playSoundThen(`wrong_${soundKey}`, () => {
       playChordFile(currentAnswer.file);
@@ -716,7 +716,7 @@ function showSingleNoteQuiz(chord, onFinish, isLast = false) {
         onFinish();
       });
     } else {
-      showFeedback('もういちど', 'bad');
+      showFeedback(t('btn_retry'), 'bad');
       const wrongName = getWrongSoundName();
       playSoundThen(wrongName, () => {
         playNoteFile(note, () => {
@@ -917,7 +917,7 @@ function checkAnswer(selected) {
     correctBtn.classList.add("correct-highlight");
   }
 
-    showFeedback("もういちど", "bad");
+    showFeedback(t("btn_retry"), "bad");
     const soundKey = currentAnswer.soundKey || currentAnswer.colorClass;
     playSoundThen(`wrong_${soundKey}`, () => {
       playChordFile(currentAnswer.file);

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -1,7 +1,7 @@
 // 修正済み training.js（黒鍵転回形も正しく表示）
 import { chords } from "../data/chords.js";
 import { selectedChords } from "./settings.js";
-import { switchScreen } from "../main.js";
+import { switchScreen, t } from "../main.js";
 import { showCustomConfirm } from "./home.js";
 import { resetResultFlag } from "./result.js";
 import { saveSessionToHistory } from "./summary.js";
@@ -301,7 +301,7 @@ if (correctBtn) {
   correctBtn.classList.add("correct-highlight");
 }
 
-    showFeedback("もういちど", "bad");
+    showFeedback(t("btn_retry"), "bad");
     const soundKey = currentAnswer.soundKey || currentAnswer.colorClass;
     playSoundThen(`wrong_${soundKey}`, () => {
       playChordFile(currentAnswer.file);
@@ -441,7 +441,7 @@ function checkAnswer(selected) {
     correctBtn.classList.add("correct-highlight");
   }
 
-    showFeedback("もういちど", "bad");
+    showFeedback(t("btn_retry"), "bad");
     const soundKey = currentAnswer.soundKey || currentAnswer.colorClass;
     playSoundThen(`wrong_${soundKey}`, () => {
       playChordFile(currentAnswer.file);

--- a/index.html
+++ b/index.html
@@ -70,6 +70,18 @@
 </head>
 
 <body class="app-root">
+  <header>
+    <div class="lang-switch">
+      <button id="lang-ja">日本語</button>
+      <button id="lang-en">English</button>
+    </div>
+  </header>
+
+  <h1 data-i18n="app_title"></h1>
+
+  <p><span data-i18n="price_monthly"></span>：<span id="price-monthly"></span></p>
+  <p><span data-i18n="price_yearly"></span>：<span id="price-yearly"></span></p>
+
   <div id="app"></div>
 
   <div id="help-modal" class="modal" style="display: none;">

--- a/main.js
+++ b/main.js
@@ -41,6 +41,60 @@ import { renderForgotPasswordScreen } from "./components/forgotPassword.js";
 import { firebaseAuth } from "./firebase/firebase-init.js";
 import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
+// i18n setup
+let dict = {};
+export function t(key) {
+  return dict[key] || key;
+}
+
+function resolveLang() {
+  const url = new URL(location.href);
+  const urlLang = url.searchParams.get('lang');
+  const stored = localStorage.getItem('lang');
+  const browser = (navigator.language || '').toLowerCase().startsWith('ja') ? 'ja' : 'en';
+  return urlLang || stored || browser;
+}
+
+async function loadDict(lang) {
+  const res = await fetch(`/locales/${lang}.json`);
+  if (!res.ok) throw new Error('i18n load failed');
+  return await res.json();
+}
+
+export let currentLang = resolveLang();
+
+export async function applyLang(lang) {
+  try {
+    dict = await loadDict(lang);
+    document.documentElement.lang = lang;
+    document.querySelectorAll('[data-i18n]').forEach(el => {
+      const key = el.dataset.i18n;
+      if (dict[key]) el.textContent = dict[key];
+    });
+    localStorage.setItem('lang', lang);
+    currentLang = lang;
+    applyPriceFormatting();
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+function applyPriceFormatting() {
+  const locale = currentLang === 'ja' ? 'ja-JP' : 'en-US';
+  const fmt = new Intl.NumberFormat(locale, { style: 'currency', currency: 'JPY' });
+  const monthly = 980;
+  const yearly = 9800;
+  const m = document.getElementById('price-monthly');
+  const y = document.getElementById('price-yearly');
+  if (m) m.textContent = fmt.format(monthly);
+  if (y) y.textContent = fmt.format(yearly);
+}
+
+await applyLang(currentLang);
+
+document.getElementById('lang-ja')?.addEventListener('click', () => applyLang('ja'));
+document.getElementById('lang-en')?.addEventListener('click', () => applyLang('en'));
+
 const INFO_SCREENS = [
   "terms",
   "privacy",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1,0 +1,7 @@
+{
+  "app_title": "OTORON",
+  "btn_retry": "Try again",
+  "label_today_count": "Today's training count",
+  "price_monthly": "Monthly",
+  "price_yearly": "Yearly"
+}

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -1,0 +1,7 @@
+{
+  "app_title": "オトロン",
+  "btn_retry": "もういちど",
+  "label_today_count": "今日のトレーニング回数",
+  "price_monthly": "月額",
+  "price_yearly": "年額"
+}


### PR DESCRIPTION
## Summary
- introduce locale dictionaries for Japanese and English
- add language toggle, automatic detection, and price display formatting
- localize retry button and today's training count using translation keys

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b28b4e5bf88323a6e37d396f44d5a5