### PR TITLE
Use Firebase email for Stripe checkout and harden Supabase optional auth routine

### DIFF
--- a/utils/stripeCheckout.js
+++ b/utils/stripeCheckout.js
@@ -1,4 +1,5 @@
 import { supabase } from './supabaseClient.js';
+import { firebaseAuth } from '../firebase/firebase-init.js';
 import { showCustomAlert } from '../components/home.js';
 
 export async function startCheckout(button) {
@@ -10,8 +11,13 @@ export async function startCheckout(button) {
   button.textContent = '処理中…';
 
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user?.email) {
+    let email = firebaseAuth.currentUser?.email || null;
+    if (!email) {
+      const { data: { user } } = await supabase.auth.getUser();
+      email = user?.email || null;
+    }
+
+    if (!email) {
       showCustomAlert('ログインしてください');
       button.disabled = false;
       button.textContent = origText;
@@ -21,7 +27,7 @@ export async function startCheckout(button) {
     const res = await fetch('/api/create-checkout-session', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: user.email, plan })
+      body: JSON.stringify({ email, plan })
     });
     const json = await res.json();
     if (json?.url) {

--- a/utils/supabaseOptionalAuth.js
+++ b/utils/supabaseOptionalAuth.js
@@ -13,19 +13,41 @@ export async function ensureSupabaseAuth(email, { quiet = true } = {}) {
   } catch (_) {}
 
   try {
-    await supabase.auth.signInWithPassword({ email, password: DUMMY });
-    return true;
-  } catch (e) {
-    try {
-      const { error: upErr } = await supabase.auth.signUp({ email, password: DUMMY });
-      if (!upErr || upErr?.status === 422) {
-        try {
-          await supabase.auth.signInWithPassword({ email, password: DUMMY });
-          return true;
-        } catch {}
-      }
-    } catch {}
+    const { data: signInData, error: signInErr } = await supabase.auth.signInWithPassword({
+      email,
+      password: DUMMY,
+    });
+    if (!signInErr && signInData?.session) return true;
 
+    if (signInErr && !/invalid login/i.test(signInErr.message || '')) {
+      if (!quiet) console.warn('[supabase-init] sign-in failed:', signInErr);
+      else console.debug('[supabase-init] sign-in failed');
+      return false;
+    }
+  } catch (e) {
+    if (!quiet) console.warn('[supabase-init] sign-in threw:', e);
+    else console.debug('[supabase-init] sign-in threw');
+    return false;
+  }
+
+  try {
+    const { error: upErr } = await supabase.auth.signUp({ email, password: DUMMY });
+    if (upErr && upErr?.status !== 422) {
+      if (!quiet) console.warn('[supabase-init] sign-up failed:', upErr);
+      else console.debug('[supabase-init] sign-up failed');
+      return false;
+    }
+
+    const { data: retryData, error: retryErr } = await supabase.auth.signInWithPassword({
+      email,
+      password: DUMMY,
+    });
+    if (!retryErr && retryData?.session) return true;
+
+    if (!quiet) console.warn('[supabase-init] retry sign-in failed:', retryErr);
+    else console.debug('[supabase-init] retry sign-in failed');
+    return false;
+  } catch (e) {
     if (!quiet) console.warn('[supabase-init] optional init failed:', e);
     else console.debug('[supabase-init] optional init failed');
     return false;


### PR DESCRIPTION
### Motivation

- Allow Stripe checkout to obtain the user's email from Firebase first when the app uses Firebase auth alongside Supabase. 
- Make the Supabase optional-auth initializer more robust against various sign-in/signup error paths and reduce noisy exceptions. 
- Avoid leaving the checkout flow in a disabled/indeterminate state when no email is available or when auth attempts fail.

### Description

- Update `utils/stripeCheckout.js` to import `firebaseAuth` and prefer `firebaseAuth.currentUser?.email` before falling back to `supabase.auth.getUser()`, and send the resolved `email` to the `/api/create-checkout-session` endpoint. 
- Refactor `utils/supabaseOptionalAuth.js` `ensureSupabaseAuth` to explicitly inspect `signInWithPassword` and `signUp` results, handle known invalid-login cases, retry sign-in after signup, and log either `console.warn` or `console.debug` depending on the `quiet` flag. 
- Preserve the `triedSupabaseAuth` guard and ensure the function returns `true` only when a valid Supabase session is present and returns `false` on controlled failures.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e0140d648325afca80a058dbffb8)