### PR TITLE
feat: add Instagram link to intro footer

### DIFF
--- a/components/intro.js
+++ b/components/intro.js
@@ -281,12 +281,15 @@ export function renderIntroScreen() {
 
       <footer class="lp-footer">
         <button id="footer-cta" class="cta-button">気になる方は「オトロン」の無料体験へ！</button>
-        <div class="social-links">
-          <a href="https://x.com/otoron_onkanDev" target="_blank" rel="noopener">
+        <div class="social-links" aria-label="オトロン公式SNS">
+          <a href="https://x.com/otoron_onkanDev" target="_blank" rel="noopener noreferrer" aria-label="X（新しいタブで開きます）">
             <img src="images/x-logo.png" alt="絶対音感トレーニングアプリ『オトロン』公式Xへのリンク" />
           </a>
-          <a href="https://note.com/otoron" target="_blank" rel="noopener">
+          <a href="https://note.com/otoron" target="_blank" rel="noopener noreferrer" aria-label="note（新しいタブで開きます）">
             <img src="images/note-logo.png" alt="絶対音感トレーニングアプリ『オトロン』公式noteへのリンク" />
+          </a>
+          <a href="https://www.instagram.com/otoron.zettaionkan/" target="_blank" rel="noopener noreferrer" aria-label="Instagram（新しいタブで開きます）">
+            <img src="images/Instagram_Glyph_Gradient.webp" alt="絶対音感トレーニングアプリ『オトロン』公式Instagramへのリンク" />
           </a>
         </div>
         <p>&copy; 2024 Otoron</p>

--- a/css/intro.css
+++ b/css/intro.css
@@ -577,6 +577,7 @@ body.intro-scroll {
 
 .social-links {
   display: flex;
+  align-items: center;
   justify-content: center;
   gap: 1em;
   margin-bottom: 1em;
@@ -590,7 +591,24 @@ body.intro-scroll {
 
 .social-links img {
   width: 24px;
-  height: auto;
+  height: 24px;
+  object-fit: contain;
+  display: block;
+}
+
+.social-links a:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 4px;
+  border-radius: 8px;
+}
+
+@media (hover: hover) {
+  .social-links a {
+    transition: transform .15s ease;
+  }
+  .social-links a:hover {
+    transform: translateY(-2px);
+  }
 }
 
 /* FAQ accordion */

--- a/style.css
+++ b/style.css
@@ -1977,6 +1977,7 @@ button:hover {
 
 .social-links {
   display: flex;
+  align-items: center;
   justify-content: center;
   gap: 1em;
   margin-bottom: 1em;
@@ -1990,7 +1991,24 @@ button:hover {
 
 .social-links img {
   width: 24px;
-  height: auto;
+  height: 24px;
+  object-fit: contain;
+  display: block;
+}
+
+.social-links a:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 4px;
+  border-radius: 8px;
+}
+
+@media (hover: hover) {
+  .social-links a {
+    transition: transform .15s ease;
+  }
+  .social-links a:hover {
+    transform: translateY(-2px);
+  }
 }
 
 /* FAQ accordion */


### PR DESCRIPTION
## Summary
- add Instagram link and icon to intro footer social section
- unify social link styles with focus and hover effects

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68baeb592ec4832392266badd4eff2da