### PR TITLE
Fix occasional training freeze on Android audio playback

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -108,21 +108,41 @@ async function playSoundThen(name, callback) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
   }
-  const encoded = encodeURIComponent(name);
-  currentAudio = getAudio(`audio/${encoded}.mp3`);
-  currentAudio.onended = () => setTimeout(callback, 100);
-  currentAudio.onerror = () => {
-    console.error("⚠️ 音声ファイルが読み込めませんでした:", name);
+
+  let completed = false;
+  let fallbackTimer = null;
+  const finish = () => {
+    if (completed) return;
+    completed = true;
+    if (fallbackTimer) {
+      clearTimeout(fallbackTimer);
+      fallbackTimer = null;
+    }
     callback();
   };
+
+  const encoded = encodeURIComponent(name);
+  currentAudio = getAudio(`audio/${encoded}.mp3`);
+  currentAudio.onended = () => setTimeout(finish, 100);
+  currentAudio.onerror = () => {
+    console.error("⚠️ 音声ファイルが読み込めませんでした:", name);
+    finish();
+  };
+
+  // Androidでまれにonendedが発火しないケースへの保険
+  fallbackTimer = setTimeout(() => {
+    console.warn("⚠️ onended未発火のためフォールバック遷移:", name);
+    finish();
+  }, 3000);
+
   try {
     const ok = await safePlayAudio(currentAudio, name);
     if (!ok) {
       // Playback failed so invoke callback to avoid freezing the UI
-      callback();
+      finish();
     }
   } catch (_) {
-    callback();
+    finish();
   }
 }
 


### PR DESCRIPTION
### Motivation
- Training mode temporarily disables UI until a voice SFX callback returns; on some Android devices `onended` can fail to fire and leave the UI permanently disabled. 

### Description
- Add a guarded completion helper `finish` inside `playSoundThen` to ensure the callback is executed at most once. 
- Add a 3-second fallback timer to call `finish` when `onended` does not fire to recover from Android-specific playback hangs. 
- Route `currentAudio.onerror`, `safePlayAudio` failures, and thrown exceptions to the guarded `finish` so all error paths trigger UI recovery.

### Testing
- Ran `node --check components/training.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e63ed74d6883259b234c8674a225f7)