### PR TITLE
Fix mobile audio freeze and duplicate playback callbacks in training mode

### DIFF
--- a/components/soundPlayer.js
+++ b/components/soundPlayer.js
@@ -18,16 +18,25 @@ export function playNote(noteName) {
   return new Promise((resolve) => {
     const encoded = encodeURIComponent(normalizeNoteName(noteName));
     const audio = getAudio(`sounds/${encoded}.mp3`);
+    let settled = false;
+    let watchdog = null;
+
+    const finishOnce = () => {
+      if (settled) return;
+      settled = true;
+      if (watchdog) clearTimeout(watchdog);
+      resolve();
+    };
 
     const handleEnded = () => {
       cleanup();
-      resolve();
+      finishOnce();
     };
 
     const handleError = () => {
       console.warn(`音声再生エラー: ${noteName}`);
       cleanup();
-      resolve();
+      finishOnce();
     };
 
     const cleanup = () => {
@@ -41,6 +50,11 @@ export function playNote(noteName) {
 
     (async () => {
       try {
+        // Some mobile browsers occasionally never emit ended/error.
+        watchdog = setTimeout(() => {
+          cleanup();
+          finishOnce();
+        }, 2500);
         await audio.play();
       } catch (e) {
         console.warn(`音声再生エラー: ${noteName}`, e);
@@ -49,4 +63,3 @@ export function playNote(noteName) {
     })();
   });
 }
-

--- a/components/training.js
+++ b/components/training.js
@@ -36,23 +36,30 @@ export let lastResults = [];
 export let correctCount = 0;
 
 async function playSoundThen(name, callback) {
+  let finished = false;
+  const finishOnce = () => {
+    if (finished) return;
+    finished = true;
+    setTimeout(callback, 100);
+  };
+
   if (currentAudio) {
     currentAudio.pause();
     currentAudio.currentTime = 0;
   }
   const encoded = encodeURIComponent(name);
   currentAudio = getAudio(`audio/${encoded}.mp3`);
-  currentAudio.onended = () => setTimeout(callback, 100);
+  currentAudio.onended = finishOnce;
   currentAudio.onerror = () => {
     console.error("⚠️ 音声ファイルが読み込めませんでした:", name);
-    callback();
+    finishOnce();
   };
   try {
     await currentAudio.play();
   } catch (e) {
     console.warn("🎧 audio.play() エラー:", e);
     // Playback failed so invoke callback to avoid freezing the UI
-    callback();
+    finishOnce();
   }
 }
 
@@ -549,14 +556,25 @@ async function playNoteFile(note, callback) {
   }
   const encoded = encodeURIComponent(normalizeNoteName(note));
   currentAudio = getAudio(`sounds/${encoded}.mp3`);
-  currentAudio.onerror = () => console.error("音声ファイルが見つかりません:", note);
+  let finishOnce = null;
+  currentAudio.onerror = () => {
+    console.error("音声ファイルが見つかりません:", note);
+    if (finishOnce) finishOnce();
+  };
   if (callback) {
-    currentAudio.onended = () => setTimeout(callback, 100);
+    let finished = false;
+    finishOnce = () => {
+      if (finished) return;
+      finished = true;
+      setTimeout(callback, 100);
+    };
+    currentAudio.onended = finishOnce;
   }
   try {
     await currentAudio.play();
   } catch (e) {
     console.warn("🎧 audio.play() エラー:", e);
+    if (finishOnce) finishOnce();
   }
 }
 

--- a/utils/audioCache.js
+++ b/utils/audioCache.js
@@ -12,6 +12,8 @@ export function getAudio(src) {
     audio = new Audio(src);
     cache.set(src, audio);
   }
+  // Ensure overlapping plays are stopped before reusing the same element.
+  audio.pause();
   audio.currentTime = 0;
   return audio;
 }


### PR DESCRIPTION
### Motivation

- Training mode on Android/iOS could freeze when audio never emits `ended/error`, and ad-hoc fixes caused duplicate playback/callbacks; a small, local fix was needed to reduce both freezes and double-play without large refactors. 
- The goal was to minimize code changes and runtime impact while making audio lifecycle handling more robust. 

### Description

- Ensure playback callbacks execute only once by adding one-shot guards in `playSoundThen` and `playNoteFile` in `components/training.js` so `onended`, `onerror`, and `catch` paths cannot invoke continuation twice. 
- Add a watchdog timeout and a one-shot resolver in `components/soundPlayer.js`'s `playNote` to resolve the promise if `ended/error` is never emitted by some mobile browsers. 
- Prevent overlapping reuse of the same `HTMLAudioElement` by calling `pause()` before resetting `currentTime` in `utils/audioCache.js`'s `getAudio`. 
- Changes are limited to `components/training.js`, `components/soundPlayer.js`, and `utils/audioCache.js` and do not modify data models or navigation flow. 

### Testing

- Ran syntax checks with `node --check components/training.js`, `node --check components/soundPlayer.js`, and `node --check utils/audioCache.js` and they all passed. 
- Basic runtime smoke validation was performed during development to ensure callbacks and the watchdog behave as expected on typical flows (no automated UI tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e785eb518c8325a8ab82f3441fd107)