### PR TITLE
Fix intermittent missing chord playback on mobile devices

### DIFF
--- a/utils/audioCache.js
+++ b/utils/audioCache.js
@@ -1,18 +1,24 @@
-const cache = new Map();
+const templateCache = new Map();
 
 /**
- * Get an Audio instance for the given source path, reusing
- * previously created objects for faster playback.
+ * Get an Audio instance for the given source path.
+ * We keep one cached template per file, then return a fresh clone
+ * to avoid state collisions on mobile browsers (muted flag, event
+ * listeners, interrupted play promises, etc.).
  * @param {string} src - audio file path
  * @returns {HTMLAudioElement} reusable audio element
  */
 export function getAudio(src) {
-  let audio = cache.get(src);
-  if (!audio) {
-    audio = new Audio(src);
-    cache.set(src, audio);
+  let template = templateCache.get(src);
+  if (!template) {
+    template = new Audio(src);
+    template.preload = "auto";
+    templateCache.set(src, template);
   }
-  // Ensure overlapping plays are stopped before reusing the same element.
+
+  // Clone to provide an isolated playback instance every time.
+  const audio = template.cloneNode(true);
+  audio.preload = "auto";
   audio.pause();
   audio.currentTime = 0;
   return audio;


### PR DESCRIPTION
### Motivation
- Mobile browsers can leave a reused `HTMLAudioElement` in an inconsistent state (muted flag, lingering listeners, interrupted play promises), which causes intermittent silent failures when chords are played.

### Description
- Replaced the single-instance reuse strategy with a template-cache plus per-play clone by updating `getAudio` in `utils/audioCache.js` to keep one preloaded template per source and return `template.cloneNode(true)` for each playback.
- Set `preload = "auto"` on the template and clone to reduce missed loads on mobile and to ensure isolated playback state for each play.

### Testing
- Ran a syntax check with `node --check utils/audioCache.js`, which succeeded.
- Confirmed the change was confined to `utils/audioCache.js` and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f57d27688325a14f945d3d0d8b49)