### PR TITLE
Prevent duplicate/early answers in chord training mode

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -29,6 +29,8 @@ let chordProgressCount = 0;
 let chordSoundOn = true;
 let manualQuestion = false;
 let displayMode = null; // 'note' or 'color'
+let isProcessingAnswer = false;
+let isAnswerEnabled = true;
 const TRAINING_SESSION_KEY = "trainingSessionV1";
 
 export const stats = {};
@@ -268,6 +270,8 @@ async function nextQuestion() {
   
   alreadyTried = false;
   isForcedAnswer = false;
+  isProcessingAnswer = false;
+  isAnswerEnabled = false;
   if (questionQueue.length === 0 || quitFlag) {
     const sound = (correctCount === questionCount) ? "perfect" : "end";
     playSoundThen(sound, async () => {
@@ -539,7 +543,8 @@ function drawQuizScreen() {
   unknownBtn.id = "unknownBtn";
   unknownBtn.textContent = "わからない";
   unknownBtn.onclick = () => {
-    if (alreadyTried || isForcedAnswer) return;
+    if (alreadyTried || isForcedAnswer || isProcessingAnswer || !isAnswerEnabled) return;
+    isProcessingAnswer = true;
 
     alreadyTried = true;
     isForcedAnswer = true;
@@ -573,6 +578,7 @@ if (correctBtn) {
     showFeedback("もういちど", "bad");
     const soundKey = currentAnswer.soundKey || currentAnswer.colorClass;
     playSoundThen(`wrong_${soundKey}`, () => {
+      isProcessingAnswer = false;
       playChordFile(currentAnswer.file);
     });
   };
@@ -593,7 +599,10 @@ if (correctBtn) {
 
 
 async function playChordFile(filename) {
-  if (!chordSoundOn || manualQuestion) return;
+  if (!chordSoundOn || manualQuestion) {
+    isAnswerEnabled = true;
+    return;
+  }
   if (currentAudio) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
@@ -601,6 +610,7 @@ async function playChordFile(filename) {
   currentAudio = getAudio(`audio/${filename}`);
   currentAudio.onerror = () => console.error("音声ファイルが見つかりません:", filename);
   await safePlayAudio(currentAudio, filename);
+  isAnswerEnabled = true;
 }
 
 function unlockAudio(filename) {
@@ -924,11 +934,15 @@ function updateProgressUI() {
 }
 
 function checkAnswer(selected) {
+  if (isProcessingAnswer || !isAnswerEnabled) return;
+  isProcessingAnswer = true;
+
   const name = currentAnswer.name;
   stats[name] = stats[name] || { correct: 0, wrong: 0, total: 0 };
 
   if (isForcedAnswer) {
     isForcedAnswer = false;
+    isProcessingAnswer = false;
     saveTrainingSessionSnapshot();
     nextQuestion();
     return;
@@ -960,6 +974,7 @@ function checkAnswer(selected) {
       if (questionQueue.length === 0) {
         showFeedback("がんばったね", "good", 0);
       }
+      isProcessingAnswer = false;
       nextQuestion();
     };
 
@@ -1009,6 +1024,7 @@ function checkAnswer(selected) {
     showFeedback("もういちど", "bad");
     const soundKey = currentAnswer.soundKey || currentAnswer.colorClass;
     playSoundThen(`wrong_${soundKey}`, () => {
+      isProcessingAnswer = false;
       playChordFile(currentAnswer.file);
     });
     saveTrainingSessionSnapshot();


### PR DESCRIPTION
### Motivation
- Users experienced the training-mode bug where tapping answers during audio playback could make the same sound play twice and cause incorrect judging when the UI had frozen or audio hadn't completed.
- The change intends to prevent re-entrant answer processing and to block inputs until the question audio playback attempt finishes so that answers are only judged after audio is (attempted to be) played.

### Description
- Add two guards: `isProcessingAnswer` and `isAnswerEnabled` to `components/training.js` to manage answer acceptance state.
- Disable answer acceptance at the start of each question and enable it only after `playChordFile` completes (or immediately when chord sound is off/manual).
- Short-circuit `checkAnswer` and the "わからない" button when processing is in-flight to prevent double-processing and duplicated audio, and ensure the processing lock is released after guidance audio and chord replay start.
- Keep session snapshot saving and existing result flows intact; only the input gating and state-reset points were added/adjusted.

### Testing
- Ran `node --check components/training.js` and it succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7786758088325a120e02f0731fb57)