### PR TITLE
Improve iOS audio resilience and add in-session recovery for training

### DIFF
--- a/components/home.js
+++ b/components/home.js
@@ -8,6 +8,7 @@ import {
   clearTimeOfDayStyling,
 } from "../utils/timeOfDay.js";
 import { getAudio } from "../utils/audioCache.js";
+import { safePlayAudio } from "../utils/audioPlayback.js";
 
 export async function renderHomeScreen(user, options = {}) {
   const { showWelcome = false } = options;
@@ -81,13 +82,7 @@ export async function renderHomeScreen(user, options = {}) {
   faceImg.className = "otolon-face";
   faceImg.addEventListener("pointerdown", () => {
     const audio = getAudio("audio/touch.mp3");
-    (async () => {
-      try {
-        await audio.play();
-      } catch (e) {
-        console.warn("🎧 audio.play() エラー:", e);
-      }
-    })();
+    safePlayAudio(audio, "touch");
     faceImg.classList.add("bounce");
     faceImg.addEventListener(
       "animationend",

--- a/components/soundPlayer.js
+++ b/components/soundPlayer.js
@@ -1,4 +1,5 @@
 import { getAudio } from "../utils/audioCache.js";
+import { safePlayAudio } from "../utils/audioPlayback.js";
 
 function normalizeNoteName(name) {
   return name
@@ -40,13 +41,10 @@ export function playNote(noteName) {
     audio.addEventListener("error", handleError);
 
     (async () => {
-      try {
-        await audio.play();
-      } catch (e) {
-        console.warn(`音声再生エラー: ${noteName}`, e);
+      const ok = await safePlayAudio(audio, noteName);
+      if (!ok) {
         handleError();
       }
     })();
   });
 }
-

--- a/components/training.js
+++ b/components/training.js
@@ -11,6 +11,7 @@ import { saveTrainingSession } from "../utils/trainingStore_supabase.js";
 import { generateRecommendedQueue } from "../utils/growthUtils.js";
 import { loadGrowthFlags } from "../utils/growthStore_supabase.js";
 import { getAudio } from "../utils/audioCache.js";
+import { safePlayAudio } from "../utils/audioPlayback.js";
 import { kanaToHiragana, noteLabels } from "../utils/noteUtils.js";
 import { SHOW_DEBUG } from "../utils/debug.js";
 
@@ -28,12 +29,79 @@ let chordProgressCount = 0;
 let chordSoundOn = true;
 let manualQuestion = false;
 let displayMode = null; // 'note' or 'color'
+const TRAINING_SESSION_KEY = "trainingSessionV1";
 
 export const stats = {};
 export const mistakes = {};
 export const firstMistakeInSession = { flag: false, wrong: null };
 export let lastResults = [];
 export let correctCount = 0;
+
+function clearTrainingSessionSnapshot() {
+  sessionStorage.removeItem(TRAINING_SESSION_KEY);
+}
+
+function saveTrainingSessionSnapshot() {
+  if (!currentUser?.id || !currentAnswer?.name) return;
+  const payload = {
+    userId: currentUser.id,
+    questionCount,
+    correctCount,
+    currentAnswerName: currentAnswer.name,
+    questionQueue,
+    stats,
+    mistakes,
+    lastResults,
+    selectedChords,
+    alreadyTried,
+    isForcedAnswer,
+    singleNoteMode,
+    singleNoteStrategy,
+    chordSoundOn,
+    manualQuestion,
+    displayMode,
+    savedAt: Date.now(),
+  };
+  sessionStorage.setItem(TRAINING_SESSION_KEY, JSON.stringify(payload));
+}
+
+function tryRestoreTrainingSessionSnapshot() {
+  const raw = sessionStorage.getItem(TRAINING_SESSION_KEY);
+  if (!raw || !currentUser?.id) return false;
+  try {
+    const data = JSON.parse(raw);
+    if (data.userId !== currentUser.id) return false;
+
+    questionCount = Number(data.questionCount || 0);
+    correctCount = Number(data.correctCount || 0);
+    questionQueue = Array.isArray(data.questionQueue) ? [...data.questionQueue] : [];
+    alreadyTried = Boolean(data.alreadyTried);
+    isForcedAnswer = Boolean(data.isForcedAnswer);
+    singleNoteMode = Boolean(data.singleNoteMode);
+    singleNoteStrategy = data.singleNoteStrategy || "top";
+    chordSoundOn = data.chordSoundOn !== false;
+    manualQuestion = Boolean(data.manualQuestion);
+    displayMode = data.displayMode || displayMode;
+
+    selectedChords.length = 0;
+    if (Array.isArray(data.selectedChords)) {
+      selectedChords.push(...data.selectedChords);
+    }
+
+    for (const key in stats) delete stats[key];
+    Object.assign(stats, data.stats || {});
+    for (const key in mistakes) delete mistakes[key];
+    Object.assign(mistakes, data.mistakes || {});
+    lastResults = Array.isArray(data.lastResults) ? data.lastResults : [];
+
+    const answerName = data.currentAnswerName;
+    currentAnswer = chords.find(c => c.name === answerName) || null;
+    return Boolean(currentAnswer);
+  } catch (e) {
+    console.warn("セッション復元に失敗しました", e);
+    return false;
+  }
+}
 
 async function playSoundThen(name, callback) {
   if (currentAudio) {
@@ -48,10 +116,12 @@ async function playSoundThen(name, callback) {
     callback();
   };
   try {
-    await currentAudio.play();
-  } catch (e) {
-    console.warn("🎧 audio.play() エラー:", e);
-    // Playback failed so invoke callback to avoid freezing the UI
+    const ok = await safePlayAudio(currentAudio, name);
+    if (!ok) {
+      // Playback failed so invoke callback to avoid freezing the UI
+      callback();
+    }
+  } catch (_) {
     callback();
   }
 }
@@ -147,6 +217,12 @@ export async function renderTrainingScreen(user) {
   alreadyTried = false;
   isForcedAnswer = false;
   firstMistakeInSession.flag = false;
+  if (tryRestoreTrainingSessionSnapshot()) {
+    drawQuizScreen();
+    updateProgressUI();
+    playChordFile(currentAnswer.file);
+    return;
+  }
   if (!questionQueue.length) {
     questionQueue = createQuestionQueue();
   }
@@ -175,6 +251,7 @@ async function nextQuestion() {
   if (questionQueue.length === 0 || quitFlag) {
     const sound = (correctCount === questionCount) ? "perfect" : "end";
     playSoundThen(sound, async () => {
+      clearTrainingSessionSnapshot();
       if (!currentUser.isTemp) {
         await saveTrainingSession({
           userId: currentUser.id,
@@ -219,6 +296,7 @@ function showQuiz() {
   }
   questionCount++;
   updateProgressUI();
+  saveTrainingSessionSnapshot();
 
   playChordFile(currentAnswer.file);
 }
@@ -421,6 +499,7 @@ function drawQuizScreen() {
   quitBtn.onclick = () => {
     showCustomConfirm("ほんとうに やめちゃうの？", () => {
       quitFlag = true;
+      clearTrainingSessionSnapshot();
       switchScreen("home");
     });
   };
@@ -501,27 +580,19 @@ async function playChordFile(filename) {
   }
   currentAudio = getAudio(`audio/${filename}`);
   currentAudio.onerror = () => console.error("音声ファイルが見つかりません:", filename);
-  try {
-    await currentAudio.play();
-  } catch (e) {
-    console.warn("🎧 audio.play() エラー:", e);
-  }
+  await safePlayAudio(currentAudio, filename);
 }
 
 function unlockAudio(filename) {
   if (!chordSoundOn || manualQuestion) return;
   const audio = getAudio(`audio/${filename}`);
   audio.muted = true;
-  audio
-    .play()
-    .then(() => {
-      audio.pause();
-      audio.muted = false;
-      audio.currentTime = 0;
-    })
-    .catch(e => {
-      console.warn("🎧 audio.play() エラー:", e);
-    });
+  safePlayAudio(audio, filename).then((ok) => {
+    if (!ok) return;
+    audio.pause();
+    audio.muted = false;
+    audio.currentTime = 0;
+  });
 }
 
 function normalizeNoteName(name) {
@@ -553,11 +624,7 @@ async function playNoteFile(note, callback) {
   if (callback) {
     currentAudio.onended = () => setTimeout(callback, 100);
   }
-  try {
-    await currentAudio.play();
-  } catch (e) {
-    console.warn("🎧 audio.play() エラー:", e);
-  }
+  await safePlayAudio(currentAudio, note);
 }
 
 function noteToMidi(n) {
@@ -842,7 +909,7 @@ function checkAnswer(selected) {
 
   if (isForcedAnswer) {
     isForcedAnswer = false;
-
+    saveTrainingSessionSnapshot();
     nextQuestion();
     return;
   }
@@ -883,6 +950,7 @@ function checkAnswer(selected) {
       } else {
         proceed();
       }
+      saveTrainingSessionSnapshot();
     } else {
       const voices = ["good1", "good2"];
       showFeedback("いいね", "good");
@@ -893,6 +961,7 @@ function checkAnswer(selected) {
           proceed();
         }
       });
+      saveTrainingSessionSnapshot();
     }
   } else {
     alreadyTried = true;
@@ -922,5 +991,6 @@ function checkAnswer(selected) {
     playSoundThen(`wrong_${soundKey}`, () => {
       playChordFile(currentAnswer.file);
     });
+    saveTrainingSessionSnapshot();
   }
 }

--- a/components/training_easy.js
+++ b/components/training_easy.js
@@ -8,6 +8,7 @@ import { saveSessionToHistory } from "./summary.js";
 import { incrementSetCount, updateTrainingRecord } from "../utils/recordStore_supabase.js";
 import { autoUnlockNextChord } from "../utils/progressUtils.js";
 import { getAudio } from "../utils/audioCache.js";
+import { safePlayAudio } from "../utils/audioPlayback.js";
 import { SHOW_DEBUG } from "../utils/debug.js";
 
 let questionCount = 0;
@@ -37,10 +38,12 @@ async function playSoundThen(name, callback) {
     callback();
   };
   try {
-    await currentAudio.play();
-  } catch (e) {
-    console.warn("🎧 audio.play() エラー:", e);
-    // Playback failed so invoke callback to avoid freezing the UI
+    const ok = await safePlayAudio(currentAudio, name);
+    if (!ok) {
+      // Playback failed so invoke callback to avoid freezing the UI
+      callback();
+    }
+  } catch (_) {
     callback();
   }
 }
@@ -330,11 +333,7 @@ async function playChordFile(filename) {
   }
   currentAudio = getAudio(`audio/${filename}`);
   currentAudio.onerror = () => console.error("音声ファイルが見つかりません:", filename);
-  try {
-    await currentAudio.play();
-  } catch (e) {
-    console.warn("🎧 audio.play() エラー:", e);
-  }
+  await safePlayAudio(currentAudio, filename);
 }
 
 let feedbackTimeoutId;

--- a/main.js
+++ b/main.js
@@ -36,6 +36,7 @@ import { renderChordResetScreen } from "./components/info/chordReset.js";
 import { renderPricingScreen } from "./components/pricing.js";
 import { renderLockScreen } from "./components/lock.js";
 import { renderForgotPasswordScreen } from "./components/forgotPassword.js";
+import { setupAudioResumeOnFirstTouch } from "./utils/audioPlayback.js";
 
 
 import { firebaseAuth } from "./firebase/firebase-init.js";
@@ -272,6 +273,7 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
 });
 
 const initApp = () => {
+  setupAudioResumeOnFirstTouch();
   const hash = location.hash;
   const initial = DEBUG_AUTO_LOGIN ? "home" : "intro";
   const screenHash = hash.replace("#", "");

--- a/utils/audioCache.js
+++ b/utils/audioCache.js
@@ -15,3 +15,15 @@ export function getAudio(src) {
   audio.currentTime = 0;
   return audio;
 }
+
+export function resetAudioCache() {
+  cache.forEach((audio) => {
+    try {
+      audio.pause();
+      audio.currentTime = 0;
+      audio.onended = null;
+      audio.onerror = null;
+    } catch (_) {}
+  });
+  cache.clear();
+}

--- a/utils/audioPlayback.js
+++ b/utils/audioPlayback.js
@@ -1,0 +1,65 @@
+import { resetAudioCache } from "./audioCache.js";
+
+let audioContext = null;
+let audioContextSetupDone = false;
+let playAttemptCount = 0;
+const AUDIO_CONTEXT_RESET_INTERVAL = 10;
+
+function getAudioContext() {
+  if (audioContext) return audioContext;
+  const Ctx = window.AudioContext || window.webkitAudioContext;
+  if (!Ctx) return null;
+  audioContext = new Ctx();
+  return audioContext;
+}
+
+async function recreateAudioContext() {
+  if (audioContext) {
+    try {
+      await audioContext.close();
+    } catch (_) {}
+    audioContext = null;
+  }
+  getAudioContext();
+}
+
+export async function resumeAudioContextIfNeeded() {
+  const ctx = getAudioContext();
+  if (!ctx) return;
+  if (ctx.state === "suspended") {
+    await ctx.resume();
+  }
+}
+
+export function setupAudioResumeOnFirstTouch() {
+  if (audioContextSetupDone) return;
+  audioContextSetupDone = true;
+
+  const handler = async () => {
+    try {
+      await resumeAudioContextIfNeeded();
+    } catch (e) {
+      console.warn("🎧 AudioContext resume エラー:", e);
+    }
+  };
+
+  document.addEventListener("touchstart", handler, { passive: true });
+  document.addEventListener("pointerdown", handler, { passive: true });
+}
+
+export async function safePlayAudio(audio, label = "") {
+  playAttemptCount += 1;
+  if (playAttemptCount % AUDIO_CONTEXT_RESET_INTERVAL === 0) {
+    await recreateAudioContext();
+    resetAudioCache();
+  }
+
+  await resumeAudioContextIfNeeded();
+  try {
+    await audio.play();
+    return true;
+  } catch (e) {
+    console.warn(`🎧 audio.play() エラー: ${label}`, e);
+    return false;
+  }
+}

--- a/utils/progressStatus.js
+++ b/utils/progressStatus.js
@@ -3,6 +3,7 @@ import { unlockChord } from "./progressUtils.js";
 import { applyRecommendedSelection, forceUnlock } from "./growthUtils.js";
 import { showCustomAlert } from "../components/home.js";
 import { getAudio } from "./audioCache.js";
+import { safePlayAudio } from "./audioPlayback.js";
 import { getConsecutiveQualifiedDays } from "./qualifiedStore_supabase.js";
 import { launchConfetti } from "./confetti.js";
 
@@ -113,16 +114,8 @@ export async function updateGrowthStatusBar(user, target, onUnlocked) {
         if (success) {
           const audio = getAudio("audio/unlock_chord.mp3");
           const applause = getAudio("audio/applause.mp3");
-          try {
-            await audio.play();
-          } catch (e) {
-            console.warn("🎧 audio.play() エラー:", e);
-          }
-          try {
-            await applause.play();
-          } catch (e) {
-            console.warn("🎧 audio.play() エラー:", e);
-          }
+          await safePlayAudio(audio, "unlock_chord");
+          await safePlayAudio(applause, "applause");
           launchConfetti();
           await applyRecommendedSelection(user.id);
           setTimeout(() => {


### PR DESCRIPTION
### Motivation

- Fix iPhone/Safari audio issues (playback stops, suspended `AudioContext`, rejected `play()` promises) and avoid UI freezes caused by unhandled audio errors. 
- Provide a minimal resume/recovery path so a training session can continue after reloads or interruptions.

### Description

- Add a centralized audio helper `utils/audioPlayback.js` implementing `safePlayAudio`, `resumeAudioContextIfNeeded`, `setupAudioResumeOnFirstTouch`, and periodic `AudioContext` recreation with cache reset. 
- Replace direct `audio.play()` calls with `safePlayAudio(...)` in `components/training.js`, `components/training_easy.js`, `components/soundPlayer.js`, `components/home.js`, and `utils/progressStatus.js` to avoid blocking on rejected promises. 
- Extend `utils/audioCache.js` with `resetAudioCache()` used when recreating the audio context to mitigate long-running audio instance degradation. 
- Implement minimal in-session persistence in `components/training.js` by saving/restoring a snapshot to `sessionStorage` and clearing it on quit/complete to enable resuming mid-session. 
- Wire `setupAudioResumeOnFirstTouch()` from `main.js` at app init so first user interaction attempts to resume suspended contexts globally.

### Testing

- Ran syntax checks with `node --check` across modified files (`main.js`, `components/training.js`, `components/training_easy.js`, `components/soundPlayer.js`, `components/home.js`, `utils/audioPlayback.js`, `utils/audioCache.js`, `utils/progressStatus.js`) and the checks completed without errors. 
- Verified the app builds (no runtime syntax errors detected) after the changes via the same `node --check` command.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e63566277083258739b016aa064817)