### PR TITLE
Fix Android training freeze when chord playback stalls

### DIFF
--- a/components/training.js
+++ b/components/training.js
@@ -29,6 +29,9 @@ let chordProgressCount = 0;
 let chordSoundOn = true;
 let manualQuestion = false;
 let displayMode = null; // 'note' or 'color'
+let isProcessingAnswer = false;
+let isAnswerEnabled = true;
+let chordPlayRequestId = 0;
 const TRAINING_SESSION_KEY = "trainingSessionV1";
 
 export const stats = {};
@@ -268,6 +271,8 @@ async function nextQuestion() {
   
   alreadyTried = false;
   isForcedAnswer = false;
+  isProcessingAnswer = false;
+  isAnswerEnabled = false;
   if (questionQueue.length === 0 || quitFlag) {
     const sound = (correctCount === questionCount) ? "perfect" : "end";
     playSoundThen(sound, async () => {
@@ -539,7 +544,8 @@ function drawQuizScreen() {
   unknownBtn.id = "unknownBtn";
   unknownBtn.textContent = "わからない";
   unknownBtn.onclick = () => {
-    if (alreadyTried || isForcedAnswer) return;
+    if (alreadyTried || isForcedAnswer || isProcessingAnswer || !isAnswerEnabled) return;
+    isProcessingAnswer = true;
 
     alreadyTried = true;
     isForcedAnswer = true;
@@ -573,6 +579,7 @@ if (correctBtn) {
     showFeedback("もういちど", "bad");
     const soundKey = currentAnswer.soundKey || currentAnswer.colorClass;
     playSoundThen(`wrong_${soundKey}`, () => {
+      isProcessingAnswer = false;
       playChordFile(currentAnswer.file);
     });
   };
@@ -593,14 +600,43 @@ if (correctBtn) {
 
 
 async function playChordFile(filename) {
-  if (!chordSoundOn || manualQuestion) return;
+  const requestId = ++chordPlayRequestId;
+  const unlockAnswers = () => {
+    if (requestId !== chordPlayRequestId) return;
+    isAnswerEnabled = true;
+  };
+
+  if (!chordSoundOn || manualQuestion) {
+    unlockAnswers();
+    return;
+  }
   if (currentAudio) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
   }
   currentAudio = getAudio(`audio/${filename}`);
-  currentAudio.onerror = () => console.error("音声ファイルが見つかりません:", filename);
-  await safePlayAudio(currentAudio, filename);
+  currentAudio.onerror = () => {
+    console.error("音声ファイルが見つかりません:", filename);
+    unlockAnswers();
+  };
+
+  const fallbackUnlockTimer = setTimeout(() => {
+    console.warn("⚠️ 再生開始待ちがタイムアウトしたため回答受付を再開:", filename);
+    unlockAnswers();
+  }, 1800);
+
+  currentAudio.onplaying = () => {
+    clearTimeout(fallbackUnlockTimer);
+    unlockAnswers();
+  };
+
+  const ok = await safePlayAudio(currentAudio, filename, { timeoutMs: 1800 });
+  clearTimeout(fallbackUnlockTimer);
+  if (!ok) {
+    unlockAnswers();
+    return;
+  }
+  unlockAnswers();
 }
 
 function unlockAudio(filename) {
@@ -924,11 +960,15 @@ function updateProgressUI() {
 }
 
 function checkAnswer(selected) {
+  if (isProcessingAnswer || !isAnswerEnabled) return;
+  isProcessingAnswer = true;
+
   const name = currentAnswer.name;
   stats[name] = stats[name] || { correct: 0, wrong: 0, total: 0 };
 
   if (isForcedAnswer) {
     isForcedAnswer = false;
+    isProcessingAnswer = false;
     saveTrainingSessionSnapshot();
     nextQuestion();
     return;
@@ -960,6 +1000,7 @@ function checkAnswer(selected) {
       if (questionQueue.length === 0) {
         showFeedback("がんばったね", "good", 0);
       }
+      isProcessingAnswer = false;
       nextQuestion();
     };
 
@@ -1009,6 +1050,7 @@ function checkAnswer(selected) {
     showFeedback("もういちど", "bad");
     const soundKey = currentAnswer.soundKey || currentAnswer.colorClass;
     playSoundThen(`wrong_${soundKey}`, () => {
+      isProcessingAnswer = false;
       playChordFile(currentAnswer.file);
     });
     saveTrainingSessionSnapshot();

--- a/utils/audioPlayback.js
+++ b/utils/audioPlayback.js
@@ -47,7 +47,8 @@ export function setupAudioResumeOnFirstTouch() {
   document.addEventListener("pointerdown", handler, { passive: true });
 }
 
-export async function safePlayAudio(audio, label = "") {
+export async function safePlayAudio(audio, label = "", options = {}) {
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : 2500;
   playAttemptCount += 1;
   if (playAttemptCount % AUDIO_CONTEXT_RESET_INTERVAL === 0) {
     await recreateAudioContext();
@@ -56,7 +57,15 @@ export async function safePlayAudio(audio, label = "") {
 
   await resumeAudioContextIfNeeded();
   try {
-    await audio.play();
+    const playPromise = audio.play();
+    if (playPromise && typeof playPromise.then === "function") {
+      await Promise.race([
+        playPromise,
+        new Promise((_, reject) => {
+          setTimeout(() => reject(new Error("audio.play() timeout")), timeoutMs);
+        })
+      ]);
+    }
     return true;
   } catch (e) {
     console.warn(`🎧 audio.play() エラー: ${label}`, e);


### PR DESCRIPTION
### Motivation
- Training mode could still freeze on Android when `audio.play()` or playback start signals stalled, leaving answer input disabled and preventing progress.
- The change aims to make audio playback fail fast and to ensure answer acceptance is always re-enabled even when playback start events are missing or delayed.

### Description
- Add a bounded timeout to `safePlayAudio` (`options.timeoutMs`) and use `Promise.race` to treat long-hanging `audio.play()` as a failure so the app can recover.
- Harden `playChordFile` with a per-request `chordPlayRequestId` and an `unlockAnswers` closure to ignore stale events, and use `onplaying`, `onerror`, and a fallback timer to reliably re-enable answers (`isAnswerEnabled`).
- Add input guards and proper `isProcessingAnswer` toggling in the training UI (`unknownBtn` and `checkAnswer`) so duplicate/early inputs remain blocked while preserving normal result flows.
- Keep existing session snapshot and result flows intact; this patch focuses on freeze recovery and robust answer re-enable behavior.

### Testing
- Ran `node --check components/training.js` and it completed successfully.
- Ran `node --check utils/audioPlayback.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7786758088325a120e02f0731fb57)