### PR TITLE
Handle Supabase session renewal during checkout

### DIFF
--- a/utils/stripeCheckout.js
+++ b/utils/stripeCheckout.js
@@ -13,11 +13,17 @@ export async function startCheckout(button) {
 
   try {
     let { data: { user } } = await supabase.auth.getUser();
+    let firebaseUser = firebaseAuth.currentUser;
     if (!user?.email) {
-      const firebaseUser = firebaseAuth.currentUser ?? await whenAuthSettled();
+      firebaseUser = firebaseUser ?? await whenAuthSettled();
       if (firebaseUser?.email) {
         await ensureSupabaseAuth(firebaseUser);
         ({ data: { user } } = await supabase.auth.getUser());
+
+        if (!user?.email) {
+          await ensureSupabaseAuth(firebaseUser);
+          ({ data: { user } } = await supabase.auth.getUser());
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- rerun Supabase authentication in the checkout flow when no Supabase user is found so sessions are refreshed before proceeding

## Testing
- npm run lint *(fails: script not available)*
- npm test *(fails: script not available)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6942a606db78832392567509f2167883)