### PR TITLE
Prime audio on first user gesture and switch to template-based audio cache

### DIFF
--- a/main.js
+++ b/main.js
@@ -36,6 +36,7 @@ import { renderChordResetScreen } from "./components/info/chordReset.js";
 import { renderPricingScreen } from "./components/pricing.js";
 import { renderLockScreen } from "./components/lock.js";
 import { renderForgotPasswordScreen } from "./components/forgotPassword.js";
+import { primeAudioPlaybackOnce } from "./utils/audioCache.js";
 
 
 import { firebaseAuth } from "./firebase/firebase-init.js";
@@ -117,6 +118,19 @@ window.closeHelp = closeHelp;
 
 window.addEventListener("error", (e) => {
   console.error("Uncaught error", e.error);
+});
+
+// iOS Safari で音声再生がブロックされやすいため、
+// 最初のユーザー操作タイミングでオーディオ再生をプライミングする。
+const audioPrimeEvents = ["touchstart", "pointerdown", "click"];
+const primeAudioOnFirstGesture = () => {
+  primeAudioPlaybackOnce();
+  audioPrimeEvents.forEach((eventName) => {
+    window.removeEventListener(eventName, primeAudioOnFirstGesture, true);
+  });
+};
+audioPrimeEvents.forEach((eventName) => {
+  window.addEventListener(eventName, primeAudioOnFirstGesture, { capture: true, passive: true });
 });
 
 

--- a/utils/audioCache.js
+++ b/utils/audioCache.js
@@ -1,19 +1,50 @@
-const cache = new Map();
+const templateCache = new Map();
+let audioPrimed = false;
 
 /**
- * Get an Audio instance for the given source path, reusing
- * previously created objects for faster playback.
+ * Get an Audio instance for the given source path.
+ * We keep one cached template per file, then return a fresh clone
+ * to avoid state collisions on mobile browsers (muted flag, event
+ * listeners, interrupted play promises, etc.).
  * @param {string} src - audio file path
  * @returns {HTMLAudioElement} reusable audio element
  */
 export function getAudio(src) {
-  let audio = cache.get(src);
-  if (!audio) {
-    audio = new Audio(src);
-    cache.set(src, audio);
+  let template = templateCache.get(src);
+  if (!template) {
+    template = new Audio(src);
+    template.preload = "auto";
+    templateCache.set(src, template);
   }
-  // Ensure overlapping plays are stopped before reusing the same element.
+
+  // Clone to provide an isolated playback instance every time.
+  const audio = template.cloneNode(true);
+  audio.preload = "auto";
   audio.pause();
   audio.currentTime = 0;
   return audio;
+}
+
+/**
+ * Safari/iOS対策:
+ * 初回ユーザー操作で小さな無音再生を行い、以降の再生ブロックを起きにくくする。
+ */
+export function primeAudioPlaybackOnce() {
+  if (audioPrimed) return;
+  audioPrimed = true;
+  const primer = new Audio();
+  primer.playsInline = true;
+  primer.setAttribute("playsinline", "");
+  primer.setAttribute("webkit-playsinline", "");
+  primer.muted = true;
+  primer.volume = 0;
+  const p = primer.play();
+  if (p && typeof p.then === "function") {
+    p.then(() => {
+      primer.pause();
+      primer.currentTime = 0;
+    }).catch(() => {
+      // ユーザー操作直後でも端末状態により失敗することがあるため握りつぶす
+    });
+  }
 }


### PR DESCRIPTION
### Motivation
- Prevent audio playback from being blocked on iOS Safari by performing a tiny, muted playback on the first user gesture. 
- Avoid state collisions and play promise interruptions caused by reusing the same `Audio` instance across overlapping plays on mobile browsers.

### Description
- Replace the single-instance cache in `utils/audioCache.js` with a `templateCache` that stores a template `Audio` per source and return a fresh `cloneNode(true)` on each `getAudio` call, with `preload` set to `auto`.
- Add `primeAudioPlaybackOnce()` to `utils/audioCache.js` which performs a muted, inline play once to prime browser playback permission and suppresses errors from failed plays. 
- Import and wire `primeAudioPlaybackOnce` in `main.js` and attach capture-phase handlers for `touchstart`, `pointerdown`, and `click` to trigger the primer on the first user gesture and then remove the listeners.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f57d27688325a14f945d3d0d8b49)