### PR TITLE
Fix checkout login prompt by validating Supabase optional auth initialization

### DIFF
--- a/utils/supabaseOptionalAuth.js
+++ b/utils/supabaseOptionalAuth.js
@@ -13,19 +13,41 @@ export async function ensureSupabaseAuth(email, { quiet = true } = {}) {
   } catch (_) {}
 
   try {
-    await supabase.auth.signInWithPassword({ email, password: DUMMY });
-    return true;
-  } catch (e) {
-    try {
-      const { error: upErr } = await supabase.auth.signUp({ email, password: DUMMY });
-      if (!upErr || upErr?.status === 422) {
-        try {
-          await supabase.auth.signInWithPassword({ email, password: DUMMY });
-          return true;
-        } catch {}
-      }
-    } catch {}
+    const { data: signInData, error: signInErr } = await supabase.auth.signInWithPassword({
+      email,
+      password: DUMMY,
+    });
+    if (!signInErr && signInData?.session) return true;
 
+    if (signInErr && !/invalid login/i.test(signInErr.message || '')) {
+      if (!quiet) console.warn('[supabase-init] sign-in failed:', signInErr);
+      else console.debug('[supabase-init] sign-in failed');
+      return false;
+    }
+  } catch (e) {
+    if (!quiet) console.warn('[supabase-init] sign-in threw:', e);
+    else console.debug('[supabase-init] sign-in threw');
+    return false;
+  }
+
+  try {
+    const { error: upErr } = await supabase.auth.signUp({ email, password: DUMMY });
+    if (upErr && upErr?.status !== 422) {
+      if (!quiet) console.warn('[supabase-init] sign-up failed:', upErr);
+      else console.debug('[supabase-init] sign-up failed');
+      return false;
+    }
+
+    const { data: retryData, error: retryErr } = await supabase.auth.signInWithPassword({
+      email,
+      password: DUMMY,
+    });
+    if (!retryErr && retryData?.session) return true;
+
+    if (!quiet) console.warn('[supabase-init] retry sign-in failed:', retryErr);
+    else console.debug('[supabase-init] retry sign-in failed');
+    return false;
+  } catch (e) {
     if (!quiet) console.warn('[supabase-init] optional init failed:', e);
     else console.debug('[supabase-init] optional init failed');
     return false;


### PR DESCRIPTION
### Motivation
- Users logged in via Firebase could still see `ログインしてください` during checkout because the optional Supabase auth initializer could return success without an actual Supabase session.
- The checkout flow (`startCheckout`) relies on `supabase.auth.getUser()` to determine login state, so a false-positive from `ensureSupabaseAuth` caused a visible mismatch.

### Description
- Update `ensureSupabaseAuth` in `utils/supabaseOptionalAuth.js` to inspect `signInWithPassword` return values and only return `true` when a valid `session` is present.
- Treat non-`invalid login` sign-in errors as failures instead of proceeding, and surface clearer debug logs using `console.warn`/`console.debug` depending on `quiet`.
- Preserve the sign-up-and-retry flow for the `invalid login` case, and validate the retry sign-in result before returning success.
- Keep the `triedSupabaseAuth` guard and the initial `getSession` check, but tighten all success/failure branching to avoid false positives.

### Testing
- Ran `node --check utils/supabaseOptionalAuth.js` and it completed without syntax errors.
- Performed static inspection of the checkout path from `startCheckout` to `supabase.auth.getUser()` to ensure the new behavior addresses the login prompt issue.
- Verified logging branches for sign-in, sign-up, and retry-sign-in to aid troubleshooting in failure cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e0140d648325afca80a058dbffb8)