### PR TITLE
Fix premium state when switching saved settings

### DIFF
--- a/main.js
+++ b/main.js
@@ -149,7 +149,7 @@ export function clearTempUser() {
 }
 
 export function getBaseUser() {
-  return baseUser;
+  return baseUser || (currentUser && !currentUser.isTemp ? currentUser : null);
 }
 
 async function checkTrainingLimit(user) {
@@ -268,6 +268,8 @@ onAuthStateChanged(firebaseAuth, async (firebaseUser) => {
       name: firebaseUser.displayName ?? null,
       avatar_url: firebaseUser.photoURL ?? null,
     });
+    baseUser = profile;
+    currentUser = profile;
     window.currentUser = profile;
     const { count, error } = await supabase
       .from('user_chord_progress')


### PR DESCRIPTION
### Motivation
- Saved preset loading created a temporary user without inheriting the authenticated user's premium/trial flags, which could make the app treat the session as expired and show the lock screen. 
- The change ensures presets inherit the correct premium/trial state so users who switch presets keep their active subscription/trial status.

### Description
- Update `main.js` to set the authenticated app profile to `baseUser` and `currentUser` when Firebase auth resolves so the canonical signed-in user is preserved. 
- Add a fallback in `getBaseUser()` to return the current non-temp `currentUser` when `baseUser` is not yet set so preset-load logic can read `is_premium`/`trial_active`. 
- The modifications are limited to `main.js` and affect `setTempUser`/`clearTempUser`/`getBaseUser` and the auth initialization path.

### Testing
- Ran `node --check main.js` and it completed successfully. 
- Ran `node --check utils/accessControl.js` and it completed successfully. 
- Ran `node --check components/presetModal.js` and it completed successfully. 
- Ran `git diff --check` and there were no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58bc261c748325981299574785a7f8)